### PR TITLE
Having newlines in the description causes an error with setup.py bdist_r...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='BSD',
     author='Vincent Driessen',
     author_email='vincent@3rdcloud.com',
-    description=__doc__,
+    description=__doc__.strip('\n'),
     #packages=[],
     scripts=['bin/pip-review', 'bin/pip-dump'],
     #include_package_data=True,


### PR DESCRIPTION
Having newlines in the description causes an error with `setup.py bdist_rpm`. This PR simply strips newlines.
