### PR TITLE
Added option to turn off sorting in pip-dump

### DIFF
--- a/bin/pip-dump
+++ b/bin/pip-dump
@@ -72,6 +72,9 @@ def parse_args():
     parser.add_argument(
         '--verbose', '-v', action='store_true', default=False, help='Show more output'
     )
+    parser.add_argument(
+        '--no-sort', action='store_false', default=True, help="Don't sort package names (default is to sort)", dest="should_sort"
+    )
     parser.add_argument('files', nargs='*')
     return parser.parse_args()
 
@@ -99,22 +102,27 @@ def append_lines(lines, filename):
             f.write('{0}\n'.format(line))
 
 
-def rewrite(filename, lines):
+def rewrite(filename, lines, should_sort=True):
+    if should_sort:
+        lines.sort(key=lambda s: s.lower())
     with open(filename, 'w') as f:
-        for line in sorted(lines, key=lambda s: s.lower()):
+        for line in lines:
             line = line.strip()
             if line:
                 f.write('{0}\n'.format(line))
 
 
-def dump_requirements(files):
+def dump_requirements(files, should_sort=True):
     if not files:
         raise ValueError(u'Expected a list of at least one file name.')
 
     _, tmpfile = tempfile.mkstemp()
     existing_files = list(filter(os.path.exists, files))
     if existing_files:
-        check_call(u'cat {0} | sort -fu > {1}'.format(' '.join(existing_files), tmpfile))
+        if should_sort:
+            check_call(u'cat {0} | sort -fu > {1}'.format(' '.join(existing_files), tmpfile))
+        else:
+            check_call(u'cat {0} > {1}'.format(' '.join(existing_files), tmpfile))
     _, new = pip_info(tmpfile)
     check_call(u'rm {0}'.format(tmpfile))
     append_lines(new, files[0])
@@ -123,7 +131,7 @@ def dump_requirements(files):
         if os.path.basename(filename) == PIP_IGNORE_FILE:  # never rewrite the pip ignore file
             continue
         pkgs, _ = pip_info(filename)
-        rewrite(filename, pkgs)
+        rewrite(filename, pkgs, should_sort=should_sort)
 
 
 def find_default_files():
@@ -152,7 +160,7 @@ def main():
 
     if not args.files:
         args.files = find_default_files()
-    dump_requirements(args.files)
+    dump_requirements(args.files, should_sort=args.should_sort)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added the option, with `--no-sort` to not sort the package names when running `pip-dump`.

Sorted files do allow easier merging later, but if the requirements file is left in it's original order, it's easier to view the comparison when you first use pip-dump. Comments will also be preserved and make sense if the programme doesn't sort.
