### PR TITLE
Use https for pypi.python.org (avoiding a redirect)

### DIFF
--- a/bin/pip-review
+++ b/bin/pip-review
@@ -71,7 +71,7 @@ def load_pkg_info(pkg_name):
     logger.debug('Checking for updates of {0}'.format(pkg_name))
 
     req = urllib_request.Request(
-        'http://pypi.python.org/pypi/{0}/json'.format(pkg_name))
+        'https://pypi.python.org/pypi/{0}/json'.format(pkg_name))
     try:
         handler = urllib_request.urlopen(req)
     except urllib_request.HTTPError:
@@ -86,7 +86,7 @@ def guess_pkg_name(pkg_name):
     logger = logging.getLogger(u'pip-review')
     logger.debug('Try to guess package {0} name on PyPI.'.format(pkg_name))
     req = urllib_request.Request(
-        'http://pypi.python.org/simple/{0}/'.format(pkg_name))
+        'https://pypi.python.org/simple/{0}/'.format(pkg_name))
     try:
         handler = urllib_request.urlopen(req)
     except urllib_request.HTTPError:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     platforms='any',
     install_requires=get_dependencies(),
     classifiers=[
-        # As from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+        # As from https://pypi.python.org/pypi?%3Aaction=list_classifiers
         #'Development Status :: 1 - Planning',
         #'Development Status :: 2 - Pre-Alpha',
         #'Development Status :: 3 - Alpha',


### PR DESCRIPTION
http://pypi.python.org/ redirects to https://pypi.python.org/. Going
there directly will speed up lookups.
