### PR TITLE
pip-review: fix interactive mode for Python2

### DIFF
--- a/bin/pip-review
+++ b/bin/pip-review
@@ -32,8 +32,9 @@ except ImportError:
 check_output = partial(_check_output, shell=True)
 
 try:
-    raw_input = input # Python 3.
-except NameError:
+    import __builtin__
+    input = getattr(__builtin__, 'raw_input')  # Python2
+except (ImportError, AttributeError):
     pass
 
 
@@ -193,7 +194,7 @@ class InteractiveAsker(object):
 
         answer = ''
         while answer not in ['y', 'n', 'a', 'q']:
-            answer = raw_input(
+            answer = input(
                 '{0} [Y]es, [N]o, [A]ll, [Q]uit '.format(prompt))
             answer = answer.strip().lower()
 
@@ -213,7 +214,7 @@ def update_pkg(pkg, version):
 def confirm(question):
     answer = ''
     while not answer in ['y', 'n']:
-        answer = raw_input(question)
+        answer = input(question)
         answer = answer.strip().lower()
     return answer == 'y'
 


### PR DESCRIPTION
With Python2 (2.7.5), `input` exists and is quite different from
`raw_input`:

```
Help on built-in function input in module __builtin__:

input(...)
    input([prompt]) -> value

    Equivalent to eval(raw_input(prompt)).
```

Therefore, this patch overwrites `input` with `raw_input`, if it exists.

Source: http://stackoverflow.com/a/18332097/15690
