### PR TITLE
feature: review requirements file instead 'pip freeze' output

### DIFF
--- a/tests/review.t
+++ b/tests/review.t
@@ -31,8 +31,8 @@ We can also install these updates automatically:
 
   $ pip-review --auto >/dev/null 2>&1
   $ pip-review
-  Warning: cannot find svn location for cElementTree==1.0.5-20051216
-  cElementTree==1.0.2-20050302 is available (you have 1.0.5-20051216)
+  Warning: cannot find svn location for cElementTree==1.0.2-20050302
+  Everything up-to-date
 
 Cleanup our playground:
 


### PR DESCRIPTION
Would be nice to check project requirements file instead of actual virtualenv.
It will help to check that requirements file is in actual state.
