### PR TITLE
Allow wheel as requirements source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ htmlcov
 build
 dist
 *.egg-info
+.cache/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://secure.travis-ci.org/nvie/pip-tools.png?branch=future)](https://secure.travis-ci.org/nvie/pip-tools)
+[![Build status](https://secure.travis-ci.org/nvie/pip-tools.png?branch=master)](https://secure.travis-ci.org/nvie/pip-tools)
 
 pip-tools = pip-compile + pip-sync
 ==================================

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -1,6 +1,5 @@
 # coding: utf-8
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import os
 from functools import partial
@@ -94,7 +93,7 @@ class Resolver(object):
 
     def _check_constraints(self):
         for constraint in chain(self.our_constraints, self.their_constraints):
-            if constraint.link is not None and not constraint.editable:
+            if constraint.link is not None and not constraint.editable and not constraint.link.is_wheel:
                 msg = ('pip-compile does not support URLs as packages, unless they are editable. '
                        'Perhaps add -e option?')
                 raise UnsupportedConstraint(msg, constraint)

--- a/tests/fixtures/fake_project/setup.cfg
+++ b/tests/fixtures/fake_project/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/tests/fixtures/fake_project/setup.py
+++ b/tests/fixtures/fake_project/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='sample',
+    version='1.2.3',
+    packages=['fake_project'],
+    install_requires=['pip-tools==1.1.5'],
+)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,18 @@ import os
 import sys
 
 import pytest
+import pip
 
 from click.testing import CliRunner
 from piptools.scripts.compile import cli
 
+
+
 @pytest.fixture
 def pip_conf(request):
+    """
+    inject a fake pip.{ini,conf} inside current env
+    """
     test_conf = """
 [global]
 index-url = http://example.com
@@ -16,15 +22,36 @@ trusted-host = example.com
     #write pip.conf (pip.ini) at root of virtualenv
     pip_conf_file = 'pip.conf' if os.name != 'nt' else 'pip.ini'
     pip_conf_file = os.path.join(sys.prefix, pip_conf_file)
+    real_pip_conf = None
+    if os.path.exists(pip_conf_file):
+        # backup real file
+        with open(pip_conf_file) as original:
+            real_pip_conf = original.read()
+
     with open(pip_conf_file, 'w') as pip_conf:
         pip_conf.write(test_conf)
     
     def tear_down():
-        os.remove(pip_conf_file)
+        if real_pip_conf:
+            with open(pip_conf_file, 'w') as pip_conf:
+                pip_conf.write(real_pip_conf)
+        else:
+            os.remove(pip_conf_file)
 
     request.addfinalizer(tear_down)
     
     return pip_conf_file
+
+
+@pytest.fixture
+def wheel(tmpdir):
+    """
+    creates a temporary wheel with one depenendency: pip-tools==1.1.5
+    """
+    pip.main(['wheel', '-b', tmpdir.strpath, '--no-deps', '-w', tmpdir.strpath, os.path.abspath('tests/fixtures/fake_project')]) 
+
+    return tmpdir.join('sample-1.2.3-py2.py3-none-any.whl').strpath
+    
 
 
 def test_default_pip_conf_read(pip_conf):
@@ -54,3 +81,15 @@ def test_command_line_overrides_pip_conf(pip_conf):
 
         # check that we have our index-url as specified in pip.conf
         assert 'Using indexes:\n  http://override.com' in out.output
+
+
+def test_can_compile_requirements_from_wheel(wheel):
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        out = runner.invoke(cli, [wheel])
+
+    # massage output
+    output = ' '.join(out.output.split())
+    assert 'pip-tools==1.1.5 # via sample sample==1.2.3' in output


### PR DESCRIPTION
It can be practical to use a wheel to calculate dependencies. This PR implements this in a simple manner (leveraging wheel support from pip).

Allows

```
pip-compile my-wheel.whl
```

In our use case, we use this to pin requirements **after** the top level package (wheel) has been created. This helps in our automation of deployments, without the dependency of an external requirements.txt file.
