### PR TITLE
Use ignore_installed=True with PyPIRepository.get_dependencies

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -128,6 +128,7 @@ class PyPIRepository(BaseRepository):
                                 self.source_dir,
                                 download_dir=self._download_dir,
                                 wheel_download_dir=self._wheel_download_dir,
+                                ignore_installed=True,
                                 session=self.session)
         dependencies = reqset._prepare_file(self.finder, ireq)
         return set(dependencies)


### PR DESCRIPTION
This ignores installed packages, which seems to be desired behaviour in
general, but also works around a bug in pip/setuptools/pkg_resources.
(https://github.com/pypa/pip/issues/3661)

TEST CASE:

```
1. rm ~/.cache/pip-tools/depcache*
2. echo "django-autocomplete-light[gfk]==3.1.5" > test.in
3. pip-compile test.in
=> correct
4. pip install django-autocomplete-light
5. rm ~/.cache/pip-tools/depcache*
6. pip-compile test.in
=> incorrect
```

EXPECTED:
It should have `django-querysetsequence` and `django` as additional
dependencies, but this is not the case when `django-autocomplete-light`
is installed.
