### PR TITLE
Improve pip-compile with regard to stdout

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -68,6 +68,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if len(src_files) == 1 and src_files[0] == '-':
         if not output_file:
             output_file = '-'
+    if output_file == '-':
+        header = False
 
     if len(src_files) > 1 and not output_file:
         raise click.BadParameter('--output-file is required if two or more input files are given.')

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -67,7 +67,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
 
     if len(src_files) == 1 and src_files[0] == '-':
         if not output_file:
-            raise click.BadParameter('--output-file is required if input is from stdin')
+            output_file = '-'
 
     if len(src_files) > 1 and not output_file:
         raise click.BadParameter('--output-file is required if two or more input files are given.')

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -52,11 +52,12 @@ class OutputWriter(object):
                 yield ''  # extra line of whitespace
 
     def write_format_controls(self):
-        for nb in self.format_control.no_binary:
-            yield '--no-binary {}'.format(nb)
-        for ob in self.format_control.only_binary:
-            yield '--only-binary {}'.format(ob)
-        yield ''
+        if self.format_control.no_binary or self.format_control.only_binary:
+            for nb in self.format_control.no_binary:
+                yield '--no-binary {}'.format(nb)
+            for ob in self.format_control.only_binary:
+                yield '--only-binary {}'.format(ob)
+            yield ''
 
     def _iter_lines(self, results, reverse_dependencies, primary_packages):
         for line in self.write_header():

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -89,13 +89,15 @@ class OutputWriter(object):
     def write(self, results, reverse_dependencies, primary_packages):
         with ExitStack() as stack:
             f = None
-            if not self.dry_run:
+            if not self.dry_run and self.dst_file != '-':
                 f = stack.enter_context(AtomicSaver(self.dst_file))
 
             for line in self._iter_lines(results, reverse_dependencies, primary_packages):
                 if f:
                     f.write(unstyle(line).encode('utf-8'))
                     f.write(os.linesep.encode('utf-8'))
+                else:
+                    print(line)
 
     def _format_requirement(self, ireq, reverse_dependencies, primary_packages, include_specifier=True):
         line = format_requirement(ireq, include_specifier=include_specifier)

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -93,7 +93,6 @@ class OutputWriter(object):
                 f = stack.enter_context(AtomicSaver(self.dst_file))
 
             for line in self._iter_lines(results, reverse_dependencies, primary_packages):
-                log.info(line)
                 if f:
                     f.write(unstyle(line).encode('utf-8'))
                     f.write(os.linesep.encode('utf-8'))


### PR DESCRIPTION
I also had this, but it seems like `-o -` should be given explicitly?!

Or should `-o -` be the default for `-` as input file (which makes sense to me)?
(Done in 31cbab8)

See also 1aa91b5 where `--header` gets disabled for this.
Should it be still possible to pass in `--header` to force it, as with `pip-comfile --header -`?

```
diff --git a/piptools/scripts/compile.py b/piptools/scripts/compile.py
index 9b94809..fd075e6 100755
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -65,10 +65,6 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                                       "the default is {}").format(DEFAULT_REQUIREMENTS_FILE))
         src_files = (DEFAULT_REQUIREMENTS_FILE,)

-    if len(src_files) == 1 and src_files[0] == '-':
-        if not output_file:
-            raise click.BadParameter('--output-file is required if input is from stdin')
-
     if len(src_files) > 1 and not output_file:
         raise click.BadParameter('--output-file is required if two or more input files are given.')
```
