### PR TITLE
Write error message to the stderr.

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -25,18 +25,19 @@ pip_version_info = tuple(safeint(digit) for digit in pip.__version__.split('.'))
 def assert_compatible_pip_version():
     # Make sure we're using a reasonably modern version of pip
     if not pip_version_info >= (7, 0):
-        print('pip-compile requires at least version 7.0 of pip ({} found), '
-              'perhaps run `pip install --upgrade pip`?'.format(pip.__version__))
+        sys.stderr.write('pip-compile requires at least version 7.0 of pip ({} found), '
+                         'perhaps run `pip install --upgrade pip`?'.format(pip.__version__))
         sys.exit(4)
 
     if pip_version_info >= (8, 1, 2):
-        print('ERROR:')
-        print('You are using pip>=8.1.2, which changed some internal data structures pip-tools')
-        print('depends on.  Support for this is scheduled for pip-tools>=1.7.  Until then,')
-        print('consider downgrading your pip:')
-        print('')
-        print('    $ pip install --upgrade pip==8.1.1')
-        print('')
+        sys.stderr.write(
+        '''ERROR:
+        You are using pip>=8.1.2, which changed some internal data structures pip-tools
+        depends on.  Support for this is scheduled for pip-tools>=1.7.  Until then,
+        consider downgrading your pip:
+
+            $ pip install --upgrade pip==8.1.1
+        ''')
         sys.exit(4)
 
 


### PR DESCRIPTION
Some users may want to filter log messages using pipes. Error messages
should be written to stderr so that errors remain visible.
