### PR TITLE
Add ability to process CA Bundles

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -32,6 +32,8 @@ class PyPIRepository(BaseRepository):
     """
     def __init__(self, pip_options):
         self.session = PipSession()
+        if pip_options.cert:
+            self.session.verify = pip_options.cert
         if pip_options.client_cert:
             self.session.cert = pip_options.client_cert
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -41,6 +41,7 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page", envvar='PIP_FIND_LINKS')  # noqa
 @click.option('-i', '--index-url', help="Change index URL (defaults to PyPI)", envvar='PIP_INDEX_URL')
 @click.option('--extra-index-url', multiple=True, help="Add additional index URL to search", envvar='PIP_EXTRA_INDEX_URL')  # noqa
+@click.option('--cert', help="Path to alternate CA bundle.")
 @click.option('--client-cert', help="Path to SSL client certificate, a single file containing the private key and the certificate in PEM format.")  # noqa
 @click.option('--trusted-host', multiple=True, envvar='PIP_TRUSTED_HOST',
               help="Mark this host as trusted, even though it does not have "
@@ -58,7 +59,7 @@ class PipCommand(pip.basecommand.Command):
                     'Will be derived from input file otherwise.'))
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
-        client_cert, trusted_host, header, index, annotate, upgrade,
+        cert, client_cert, trusted_host, header, index, annotate, upgrade,
         output_file, src_files):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
@@ -106,6 +107,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if extra_index_url:
         for extra_index in extra_index_url:
             pip_args.extend(['--extra-index-url', extra_index])
+    if cert:
+        pip_args.extend(['--cert', cert])
     if client_cert:
         pip_args.extend(['--client-cert', client_cert])
     if pre:


### PR DESCRIPTION
One of the options that's missing from pip-compile that pip allows for is `--cert`, which has been around longer than `--client-cert` (at least since pip 5).

These commits attach the cert to the PipSession in the same way that pip does and also exposes the option in the CLI.
