### PR TITLE
Add -markerlib and pkg-resources to the list of PACKAGES_TO_IGNORE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
-# 1.7.1
+# 1.7.0+nimbis.1
+
+- Bug fix to work with Debian mkvirtualenv (this has been submitted
+  upstream here: https://github.com/nvie/pip-tools/pull/368 )
 
 - Add `--allow-unsafe` option (#377)
-
 
 # 1.7.0
 
 - Add compatibility with pip >= 8.1.2 (#374)
   Thanks so much, @jmbowman!
-
 
 # 1.6.5
 

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -8,9 +8,11 @@ from .exceptions import IncompatibleRequirements, UnsupportedConstraint
 from .utils import flat_map, key_from_req
 
 PACKAGES_TO_IGNORE = [
+    '-markerlib',
     'pip',
     'pip-tools',
     'pip-review',
+    'pkg-resources',
     'setuptools',
     'wheel',
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pip-tools',
-    version='1.7.1dev0',
+    version='1.7.0+nimbis.1',
     url='https://github.com/nvie/pip-tools/',
     license='BSD',
     author='Vincent Driessen',


### PR DESCRIPTION
On Debian unstable, mkvirtualenv 15.0.0 is installing two pseudo
packages (each with a version number of 0.0.0) as can be seen here:

```
$ mkvirtualenv foo
Running virtualenv with interpreter /usr/bin/python2
New python executable in /home/cworth/.virtualenvs/foo/bin/python2
Also creating executable in /home/cworth/.virtualenvs/foo/bin/python
Installing setuptools, pkg_resources, _markerlib, pip, wheel...done.
```

But then pip-sync will try to uninstall these packages (since nothing
explicitly depends on them) which will then cause pip stop working as
can be seen here:

```
$ pip-sync reqs.txt
Uninstalling pkg-resources-0.0.0:
  Successfully uninstalled pkg-resources-0.0.0

$ pip-sync reqs.txt
Traceback (most recent call last):
  File "/home/cworth/.virtualenvs/foo/bin/pip-sync", line 5, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
```

This commit adds these two package names to the PACKAGES_TO_IGNORE
list so that pip-sync will not try to uninstall them.
