### PR TITLE
Use download_dir=None for editable PyPI dependencies

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -119,14 +119,20 @@ class PyPIRepository(BaseRepository):
         if not (ireq.editable or is_pinned_requirement(ireq)):
             raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
 
-        if not os.path.isdir(self._download_dir):
-            os.makedirs(self._download_dir)
+        if ireq.link and not ireq.link.is_artifact:
+            # No download_dir for VCS sources.  This also works around pip
+            # using git-checkout-index, which gets rid of the .git dir.
+            download_dir = None
+        else:
+            download_dir = self._download_dir
+            if not os.path.isdir(download_dir):
+                os.makedirs(download_dir)
         if not os.path.isdir(self._wheel_download_dir):
             os.makedirs(self._wheel_download_dir)
 
         reqset = RequirementSet(self.build_dir,
                                 self.source_dir,
-                                download_dir=self._download_dir,
+                                download_dir=download_dir,
                                 wheel_download_dir=self._wheel_download_dir,
                                 session=self.session)
         dependencies = reqset._prepare_file(self.finder, ireq)


### PR DESCRIPTION
Using a `download_dir` will make `pip` export the cloned repo via
`reqset._prepare_file` and `git-checkout-index`, which then makes
`python setup.py egg_info` fail, when
[setuptools_scm](https://github.com/pypa/setuptools_scm) is used.

Fixes https://github.com/nvie/pip-tools/issues/369.
