### PR TITLE
Remove the restriction on package urls because it is unnecessary

### DIFF
--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -82,7 +82,7 @@ class DependencyCache(object):
         ("ipython", "2.1.0[nbconvert,notebook]")
 
         For a requirement with a link (either editable or not), the link will be
-        used as the second elemnt of the tuple.
+        used as the second element of the tuple.
         """
         name, version, extras = as_tuple(ireq)
         if not extras:

--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -80,6 +80,9 @@ class DependencyCache(object):
         like so:
 
         ("ipython", "2.1.0[nbconvert,notebook]")
+
+        For a requirement with a link (either editable or not), the link will be
+        used as the second elemnt of the tuple.
         """
         name, version, extras = as_tuple(ireq)
         if not extras:

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -45,6 +45,8 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_fi
             log.error('ERROR: ' + msg)
             sys.exit(2)
 
+    # N.B. Using 'session=True' is safe because this is always installing from a local file,
+    # rather than a url.
     requirements = flat_map(lambda src: pip.req.parse_requirements(src, session=True),
                             src_files)
 

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -69,9 +69,17 @@ def merge(requirements, ignore_conflicts):
 
     for ireq in requirements:
         if ireq.link is not None and not ireq.editable:
-            msg = ('pip-compile does not support URLs as packages, unless they are editable. '
-                   'Perhaps add -e option?')
-            raise UnsupportedConstraint(msg, ireq)
+            if not hasattr(ireq, 'original_link'):
+                raise UnsupportedConstraint(
+                    'pip-compile does not support URLs unless you have pip >= 8.0.0 installed',
+                    ireq
+                )
+            try:
+                ireq.specifier
+            except:
+                msg = ('pip-compile does not support URLs without specifiers, '
+                       'add #egg= with a specifier at the end of the url.')
+                raise UnsupportedConstraint(msg, ireq)
 
         key = ireq.link or key_from_req(ireq.req)
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -71,6 +71,8 @@ def format_requirement(ireq, include_specifier=True):
     """
     if ireq.editable:
         line = '-e {}'.format(ireq.link)
+    elif hasattr(ireq, 'original_link') and ireq.original_link:
+        line = str(ireq.original_link)
     elif include_specifier:
         line = str(ireq.req)
     else:
@@ -119,12 +121,17 @@ def is_pinned_requirement(ireq):
 def as_tuple(ireq):
     """
     Pulls out the (name: str, version:str, extras:(str)) tuple from the pinned InstallRequirement.
+
+    If ireq has a link, treat the whole link as the version.
     """
     if not is_pinned_requirement(ireq):
         raise TypeError('Expected a pinned InstallRequirement, got {}'.format(ireq))
 
     name = key_from_req(ireq.req)
-    version = first(ireq.specifier._specs)._spec[1]
+    if ireq.link:
+        version = ireq.link
+    else:
+        version = first(ireq.specifier._specs)._spec[1]
     extras = tuple(sorted(ireq.extras))
     return name, version, extras
 


### PR DESCRIPTION
`pip` seems to correctly resolve the dependencies needed for packages pulled in by urls.

For instance

```
# ./test.in
git+https://github.com/nvie/pip-tools.git@811e2d#egg=pip-tools==0.0
```

```
# ./test.txt

# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file test.txt test.in
#
click==6.6                # via pip-tools
pip-tools==0.0
six==1.10.0               # via pip-tools
```

```
# ./test.in
git+https://github.com/nvie/pip-tools.git@master#egg=pip-tools==0.0
```

```
# ./test.txt

# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file test.txt test.in
#
click==6.6                # via pip-tools
first==2.0.1              # via pip-tools
pip-tools==0.0
six==1.10.0               # via pip-tools
```

The diff in `setup.py` (https://github.com/nvie/pip-tools/compare/811e2d...master#diff-2eeaed663bd0d25b7e608891384b7298L15) translates properly to a diff in the generated requirements file.
