### PR TITLE
Phased install

### DIFF
--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -80,6 +80,9 @@ class DependencyCache(object):
         like so:
 
         ("ipython", "2.1.0[nbconvert,notebook]")
+
+        For a requirement with a link (either editable or not), the link will be
+        used as the second elemnt of the tuple.
         """
         name, version, extras = as_tuple(ireq)
         if not extras:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -107,7 +107,10 @@ class PyPIRepository(BaseRepository):
 
         # Turn the candidate into a pinned InstallRequirement
         return make_install_requirement(
-            best_candidate.project, best_candidate.version, ireq.extras
+            best_candidate.project,
+            best_candidate.version,
+            ireq.extras,
+            ireq.comes_from
         )
 
     def get_dependencies(self, ireq):

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import pip
+from itertools import chain
 
 from .. import click, sync
 from ..exceptions import PipToolsError
@@ -26,8 +27,9 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 @click.option('-i', '--index-url', help="Change index URL (defaults to PyPI)", envvar='PIP_INDEX_URL')
 @click.option('--extra-index-url', multiple=True, help="Add additional index URL to search", envvar='PIP_EXTRA_INDEX_URL')  # noqa
 @click.option('--no-index', is_flag=True, help="Ignore package index (only looking at --find-links URLs instead)")
+@click.option('--phased', is_flag=True, help="Install each provided file as a separate pip operation (but uninstall unused packages as usual)")
 @click.argument('src_files', required=False, type=click.Path(exists=True), nargs=-1)
-def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_files):
+def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, phased, src_files):
     if not src_files:
         if os.path.exists(DEFAULT_REQUIREMENTS_FILE):
             src_files = (DEFAULT_REQUIREMENTS_FILE,)
@@ -47,17 +49,16 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_fi
 
     # N.B. Using 'session=True' is safe because this is always installing from a local file,
     # rather than a url.
-    requirements = flat_map(lambda src: pip.req.parse_requirements(src, session=True),
-                            src_files)
+    requirements = [list(pip.req.parse_requirements(src, session=True)) for src in src_files]
 
     try:
-        requirements = sync.merge(requirements, ignore_conflicts=force)
+        merged_requirements = sync.merge(chain.from_iterable(requirements), ignore_conflicts=force)
     except PipToolsError as e:
         log.error(str(e))
         sys.exit(2)
 
     installed_dists = pip.get_installed_distributions(skip=[])
-    to_install, to_uninstall = sync.diff(requirements, installed_dists)
+    to_install, to_uninstall = sync.diff(merged_requirements, installed_dists)
 
     install_flags = []
     for link in find_links or []:
@@ -70,5 +71,19 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_fi
         for extra_index in extra_index_url:
             install_flags.extend(['--extra-index-url', extra_index])
 
-    sys.exit(sync.sync(to_install, to_uninstall, verbose=True, dry_run=dry_run,
-                       install_flags=install_flags))
+    if phased:
+        pkg_to_install = {
+            req.name: str(req.link or req.req)
+            for req in merged_requirements
+        }
+        already_installed = set()
+
+        sync.sync([], to_uninstall, verbose=True, dry_run=dry_run, install_flags=install_flags)
+        for req_set in requirements:
+            this_phase = set(pkg_to_install[req.name] for req in req_set)
+            actual_reqs = (this_phase & to_install) - already_installed
+            sync.sync(actual_reqs, [], verbose=True, dry_run=dry_run, install_flags=install_flags)
+            already_installed |= actual_reqs
+    else:
+        sys.exit(sync.sync(to_install, to_uninstall, verbose=True, dry_run=dry_run,
+                           install_flags=install_flags))

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -45,6 +45,8 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_fi
             log.error('ERROR: ' + msg)
             sys.exit(2)
 
+    # N.B. Using 'session=True' is safe because this is always installing from a local file,
+    # rather than a url.
     requirements = flat_map(lambda src: pip.req.parse_requirements(src, session=True),
                             src_files)
 

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -69,9 +69,17 @@ def merge(requirements, ignore_conflicts):
 
     for ireq in requirements:
         if ireq.link is not None and not ireq.editable:
-            msg = ('pip-compile does not support URLs as packages, unless they are editable. '
-                   'Perhaps add -e option?')
-            raise UnsupportedConstraint(msg, ireq)
+            if not hasattr(ireq, 'original_link'):
+                raise UnsupportedConstraint(
+                    'pip-compile does not support URLs unless you have pip >= 8.0.0 installed',
+                    ireq
+                )
+            try:
+                ireq.specifier
+            except:
+                msg = ('pip-compile does not support URLs without specifiers, '
+                       'add #egg= with a specifier at the end of the url.')
+                raise UnsupportedConstraint(msg, ireq)
 
         key = ireq.link or key_from_req(ireq.req)
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -71,6 +71,8 @@ def format_requirement(ireq, include_specifier=True):
     """
     if ireq.editable:
         line = '-e {}'.format(ireq.link)
+    elif hasattr(ireq, 'original_link') and ireq.original_link:
+        line = str(ireq.original_link)
     elif include_specifier:
         line = str(ireq.req)
     else:
@@ -119,12 +121,17 @@ def is_pinned_requirement(ireq):
 def as_tuple(ireq):
     """
     Pulls out the (name: str, version:str, extras:(str)) tuple from the pinned InstallRequirement.
+
+    If ireq has a link, treat the whole link as the version.
     """
     if not is_pinned_requirement(ireq):
         raise TypeError('Expected a pinned InstallRequirement, got {}'.format(ireq))
 
     name = key_from_req(ireq.req)
-    version = first(ireq.specifier._specs)._spec[1]
+    if ireq.link:
+        version = ireq.link
+    else:
+        version = first(ireq.specifier._specs)._spec[1]
     extras = tuple(sorted(ireq.extras))
     return name, version, extras
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -54,14 +54,17 @@ def comment(text):
     return style(text, fg='green')
 
 
-def make_install_requirement(name, version, extras):
+def make_install_requirement(name, version, extras, comes_from=None):
     # If no extras are specified, the extras string is blank
     extras_string = ""
     if extras:
         # Sort extras for stability
         extras_string = "[{}]".format(",".join(sorted(extras)))
 
-    return InstallRequirement.from_line('{}{}=={}'.format(name, extras_string, str(version)))
+    return InstallRequirement.from_line(
+        '{}{}=={}'.format(name, extras_string, str(version)),
+        comes_from=comes_from
+    )
 
 
 def format_requirement(ireq, include_specifier=True):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -7,10 +7,10 @@ from piptools.writer import OutputWriter
 
 @fixture
 def writer():
-    return OutputWriter(src_files=["src_file", "src_file2"], dst_file="dst_file", dry_run=True,
+    return OutputWriter(src_files=["src_file", "src_file2"], dst_files=["dst_file"], dry_run=True,
                         emit_header=True, emit_index=True, annotate=True,
                         default_index_url=None, index_urls=[],
-                        trusted_hosts=[],
+                        trusted_hosts=[], phased=False,
                         format_control=FormatControl(set(), set()))
 
 
@@ -21,7 +21,7 @@ def test_format_requirement_annotation_editable(from_editable, writer):
 
     assert (writer._format_requirement(ireq,
                                        reverse_dependencies,
-                                       primary_packages=[]) ==
+                                       primary_packages={'xyz'}) ==
             '-e git+git://fake.org/x/y.git#egg=y' + comment('  # via xyz'))
 
 
@@ -31,7 +31,7 @@ def test_format_requirement_annotation(from_line, writer):
 
     assert (writer._format_requirement(ireq,
                                        reverse_dependencies,
-                                       primary_packages=[]) ==
+                                       primary_packages={'xyz'}) ==
             'test==1.2               ' + comment('  # via xyz'))
 
 
@@ -41,7 +41,7 @@ def test_format_requirement_annotation_case_sensitive(from_line, writer):
 
     assert (writer._format_requirement(ireq,
                                        reverse_dependencies,
-                                       primary_packages=[]) ==
+                                       primary_packages={'xyz'}) ==
             'Test==1.2               ' + comment('  # via xyz'))
 
 
@@ -52,5 +52,5 @@ def test_format_requirement_not_for_primary(from_line, writer):
 
     assert (writer._format_requirement(ireq,
                                        reverse_dependencies,
-                                       primary_packages=['test']) ==
+                                       primary_packages={'test', 'xyz'}) ==
             'test==1.2')


### PR DESCRIPTION
In some cases, a package A may required that package B has been fully installed before the installation for package A can start (numpy and scipy, for some set of versions, for instance). In this case, we need a way to get consistent versions across a number of requirements files, without forcing installation from a single requirements file.

To that end, this PR adds `--phased` to both `pip-compile` and `pip-sync`, which compiles and installs sets of requirements files **in the order they are listed on the commandline**.