### PR TITLE
Allow editable dependencies with hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Features:
 - `--generate-hashes` now generates hashes for all wheels, not only wheels for the currently running platform ([#414](https://github.com/jazzband/pip-tools/issues/414))
+- `--generate-hashes` now does not error if an editable dependency is present ([#424](https://github.com/jazzband/pip-tools/pull/424))
+
 
 # 1.9.1
 

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -75,7 +75,17 @@ class Resolver(object):
         """
         Finds acceptable hashes for all of the given InstallRequirements.
         """
-        return {ireq: self.repository.get_hashes(ireq) for ireq in ireqs}
+        hashes = {}
+        for ireq in ireqs:
+            try:
+                ireq_hash = self.repository.get_hashes(ireq)
+            except TypeError:
+                continue
+            else:
+                if ireq_hash is not None:
+                    hashes[ireq] = ireq_hash
+
+        return hashes
 
     def resolve(self, max_rounds=10):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,9 @@ class FakeRepository(BaseRepository):
             self.editables = json.load(f)
 
     def get_hashes(self, ireq):
+        if ireq.editable:
+            raise TypeError('{0} is an editable requirement'.format(ireq))
+
         # Some fake hashes
         return {
             'test:123',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,6 +222,28 @@ def test_editable_package(tmpdir):
         assert 'six==1.10.0' in out.output
 
 
+def test_editable_package_with_hash(tmpdir):
+    """
+    piptools can use --generate-hashes with editable and non-editable dependencies
+    """
+    fake_package_dir = os.path.join(os.path.split(__file__)[0], 'fixtures', 'small_fake_package')
+    fake_package_dir = 'file:' + pathname2url(fake_package_dir)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('requirements', 'w') as req_in:
+            req_in.write('six==1.10.0\n')
+            req_in.write('-e ' + fake_package_dir)  # require editable fake package
+
+        out = runner.invoke(cli, ['-n', 'requirements', '--generate-hashes'])
+
+        print(out.output)
+        assert out.exit_code == 0
+        assert '--output-file requirements.txt' in out.output
+        assert 'six==1.10.0' in out.output
+        assert '-e ' + fake_package_dir + '\n' in out.output
+
+
 def test_input_file_without_extension(tmpdir):
     """
     piptools can compile a file without an extension,

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -142,3 +142,14 @@ def test_resolver__allows_unsafe_deps(resolver, from_line, input, expected, prer
     output = resolver(input, prereleases=prereleases, allow_unsafe=True).resolve()
     output = {str(line) for line in output}
     assert output == {str(line) for line in expected}
+
+
+def test_resolver__resolve_hashes_ignores_editable_hashes(resolver, from_editable, from_line):
+    resolver = resolver([])
+
+    non_editable = from_line('appdirs==1.4.9')
+    editable = from_editable('git+git://fake.org/x/y.git#egg=y')
+
+    resolved = resolver.resolve_hashes((non_editable, editable))
+    assert non_editable in resolved
+    assert editable not in resolved


### PR DESCRIPTION
I don't think the `--generate-hashes` flag should give up and quit if a single dependency is editable/not pinned. This MR just skips those that don't have hashes.