### PR TITLE
Fix the usage of ireq keys for comparison purposes

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -35,10 +35,12 @@ def key_from_req(req):
     """Get an all-lowercase version of the requirement's name."""
     if hasattr(req, 'key'):
         # pip 8.1.1 or below, using pkg_resources
-        return req.key
+        key = req.key
     else:
         # pip 8.1.2 or above, using packaging
-        return req.name.lower()
+        key = req.name.lower()
+    key = key.replace('_', '-')
+    return key
 
 
 def name_from_req(req):


### PR DESCRIPTION
Per [PEP 426](https://www.python.org/dev/peps/pep-0426/):

>  All comparisons of distribution names MUST be case insensitive, and
>  MUST consider hyphens and underscores to be equivalent.

Without this normalization, dependencies can become unintentionally
upgraded if the existing pinned `requirements.txt` contains a package
specified in a different style from another packages `setup.py`.

Example of the current behavior without this change:

`requirements.in`

    aiohttp==1.0.1

`requirements.txt` (before running `pip-compile`)

    #
    # This file is autogenerated by pip-compile
    # To update, run:
    #
    #    pip-compile --output-file requirements.txt requirements.in
    #
    aiohttp==1.0.1
    async-timeout==1.0.0      # via aiohttp
    chardet==2.3.0            # via aiohttp
    multidict==2.1.4          # via aiohttp

`requirements.txt` (after running `pip-compile`)

    #
    # This file is autogenerated by pip-compile
    # To update, run:
    #
    #    pip-compile --output-file requirements.txt requirements.in
    #
    aiohttp==1.0.1
    async-timeout==1.1.0      # via aiohttp
    chardet==2.3.0            # via aiohttp
    multidict==2.1.4          # via aiohttp

Desired behavior: `async-timeout` is pinned here and should not be
automatically upgraded, as `aiohttp` does not place a minimum version
requirement on `async-timeout` in the `1.0.1` release
(https://github.com/KeepSafe/aiohttp/blob/v1.0.1/setup.py#L57).