### PR TITLE
Check the pip version is compatible ASAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 ============
 
 ```console
-$ pip install --upgrade pip  # pip-tools needs pip==6.1 or higher (!)
+$ pip install --upgrade pip  # pip-tools needs pip==8 or higher (!)
 $ pip install pip-tools
 ```
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -8,6 +8,11 @@ import sys
 import tempfile
 
 import pip
+
+# Make sure we're using a compatible version of pip
+from ..utils import assert_compatible_pip_version
+assert_compatible_pip_version()
+
 from pip.req import InstallRequirement, parse_requirements
 
 from .. import click
@@ -15,12 +20,8 @@ from ..exceptions import PipToolsError
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..resolver import Resolver
-from ..utils import (assert_compatible_pip_version, is_pinned_requirement,
-                     key_from_req)
+from ..utils import is_pinned_requirement, key_from_req
 from ..writer import OutputWriter
-
-# Make sure we're using a compatible version of pip
-assert_compatible_pip_version()
 
 DEFAULT_REQUIREMENTS_FILE = 'requirements.in'
 

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -7,13 +7,14 @@ import sys
 
 import pip
 
+# Make sure we're using a compatible version of pip
+from ..utils import assert_compatible_pip_version
+assert_compatible_pip_version()
+
 from .. import click, sync
 from ..exceptions import PipToolsError
 from ..logging import log
-from ..utils import assert_compatible_pip_version, flat_map
-
-# Make sure we're using a compatible version of pip
-assert_compatible_pip_version()
+from ..utils import flat_map
 
 DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 


### PR DESCRIPTION
This avoids getting a nasty traceback if we hit an error between importing pip and running the compatibility check.

Additionally, it seems like the supported version of pip was incremented but the README wasn’t. This patch fixes the README.

I considered adding a test for this, but that would require an entirely new set of tests for what is hopefully an edge case scenario.

Resolves #484.