### PR TITLE
Enhance the option lines in output

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -47,8 +47,8 @@ class PipCommand(pip.basecommand.Command):
               help="Add header to generated file")
 @click.option('--index/--no-index', is_flag=True, default=True,
               help="Add index URL to generated file")
-@click.option('--emit-trusted-host/--no-trusted-host', is_flag=True, default=True,
-              help="Add trusted host option to generated file")
+@click.option('--emit-trusted-host/--no-emit-trusted-host', is_flag=True,
+              default=True, help="Add trusted host option to generated file")
 @click.option('--annotate/--no-annotate', is_flag=True, default=True,
               help="Annotate results, indicating where dependencies come from")
 @click.option('-U', '--upgrade', is_flag=True, default=False,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -47,6 +47,8 @@ class PipCommand(pip.basecommand.Command):
               help="Add header to generated file")
 @click.option('--index/--no-index', is_flag=True, default=True,
               help="Add index URL to generated file")
+@click.option('--emit-trusted-host/--no-trusted-host', is_flag=True, default=True,
+              help="Add trusted host option to generated file")
 @click.option('--annotate/--no-annotate', is_flag=True, default=True,
               help="Annotate results, indicating where dependencies come from")
 @click.option('-U', '--upgrade', is_flag=True, default=False,
@@ -64,8 +66,9 @@ class PipCommand(pip.basecommand.Command):
               help="Maximum number of rounds before resolving the requirements aborts.")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
-        client_cert, trusted_host, header, index, annotate, upgrade, upgrade_packages,
-        output_file, allow_unsafe, generate_hashes, src_files, max_rounds):
+        client_cert, trusted_host, header, index, emit_trusted_host, annotate,
+        upgrade, upgrade_packages, output_file, allow_unsafe, generate_hashes,
+        src_files, max_rounds):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -219,6 +222,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
 
     writer = OutputWriter(src_files, dst_file, dry_run=dry_run,
                           emit_header=header, emit_index=index,
+                          emit_trusted_host=emit_trusted_host,
                           annotate=annotate,
                           generate_hashes=generate_hashes,
                           default_index_url=repository.DEFAULT_INDEX_URL,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -6,7 +6,6 @@ import optparse
 import os
 import sys
 import tempfile
-from collections import OrderedDict
 
 import pip
 from pip.req import InstallRequirement, parse_requirements
@@ -17,7 +16,7 @@ from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..resolver import Resolver
 from ..utils import (assert_compatible_pip_version, is_pinned_requirement,
-                     key_from_req)
+                     key_from_req, dedup)
 from ..writer import OutputWriter
 
 # Make sure we're using a compatible version of pip
@@ -141,7 +140,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
 
     log.debug('Using indexes:')
     # remove duplicate index urls before processing
-    repository.finder.index_urls = list(OrderedDict.fromkeys(repository.finder.index_urls))
+    repository.finder.index_urls = list(dedup(repository.finder.index_urls))
     for index_url in repository.finder.index_urls:
         log.debug('  {}'.format(index_url))
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -200,3 +200,14 @@ def lookup_table(values, key=None, keyval=None, unique=False, use_lists=False):
         else:
             s.add(v)
     return dict(lut)
+
+
+def dedup(iterable):
+    """Deduplicate an iterable object like iter(set(iterable)) but
+    order-reserved.
+    """
+    emitted = set()
+    for x in iterable:
+        if x not in emitted:
+            yield x
+            emitted.add(x)

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import sys
 from itertools import chain, groupby
+from collections import OrderedDict
 
 import pip
 from pip.req import InstallRequirement
@@ -206,8 +207,4 @@ def dedup(iterable):
     """Deduplicate an iterable object like iter(set(iterable)) but
     order-reserved.
     """
-    emitted = set()
-    for x in iterable:
-        if x not in emitted:
-            yield x
-            emitted.add(x)
+    return iter(OrderedDict.fromkeys(iterable))

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -10,13 +10,14 @@ from .utils import comment, format_requirement, dedup, UNSAFE_PACKAGES
 
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
-                 annotate, generate_hashes, default_index_url, index_urls,
-                 trusted_hosts, format_control):
+                 emit_trusted_host, annotate, generate_hashes,
+                 default_index_url, index_urls, trusted_hosts, format_control):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run
         self.emit_header = emit_header
         self.emit_index = emit_index
+        self.emit_trusted_host = emit_trusted_host
         self.annotate = annotate
         self.generate_hashes = generate_hashes
         self.default_index_url = default_index_url
@@ -36,6 +37,8 @@ class OutputWriter(object):
             params = []
             if not self.emit_index:
                 params += ['--no-index']
+            if not self.emit_trusted_host:
+                params += ['--no-trusted-host']
             if not self.annotate:
                 params += ['--no-annotate']
             if self.generate_hashes:
@@ -54,8 +57,9 @@ class OutputWriter(object):
                 yield '{} {}'.format(flag, index_url)
 
     def write_trusted_hosts(self):
-        for trusted_host in dedup(self.trusted_hosts):
-            yield '--trusted-host {}'.format(trusted_host)
+        if self.emit_trusted_host:
+            for trusted_host in dedup(self.trusted_hosts):
+                yield '--trusted-host {}'.format(trusted_host)
 
     def write_format_controls(self):
         for nb in dedup(self.format_control.no_binary):

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -5,7 +5,7 @@ from ._compat import ExitStack
 from .click import unstyle
 from .io import AtomicSaver
 from .logging import log
-from .utils import comment, format_requirement, UNSAFE_PACKAGES
+from .utils import comment, format_requirement, dedup, UNSAFE_PACKAGES
 
 
 class OutputWriter(object):
@@ -47,20 +47,20 @@ class OutputWriter(object):
 
     def write_index_options(self):
         if self.emit_index:
-            for index, index_url in enumerate(self.index_urls):
+            for index, index_url in enumerate(dedup(self.index_urls)):
                 if index_url.rstrip('/') == self.default_index_url:
                     continue
                 flag = '--index-url' if index == 0 else '--extra-index-url'
                 yield '{} {}'.format(flag, index_url)
 
     def write_trusted_hosts(self):
-        for trusted_host in self.trusted_hosts:
+        for trusted_host in dedup(self.trusted_hosts):
             yield '--trusted-host {}'.format(trusted_host)
 
     def write_format_controls(self):
-        for nb in self.format_control.no_binary:
+        for nb in dedup(self.format_control.no_binary):
             yield '--no-binary {}'.format(nb)
-        for ob in self.format_control.only_binary:
+        for ob in dedup(self.format_control.only_binary):
             yield '--only-binary {}'.format(ob)
 
     def write_flags(self):

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -38,7 +38,7 @@ class OutputWriter(object):
             if not self.emit_index:
                 params += ['--no-index']
             if not self.emit_trusted_host:
-                params += ['--no-trusted-host']
+                params += ['--no-emit-trusted-host']
             if not self.annotate:
                 params += ['--no-annotate']
             if self.generate_hashes:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,10 +134,10 @@ def test_trusted_host_no_emit(pip_conf):
         open('requirements.in', 'w').close()
         out = runner.invoke(cli, ['-v',
                                   '--trusted-host', 'example.com',
-                                  '--no-trusted-host'])
+                                  '--no-emit-trusted-host'])
         print(out.output)
         assert '--trusted-host example.com' not in out.output
-        assert '--no-trusted-host' in out.output
+        assert '--no-emit-trusted-host' in out.output
 
 
 def test_realistic_complex_sub_dependencies(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,6 +107,9 @@ def test_extra_index_option(pip_conf):
                 '  http://example.com\n'
                 '  http://extraindex1.com\n'
                 '  http://extraindex2.com' in out.output)
+        assert ('--index-url http://example.com\n'
+                '--extra-index-url http://extraindex1.com\n'
+                '--extra-index-url http://extraindex2.com' in out.output)
 
 
 def test_trusted_host(pip_conf):
@@ -117,6 +120,7 @@ def test_trusted_host(pip_conf):
     with runner.isolated_filesystem():
         open('requirements.in', 'w').close()
         out = runner.invoke(cli, ['-v',
+                                  '--trusted-host', 'example.com',
                                   '--trusted-host', 'example2.com'])
         print(out.output)
         assert ('--trusted-host example.com\n'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,7 +113,6 @@ def test_extra_index_option(pip_conf):
 
 
 def test_trusted_host(pip_conf):
-
     assert os.path.exists(pip_conf)
 
     runner = CliRunner()
@@ -125,6 +124,20 @@ def test_trusted_host(pip_conf):
         print(out.output)
         assert ('--trusted-host example.com\n'
                 '--trusted-host example2.com\n' in out.output)
+
+
+def test_trusted_host_no_emit(pip_conf):
+    assert os.path.exists(pip_conf)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open('requirements.in', 'w').close()
+        out = runner.invoke(cli, ['-v',
+                                  '--trusted-host', 'example.com',
+                                  '--no-trusted-host'])
+        print(out.output)
+        assert '--trusted-host example.com' not in out.output
+        assert '--no-trusted-host' in out.output
 
 
 def test_realistic_complex_sub_dependencies(tmpdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 from pytest import raises
 
-from piptools.utils import as_tuple, format_requirement, format_specifier, flat_map
+from piptools.utils import (
+    as_tuple, format_requirement, format_specifier, flat_map, dedup)
 
 
 def test_format_requirement(from_line):
@@ -53,3 +54,7 @@ def test_as_tuple(from_line):
 
 def test_flat_map():
     assert [1, 2, 4, 1, 3, 9] == list(flat_map(lambda x: [1, x, x * x], [2, 3]))
+
+
+def test_dedup():
+    assert list(dedup([3, 1, 2, 4, 3, 5])) == [3, 1, 2, 4, 5]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -7,8 +7,10 @@ from piptools.writer import OutputWriter
 
 @fixture
 def writer():
-    return OutputWriter(src_files=["src_file", "src_file2"], dst_file="dst_file", dry_run=True,
-                        emit_header=True, emit_index=True, annotate=True,
+    return OutputWriter(src_files=["src_file", "src_file2"], dst_file="dst_file",
+                        dry_run=True,
+                        emit_header=True, emit_index=True, emit_trusted_host=True,
+                        annotate=True,
                         generate_hashes=False,
                         default_index_url=None, index_urls=[],
                         trusted_hosts=[],


### PR DESCRIPTION
### Description

There is a proposal to fix following output:

```
--index-url http://pypi.example.com/root/pypi
--extra-index-url http://pypi.example.com/root/pypi
--extra-index-url http://pypi.example.com/root/pypi
--trusted-host pypi.example.com
--trusted-host pypi.example.com
```

Those output may be caused by multiple option sources (e.g. `env PIP_INDEX_URL=$U PIP_EXTRA_INDEX_URL=$U pip-compile --extra-index-url=$U x.in`).

### Changes

- Deduplicate the option lines of index urls and trusted hosts
- Add "--emit-trusted-host/--no-emit-trusted-host" option to fix #382