### PR TITLE
Write relative find-links opts to output file

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -232,6 +232,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           default_index_url=repository.DEFAULT_INDEX_URL,
                           index_urls=repository.finder.index_urls,
                           trusted_hosts=pip_options.trusted_hosts,
+                          find_links=repository.finder.find_links,
                           format_control=repository.finder.format_control)
     writer.write(results=results,
                  unsafe_requirements=resolver.unsafe_constraints,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,10 +93,21 @@ def test_find_links_option(pip_conf):
     with runner.isolated_filesystem():
         with open('requirements.in', 'w'):
             pass
-        out = runner.invoke(cli, ['-v', '-f', './libs1', '-f', './libs2'])
+        find_link_options = [
+            '-f', './libs1',
+            '-f', '/global-libs',
+            '-f', './libs2',
+        ]
+        out = runner.invoke(cli, ['-v'] + find_link_options)
 
         # Check that find-links has been passed to pip
-        assert 'Configuration:\n  -f ./libs1\n  -f ./libs2' in out.output
+        assert ('Configuration:\n'
+                '  -f ./libs1\n'
+                '  -f /global-libs\n'
+                '  -f ./libs2\n') in out.output
+
+        assert ('--find-links libs1\n'
+                '--find-links libs2\n') in out.output
 
 
 def test_extra_index_option(pip_conf):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -14,6 +14,7 @@ def writer():
                         generate_hashes=False,
                         default_index_url=None, index_urls=[],
                         trusted_hosts=[],
+                        find_links=[],
                         format_control=FormatControl(set(), set()))
 
 


### PR DESCRIPTION
If input file or command line has `--find-links` options that point to directories which are relative to the destination file (i.e. relative path from destination directory to find-links directory does not contain any `../` components), then those should be written to the output file.

Now `--find-links` options in the source file work similarly as e.g. the `--extra-index-url` options.  This makes it possible to make deploy scripts to install from `requirements.txt` without knowing about the find-links options.