### PR TITLE
Fallback to sha256 hash on hashes import error

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -9,7 +9,10 @@ from shutil import rmtree
 from pip.download import unpack_url
 from pip.index import PackageFinder
 from pip.req.req_set import RequirementSet
-from pip.utils.hashes import FAVORITE_HASH
+try:
+    from pip.utils.hashes import FAVORITE_HASH
+except ImportError:
+    FAVORITE_HASH = 'sha256'
 
 from ..cache import CACHE_DIR
 from ..exceptions import NoCandidateFound


### PR DESCRIPTION
People on pip < 8.x currently run into an import error before the error message about pip being outdated appears:
```bash
 > pip-compile 
Traceback (most recent call last):
  File "/Users/dschaller/.virtualenvs/pip-tools/bin/pip-compile", line 9, in <module>
    load_entry_point('pip-tools==1.8.1rc1', 'console_scripts', 'pip-compile')()
  File "/Users/dschaller/.virtualenvs/pip-tools/lib/python2.7/site-packages/pkg_resources/__init__.py", line 558, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/dschaller/.virtualenvs/pip-tools/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2682, in load_entry_point
    return ep.load()
  File "/Users/dschaller/.virtualenvs/pip-tools/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2355, in load
    return self.resolve()
  File "/Users/dschaller/.virtualenvs/pip-tools/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2361, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/dschaller/Documents/git_work/pip-tools-upstream/piptools/scripts/compile.py", line 16, in <module>
    from ..repositories import LocalRequirementsRepository, PyPIRepository
  File "/Users/dschaller/Documents/git_work/pip-tools-upstream/piptools/repositories/__init__.py", line 3, in <module>
    from .pypi import PyPIRepository
  File "/Users/dschaller/Documents/git_work/pip-tools-upstream/piptools/repositories/pypi.py", line 12, in <module>
    from pip.utils.hashes import FAVORITE_HASH
ImportError: No module named hashes
```

After this fix:
```bash
 > pip-compile 
pip-compile requires at least version 8.0 of pip (7.1.2 found), perhaps run `pip install --upgrade pip`?
```