### PR TITLE
Remove special casing of pip specifier attribute.

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -36,12 +36,7 @@ class RequirementSummary(object):
         self.req = req
         self.key = key_from_req(req)
         self.extras = str(sorted(req.extras))
-        if hasattr(req, 'specs'):
-            # pip < 8.1.2
-            self.specifier = str(req.specs)
-        else:
-            # pip >= 8.1.2
-            self.specifier = str(req.specifier)
+        self.specifier = str(req.specifier)
 
     def __eq__(self, other):
         return str(self) == str(other)

--- a/tests/fixtures/fake_package/setup.py
+++ b/tests/fixtures/fake_package/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup
+
+setup(
+    name='fake_with_deps',
+    version=0.1,
+    install_requires=[
+        "python-dateutil>=2.4.2,<2.5",
+        "colorama<0.4.0,>=0.3.7",
+        "cornice<1.1,>=1.0.0",
+        "enum34<1.1.7,>=1.0.4",
+        "six>1.5,<=1.8",
+        "futures<3.1,>=3.0.3",
+        "ipaddress<1.1,>=1.0.16",
+        "jsonschema<3.0,>=2.4.0",
+        "pyramid<1.6,>=1.5.7",
+        "pyzmq<14.8,>=14.7.0",
+        "simplejson>=3.5,!=3.8,>3.9",
+        "SQLAlchemy!=0.9.5,<2.0.0,>=0.7.8,>=1.0.0",
+        "python-memcached>=1.57,<2.0",
+        "xmltodict<=0.11,>=0.4.6",
+        ],
+)


### PR DESCRIPTION
The use of req.specs in the resolver causes the resolver to not
stabilize.

This happens on long lists of subdependency. The old conditionnal was
introducing discrepancies in the comparison function, under pip < 8.1.2.

This change removes the pip version dependant check and
unconditionnally uses req.specifier. Now that pip-tools only supports
pip > 8.0, and that this attribute is present in pip
>= 8.0, the special case is not needed.