### PR TITLE
#206: Preserve environment markers from requirements.in

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -226,6 +226,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     writer.write(results=results,
                  reverse_dependencies=reverse_dependencies,
                  primary_packages={key_from_req(ireq.req) for ireq in constraints},
+                 markers={key_from_req(ireq.req): ireq.markers
+                          for ireq in constraints if ireq.markers},
                  hashes=hashes)
 
     if dry_run:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -68,7 +68,7 @@ def make_install_requirement(name, version, extras):
     return InstallRequirement.from_line('{}{}=={}'.format(name, extras_string, str(version)))
 
 
-def format_requirement(ireq, include_specifier=True):
+def format_requirement(ireq, include_specifier=True, marker=None):
     """
     Generic formatter for pretty printing InstallRequirements to the terminal
     in a less verbose way than using its `__str__` method.
@@ -79,6 +79,8 @@ def format_requirement(ireq, include_specifier=True):
         line = str(ireq.req).lower()
     else:
         line = name_from_req(ireq.req).lower()
+    if marker:
+        line = '{} ; {}'.format(line, marker)
     return line
 
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -74,7 +74,7 @@ class OutputWriter(object):
         if emitted:
             yield ''
 
-    def _iter_lines(self, results, reverse_dependencies, primary_packages, hashes):
+    def _iter_lines(self, results, reverse_dependencies, primary_packages, markers, hashes):
         for line in self.write_header():
             yield line
         for line in self.write_flags():
@@ -88,7 +88,9 @@ class OutputWriter(object):
         unsafe_packages = sorted(unsafe_packages, key=self._sort_key)
 
         for ireq in packages:
-            line = self._format_requirement(ireq, reverse_dependencies, primary_packages, hashes=hashes)
+            line = self._format_requirement(
+                ireq, reverse_dependencies, primary_packages,
+                markers.get(ireq.req.name), hashes=hashes)
             yield line
 
         if unsafe_packages:
@@ -97,7 +99,7 @@ class OutputWriter(object):
 
             for ireq in unsafe_packages:
                 line = self._format_requirement(
-                    ireq, reverse_dependencies, primary_packages,
+                    ireq, reverse_dependencies, primary_packages, markers.get(ireq.req.name),
                     hashes=hashes if self.allow_unsafe else None,
                     include_specifier=self.allow_unsafe)
                 if self.allow_unsafe:
@@ -105,20 +107,22 @@ class OutputWriter(object):
                 else:
                     yield comment('# ' + line)
 
-    def write(self, results, reverse_dependencies, primary_packages, hashes):
+    def write(self, results, reverse_dependencies, primary_packages, markers, hashes):
         with ExitStack() as stack:
             f = None
             if not self.dry_run:
                 f = stack.enter_context(AtomicSaver(self.dst_file))
 
-            for line in self._iter_lines(results, reverse_dependencies, primary_packages, hashes):
+            for line in self._iter_lines(results, reverse_dependencies,
+                                         primary_packages, markers, hashes):
                 log.info(line)
                 if f:
                     f.write(unstyle(line).encode('utf-8'))
                     f.write(os.linesep.encode('utf-8'))
 
-    def _format_requirement(self, ireq, reverse_dependencies, primary_packages, include_specifier=True, hashes=None):
-        line = format_requirement(ireq, include_specifier=include_specifier)
+    def _format_requirement(self, ireq, reverse_dependencies, primary_packages,
+                            marker=None, include_specifier=True, hashes=None):
+        line = format_requirement(ireq, include_specifier=include_specifier, marker=marker)
 
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
         if ireq_hashes:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -55,3 +55,15 @@ def test_format_requirement_not_for_primary(from_line, writer):
                                        reverse_dependencies,
                                        primary_packages=['test']) ==
             'test==1.2')
+
+
+def test_format_requirement_environment_marker(from_line, writer):
+    "Environment markers should get passed through to output."
+    ireq = from_line('test ; python_version == "2.7" and platform_python_implementation == "CPython"')
+    reverse_dependencies = set()
+
+    result = writer._format_requirement(
+        ireq, reverse_dependencies, primary_packages=['test'],
+        marker=ireq.markers)
+    assert (result ==
+            'test ; python_version == "2.7" and platform_python_implementation == "CPython"')


### PR DESCRIPTION
Replaces https://github.com/jazzband/pip-tools/pull/459

* piptools/scripts/compile.py
  * When calling `OutputWriter.write()`, pass along the markers from `requirements.in`
* piptools/util.py
  * `format_requirement()` -- add support for optional markers
* piptools/writer.py
  * Add `marker` parameter to `OutputWriter.write()`, pass it to `piptools.util.format_requirement()`
* tests/test_writer.py
  * Test for the new behavior