### PR TITLE
sync: Use options from the txt file

### DIFF
--- a/piptools/scripts/_repo.py
+++ b/piptools/scripts/_repo.py
@@ -1,0 +1,59 @@
+import optparse
+
+import pip
+
+from ..repositories import PyPIRepository
+
+
+class PipCommand(pip.basecommand.Command):
+    name = 'PipCommand'
+
+
+def get_pip_options_and_pypi_repository(
+        index_url=None, extra_index_url=None, no_index=None,
+        find_links=None, cert=None, client_cert=None, pre=None,
+        trusted_host=None):
+    pip_command = get_pip_command()
+
+    pip_args = []
+    if find_links:
+        for link in find_links:
+            pip_args.extend(['-f', link])
+    if index_url:
+        pip_args.extend(['-i', index_url])
+    if no_index:
+        pip_args.extend(['--no-index'])
+    if extra_index_url:
+        for extra_index in extra_index_url:
+            pip_args.extend(['--extra-index-url', extra_index])
+    if cert:
+        pip_args.extend(['--cert', cert])
+    if client_cert:
+        pip_args.extend(['--client-cert', client_cert])
+    if pre:
+        pip_args.extend(['--pre'])
+    if trusted_host:
+        for host in trusted_host:
+            pip_args.extend(['--trusted-host', host])
+
+    pip_options, _ = pip_command.parse_args(pip_args)
+
+    session = pip_command._build_session(pip_options)
+    repository = PyPIRepository(pip_options, session)
+    return (pip_options, repository)
+
+
+def get_pip_command():
+    # Use pip's parser for pip.conf management and defaults.
+    # General options (find_links, index_url, extra_index_url, trusted_host,
+    # and pre) are defered to pip.
+    pip_command = PipCommand()
+    index_opts = pip.cmdoptions.make_option_group(
+        pip.cmdoptions.index_group,
+        pip_command.parser,
+    )
+    pip_command.parser.insert_option_group(0, index_opts)
+    pip_command.parser.add_option(
+        optparse.Option('--pre', action='store_true', default=False))
+
+    return pip_command

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import optparse
 import os
 import sys
 import tempfile
@@ -13,11 +12,12 @@ from pip.req import InstallRequirement, parse_requirements
 from .. import click
 from ..exceptions import PipToolsError
 from ..logging import log
-from ..repositories import LocalRequirementsRepository, PyPIRepository
+from ..repositories import LocalRequirementsRepository
 from ..resolver import Resolver
 from ..utils import (assert_compatible_pip_version, dedup, is_pinned_requirement,
                      key_from_req, UNSAFE_PACKAGES)
 from ..writer import OutputWriter
+from ._repo import get_pip_options_and_pypi_repository
 
 # Make sure we're using a compatible version of pip
 assert_compatible_pip_version()
@@ -103,31 +103,10 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     # Setup
     ###
 
-    pip_command = get_pip_command()
-
-    pip_args = []
-    if find_links:
-        for link in find_links:
-            pip_args.extend(['-f', link])
-    if index_url:
-        pip_args.extend(['-i', index_url])
-    if extra_index_url:
-        for extra_index in extra_index_url:
-            pip_args.extend(['--extra-index-url', extra_index])
-    if cert:
-        pip_args.extend(['--cert', cert])
-    if client_cert:
-        pip_args.extend(['--client-cert', client_cert])
-    if pre:
-        pip_args.extend(['--pre'])
-    if trusted_host:
-        for host in trusted_host:
-            pip_args.extend(['--trusted-host', host])
-
-    pip_options, _ = pip_command.parse_args(pip_args)
-
-    session = pip_command._build_session(pip_options)
-    repository = PyPIRepository(pip_options, session)
+    (pip_options, repository) = get_pip_options_and_pypi_repository(
+        index_url=index_url, extra_index_url=extra_index_url,
+        find_links=find_links, cert=cert, client_cert=client_cert,
+        pre=pre, trusted_host=trusted_host)
 
     # Proxy with a LocalRequirementsRepository if --upgrade is not specified
     # (= default invocation)
@@ -244,18 +223,3 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
 
     if dry_run:
         log.warning('Dry-run, so nothing updated.')
-
-
-def get_pip_command():
-    # Use pip's parser for pip.conf management and defaults.
-    # General options (find_links, index_url, extra_index_url, trusted_host,
-    # and pre) are defered to pip.
-    pip_command = PipCommand()
-    index_opts = pip.cmdoptions.make_option_group(
-        pip.cmdoptions.index_group,
-        pip_command.parser,
-    )
-    pip_command.parser.insert_option_group(0, index_opts)
-    pip_command.parser.add_option(optparse.Option('--pre', action='store_true', default=False))
-
-    return pip_command

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -3,7 +3,7 @@ from pip.index import PackageFinder
 from pip.req import InstallRequirement
 
 from piptools.repositories.pypi import PyPIRepository
-from piptools.scripts.compile import get_pip_command
+from piptools.scripts._repo import get_pip_command
 
 
 def test_pypirepo_build_dir_is_str():

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -1,4 +1,4 @@
-from piptools.scripts.compile import get_pip_command
+from piptools.scripts._repo import get_pip_command
 from piptools.repositories.pypi import PyPIRepository
 
 

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 from piptools.repositories import PyPIRepository
-from piptools.scripts.compile import get_pip_command
+from piptools.scripts._repo import get_pip_command
 
 
 class MockedPyPIRepository(PyPIRepository):


### PR DESCRIPTION
The requirements.txt file might have index or find-links options which
affects finding of the installable packages.  Parse those options from
the txt file before doing the sync.

Utilize the pip options parsing code from the compile command which is
now moved to a separate file.