### PR TITLE
pip-compile includes irrelevant constraints from pip contraints file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added a `--max-rounds` argument to the pip-compile command to allow for solving large requirement sets ([#472](https://github.com/jazzband/pip-tools/pull/472))
 - Exclude unsafe packages' dependencies when `--allow-unsafe` is not in use (#445)
+- Exclude irrelevant pip constraints ([#471](https://github.com/jazzband/pip-tools/pull/471))
 
 # 1.8.2
 

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -53,7 +53,7 @@ class LocalRequirementsRepository(BaseRepository):
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             project, version, _ = as_tuple(existing_pin)
             return make_install_requirement(
-                project, version, ireq.extras
+                project, version, ireq.extras, constraint=ireq.constraint
             )
         else:
             return self.repository.find_best_match(ireq, prereleases)

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -118,7 +118,7 @@ class PyPIRepository(BaseRepository):
 
         # Turn the candidate into a pinned InstallRequirement
         return make_install_requirement(
-            best_candidate.project, best_candidate.version, ireq.extras
+            best_candidate.project, best_candidate.version, ireq.extras, constraint=ireq.constraint
         )
 
     def get_dependencies(self, ireq):

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -176,6 +176,12 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
             constraints.extend(parse_requirements(
                 src_file, finder=repository.finder, session=repository.session, options=pip_options))
 
+    # Check the given base set of constraints first
+    Resolver.check_constraints(constraints)
+
+    # The requirement objects are modified in-place so we need to save off the list of primary packages first
+    primary_packages = {key_from_req(ireq.req) for ireq in constraints if not ireq.constraint}
+
     try:
         resolver = Resolver(constraints, repository, prereleases=pre,
                             clear_caches=rebuild, allow_unsafe=allow_unsafe)
@@ -230,7 +236,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           format_control=repository.finder.format_control)
     writer.write(results=results,
                  reverse_dependencies=reverse_dependencies,
-                 primary_packages={key_from_req(ireq.req) for ireq in constraints},
+                 primary_packages=primary_packages,
                  markers={key_from_req(ireq.req): ireq.markers
                           for ireq in constraints if ireq.markers},
                  hashes=hashes)

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -51,14 +51,14 @@ def comment(text):
     return style(text, fg='green')
 
 
-def make_install_requirement(name, version, extras):
+def make_install_requirement(name, version, extras, constraint=False):
     # If no extras are specified, the extras string is blank
     extras_string = ""
     if extras:
         # Sort extras for stability
         extras_string = "[{}]".format(",".join(sorted(extras)))
 
-    return InstallRequirement.from_line('{}{}=={}'.format(name, extras_string, str(version)))
+    return InstallRequirement.from_line('{}{}=={}'.format(name, extras_string, str(version)), constraint=constraint)
 
 
 def format_requirement(ireq, marker=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ class FakeRepository(BaseRepository):
         if not versions:
             raise NoCandidateFound(ireq, self.index[key_from_req(ireq.req)])
         best_version = max(versions, key=Version)
-        return make_install_requirement(key_from_req(ireq.req), best_version, ireq.extras)
+        return make_install_requirement(key_from_req(ireq.req), best_version, ireq.extras, constraint=ireq.constraint)
 
     def get_dependencies(self, ireq):
         if ireq.editable:
@@ -47,7 +47,7 @@ class FakeRepository(BaseRepository):
         # Store non-extra dependencies under the empty string
         extras += ("",)
         dependencies = [dep for extra in extras for dep in self.index[name][version][extra]]
-        return [InstallRequirement.from_line(dep) for dep in dependencies]
+        return [InstallRequirement.from_line(dep, constraint=ireq.constraint) for dep in dependencies]
 
 
 class FakeInstalledDistribution(object):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -10,7 +10,7 @@ import pytest
 
         (['Flask'],
          ['flask==0.10.1', 'itsdangerous==0.24', 'markupsafe==0.23',
-         'jinja2==2.7.3', 'werkzeug==0.10.4']),
+          'jinja2==2.7.3', 'werkzeug==0.10.4']),
 
         (['Jinja2', 'markupsafe'],
          ['jinja2==2.7.3', 'markupsafe==0.23']),
@@ -98,10 +98,18 @@ import pytest
 
         # Exclude package dependcy of setuptools as it is unsafe.
         (['html5lib'], ['html5lib==0.999999999']),
+
+        # We shouldn't include irrelevant pip constraints
+        # See: GH-471
+        (['Flask', ('click', True), ('itsdangerous', True)],
+         ['flask==0.10.1', 'itsdangerous==0.24', 'markupsafe==0.23',
+          'jinja2==2.7.3', 'werkzeug==0.10.4']
+         ),
     ])
 )
 def test_resolver(resolver, from_line, input, expected, prereleases):
-    input = [from_line(line) for line in input]
+    input = [line if isinstance(line, tuple) else (line, False) for line in input]
+    input = [from_line(req[0], constraint=req[1]) for req in input]
     output = resolver(input, prereleases=prereleases).resolve()
     output = {str(line) for line in output}
     assert output == {str(line) for line in expected}


### PR DESCRIPTION
`pip-compile` treats constraints as requirements.
 
https://pip.pypa.io/en/stable/user_guide/#constraints-files

##### Steps to replicate

1. Create a `constraints.txt` file with the following contents:

```
click==6  # Irrelevant package
itsdangerous==0.24
```

2. Create a `requirements.in` file with the following contents:

```
-c constraints.txt
Flask
```

2. run `pip-compile`

##### Expected result

```
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file requirements.txt requirements.in
#

Flask==0.11.1
itsdangerous==0.24
Jinja2==2.8               # via flask
MarkupSafe==0.23          # via jinja2
Werkzeug==0.11.11         # via flask
```

##### Actual result

```
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file requirements.txt requirements.in
#

click==6.0
Flask==0.11.1
itsdangerous==0.24
Jinja2==2.8               # via flask
MarkupSafe==0.23          # via jinja2
Werkzeug==0.11.11         # via flask

```
