### PR TITLE
Keep second-level requirements for editable reqs after round one

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = build/*, dist/*, pip_tools.egg-info/*

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -93,16 +93,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     # Setup
     ###
 
-    # Use pip's parser for pip.conf management and defaults.
-    # General options (find_links, index_url, extra_index_url, trusted_host,
-    # and pre) are defered to pip.
-    pip_command = PipCommand()
-    index_opts = pip.cmdoptions.make_option_group(
-        pip.cmdoptions.index_group,
-        pip_command.parser,
-    )
-    pip_command.parser.insert_option_group(0, index_opts)
-    pip_command.parser.add_option(optparse.Option('--pre', action='store_true', default=False))
+    pip_command = get_pip_command()
 
     pip_args = []
     if find_links:
@@ -233,3 +224,18 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
 
     if dry_run:
         log.warning('Dry-run, so nothing updated.')
+
+
+def get_pip_command():
+    # Use pip's parser for pip.conf management and defaults.
+    # General options (find_links, index_url, extra_index_url, trusted_host,
+    # and pre) are defered to pip.
+    pip_command = PipCommand()
+    index_opts = pip.cmdoptions.make_option_group(
+        pip.cmdoptions.index_group,
+        pip_command.parser,
+    )
+    pip_command.parser.insert_option_group(0, index_opts)
+    pip_command.parser.add_option(optparse.Option('--pre', action='store_true', default=False))
+
+    return pip_command

--- a/tests/fixtures/small_fake_package/setup.py
+++ b/tests/fixtures/small_fake_package/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name='small_fake_with_deps',
+    version=0.1,
+    install_requires=[
+        "six==1.10.0",
+        ],
+)

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -42,6 +42,5 @@ def test_editable_top_level_deps_preserved(base_resolver, repository, from_edita
     # sanity check that we're expecting something
     assert output != set()
 
-    # confirm incorrect behavior; note the "not in"
     for package_name in expected:
-        assert package_name not in output
+        assert package_name in output

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+
+from piptools.repositories import PyPIRepository
+from piptools.scripts.compile import get_pip_command
+
+
+class MockedPyPIRepository(PyPIRepository):
+    def get_dependencies(self, ireq):
+        # "mock" everything but editable reqs to avoid disk and network I/O
+        # when possible
+        if not ireq.editable:
+            return set()
+
+        return super(MockedPyPIRepository, self).get_dependencies(ireq)
+
+
+def _get_repository():
+    pip_command = get_pip_command()
+    pip_args = []
+    pip_options, _ = pip_command.parse_args(pip_args)
+    session = pip_command._build_session(pip_options)
+    repository = MockedPyPIRepository(pip_options, session)
+    return repository
+
+
+@pytest.mark.parametrize(
+    ('input', 'expected'),
+
+    ((tup) for tup in [
+        ([os.path.join(os.path.dirname(__file__), 'fixtures', 'small_fake_package')],
+         ['six']),
+    ])
+)
+def test_editable_top_level_deps_preserved(base_resolver, repository, from_editable, input, expected):
+    input = [from_editable(line) for line in input]
+    repository = _get_repository()
+    output = base_resolver(input, prereleases=False, repository=repository).resolve()
+
+    output = set([p.name for p in output])
+
+    # sanity check that we're expecting something
+    assert output != set()
+
+    # confirm incorrect behavior; note the "not in"
+    for package_name in expected:
+        assert package_name not in output


### PR DESCRIPTION
This is a straw-man proposal to address #466 based on my comments there.