### PR TITLE
add requirement for minimal version of setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'click>=6',
         'first',
         'six',
+        'setuptools>=20.2.2',
     ],
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
This tools doesn't work with old verisons of setuptools, due to an old version of the pkg_resources library.

Here's an error I get after running: `sudo pip install --upgrade setuptools==20.1.1`

```
Traceback (most recent call last):
  File "/usr/local/bin/pip-compile", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/piptools/scripts/compile.py", line 223, in cli
    reverse_dependencies = resolver.reverse_dependencies(results)
  File "/usr/local/lib/python2.7/dist-packages/piptools/resolver.py", line 273, in reverse_dependencies
    return self.dependency_cache.reverse_dependencies(non_editable)
  File "/usr/local/lib/python2.7/dist-packages/piptools/cache.py", line 139, in reverse_dependencies
    return self._reverse_dependencies(ireqs_as_cache_values)
  File "/usr/local/lib/python2.7/dist-packages/piptools/cache.py", line 163, in _reverse_dependencies
    for name, version_and_extras in cache_keys
  File "/usr/local/lib/python2.7/dist-packages/piptools/utils.py", line 192, in lookup_table
    for value in values:
  File "/usr/local/lib/python2.7/dist-packages/piptools/cache.py", line 164, in <genexpr>
    for dep_name in self.cache[name][version_and_extras])
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3047, in parse
    req, = parse_requirements(s)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2991, in parse_requirements
    "version spec")
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2967, in scan_list
    raise RequirementParseError(msg, line, "at", line[p:])
pkg_resources.RequirementParseError: Expected ',' or end-of-list in funcsigs>=1; python_version < "3.3" at ; python_version < "3.3"
```

With the next available version of setuptools (20.2.2), it works normally.