### PR TITLE
Fix usage for source file without an extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.9.0 (Unreleased)
 
+- Fixed the default output file name when the source file has no extension ([#470](https://github.com/jazzband/pip-tools/issues/470))
 - Added a `--max-rounds` argument to the pip-compile command to allow for solving large requirement sets ([#472](https://github.com/jazzband/pip-tools/pull/472))
 - Exclude unsafe packages' dependencies when `--allow-unsafe` is not in use (#445)
 - Exclude irrelevant pip constraints ([#471](https://github.com/jazzband/pip-tools/pull/471))

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -92,7 +92,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if output_file:
         dst_file = output_file
     else:
-        base_name, _, _ = src_files[0].rpartition('.')
+        base_name = src_files[0].rsplit('.', 1)[0]
         dst_file = base_name + '.txt'
 
     if upgrade and upgrade_packages:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -219,3 +219,21 @@ def test_editable_package(tmpdir):
         assert out.exit_code == 0
         assert fake_package_dir in out.output
         assert 'six==1.10.0' in out.output
+
+
+def test_input_file_without_extension(tmpdir):
+    """
+    piptools can compile a file without an extension,
+    and add .txt as the defaut output file extension.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('requirements', 'w') as req_in:
+            req_in.write('six==1.10.0')
+
+        out = runner.invoke(cli, ['-n', 'requirements'])
+
+        print(out.output)
+        assert out.exit_code == 0
+        assert '--output-file requirements.txt' in out.output
+        assert 'six==1.10.0' in out.output


### PR DESCRIPTION
Fixes #470

For the default output file, we simply add ".txt".