### PR TITLE
Fix editable unittest for users with space in their path.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import os
 from textwrap import dedent
+from six.moves.urllib.request import pathname2url
 import subprocess
 import sys
 
@@ -207,7 +208,7 @@ def test_run_as_module_sync():
 def test_editable_package(tmpdir):
     """ piptools can compile an editable """
     fake_package_dir = os.path.join(os.path.split(__file__)[0], 'fixtures', 'small_fake_package')
-    fake_package_dir = fake_package_dir.replace('\\', '/')
+    fake_package_dir = 'file:' + pathname2url(fake_package_dir)
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open('requirements.in', 'w') as req_in:


### PR DESCRIPTION
For Windows users who can have spaces in their path, this test would fail.
Ex: `C:\Users\Vincent Philippon\dev\pip-tools\tests\fixtures\small_fake_package`
This would try to install `C:\Users\Vincent` as an editable.
This is due to how pip parses its editable arguments.
By changing it to a file:// url from the starts (and escape spaces as %20), it should work allright.