### PR TITLE
Improve setup.py parsing

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -165,7 +165,15 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
             if is_setup_file:
                 from distutils.core import run_setup
                 dist = run_setup(src_file)
-                tmpfile.write('\n'.join(dist.install_requires))
+                reqs = (
+                  (dist.setup_requires or [])
+                  + (dist.install_requires or [])
+                  + (dist.tests_require or [])
+                )
+                if reqs:
+                    tmpfile.write('\n'.join(reqs))
+                else:
+                    raise PipToolsError('No requirements specified')
             else:
                 tmpfile.write(sys.stdin.read())
             tmpfile.flush()


### PR DESCRIPTION
Since requirements.txt should hold the reqs for the whole system, we should read from `setup_requires` _and_ `tests_require` when making the list of requirements.

Also avoid erroring out in an ugly if the user doesn't happen to have any requirements. Now, we throw a meaningful error if that's the case.