### PR TITLE
Fix sync of editable packages.

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,5 +1,6 @@
 from collections import Counter
 import os
+import platform
 
 import mock
 import pytest
@@ -154,6 +155,12 @@ def test_diff_leave_piptools_alone(fake_dist, from_line):
     assert to_uninstall == {'foobar'}
 
 
+def _get_file_url(local_path):
+    if platform.system() == 'Windows':
+        local_path = '/%s' % local_path.replace('\\', '/')
+    return 'file://%s' % local_path
+
+
 def test_diff_with_editable(fake_dist, from_editable):
     installed = [
         fake_dist('small-fake-with-deps==0.0.1'),
@@ -172,7 +179,7 @@ def test_diff_with_editable(fake_dist, from_editable):
     assert len(to_install) == 1
     package = list(to_install)[0]
     assert package.editable
-    assert str(package.link) == 'file://%s' % path_to_package
+    assert str(package.link) == _get_file_url(path_to_package)
 
 
 def test_sync_with_editable(from_editable):
@@ -181,4 +188,4 @@ def test_sync_with_editable(from_editable):
         to_install = {from_editable(path_to_package)}
 
         sync(to_install, set())
-        check_call.assert_called_once_with(['pip', 'install', '-q', '-e', 'file://%s' % path_to_package])
+        check_call.assert_called_once_with(['pip', 'install', '-q', '-e', _get_file_url(path_to_package)])

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -83,7 +83,7 @@ def test_diff_should_install(from_line):
     reqs = [from_line('django==1.8')]
 
     to_install, to_uninstall = diff(reqs, installed)
-    assert to_install == {'django==1.8'}
+    assert {str(x.req) for x in to_install} == {'django==1.8'}
     assert to_uninstall == set()
 
 
@@ -101,7 +101,7 @@ def test_diff_should_update(fake_dist, from_line):
     reqs = [from_line('django==1.8')]
 
     to_install, to_uninstall = diff(reqs, installed)
-    assert to_install == {'django==1.8'}
+    assert {str(x.req) for x in to_install} == {'django==1.8'}
     assert to_uninstall == set()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     pip8: pip~=8.0
     pip9: pip~=9.0
     coverage
+    mock
     pytest
 install_command= python -m pip install {opts} {packages}
 commands =


### PR DESCRIPTION
From #399:

> A) The tool shouldn't be attempting to uninstall the editable package and then reinstall it
> B) Installing editable packages should have a -e option

This fixes B, which is the main problem. I don't know why it's reinstalling editable packages, but at least the result of that is correct, even if it's a bit slow.

Closes #399 