### PR TITLE
Make editable requirements use relative paths where appropriate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Master
+
+Features:
+- Made local, editable, and relative requirements resolve to relative paths instead of absolute ones ([#507](https://github.com/jazzband/pip-tools/pull/507). Thanks to @orf)
+
 # 1.9.0
 
 Features:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 from functools import partial
 
 from pip._vendor.packaging.version import Version
@@ -106,3 +107,18 @@ def from_line():
 @fixture
 def from_editable():
     return InstallRequirement.from_editable
+
+
+@fixture
+def fake_package_dir():
+    return os.path.join(os.path.split(__file__)[0], 'fixtures', 'fake_package')
+
+
+@fixture
+def small_fake_package_dir():
+    return os.path.join(os.path.split(__file__)[0], 'fixtures', 'small_fake_package')
+
+
+@fixture
+def minimal_wheels_dir():
+    return os.path.join(os.path.split(__file__)[0], 'fixtures', 'minimal_wheels')

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,5 +1,4 @@
 from collections import Counter
-import os
 import platform
 
 import mock

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -161,14 +161,13 @@ def _get_file_url(local_path):
     return 'file://%s' % local_path
 
 
-def test_diff_with_editable(fake_dist, from_editable):
+def test_diff_with_editable(fake_dist, from_editable, small_fake_package_dir):
     installed = [
         fake_dist('small-fake-with-deps==0.0.1'),
         fake_dist('six==1.10.0'),
     ]
-    path_to_package = os.path.join(os.path.dirname(__file__), 'fixtures', 'small_fake_package')
     reqs = [
-        from_editable(path_to_package),
+        from_editable(small_fake_package_dir),
     ]
     to_install, to_uninstall = diff(reqs, installed)
 
@@ -179,13 +178,12 @@ def test_diff_with_editable(fake_dist, from_editable):
     assert len(to_install) == 1
     package = list(to_install)[0]
     assert package.editable
-    assert str(package.link) == _get_file_url(path_to_package)
+    assert str(package.link) == _get_file_url(small_fake_package_dir)
 
 
-def test_sync_with_editable(from_editable):
+def test_sync_with_editable(from_editable, small_fake_package_dir):
     with mock.patch('piptools.sync.check_call') as check_call:
-        path_to_package = os.path.join(os.path.dirname(__file__), 'fixtures', 'small_fake_package')
-        to_install = {from_editable(path_to_package)}
+        to_install = {from_editable(small_fake_package_dir)}
 
         sync(to_install, set())
-        check_call.assert_called_once_with(['pip', 'install', '-q', '-e', _get_file_url(path_to_package)])
+        check_call.assert_called_once_with(['pip', 'install', '-q', '-e', _get_file_url(small_fake_package_dir)])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -17,6 +17,11 @@ def writer():
                         format_control=FormatControl(set(), set()))
 
 
+def test_format_requirements_relative_path(from_editable, writer):
+    ireq = from_editable('file:fixtures/fake_package#egg=fake_package')
+    assert writer._format_requirement(ireq, {}, primary_packages=['fake_package']) == '-e file:./fixtures/fake_package'
+
+
 def test_format_requirement_annotation_editable(from_editable, writer):
     # Annotations are printed as comments at a fixed column
     ireq = from_editable('git+git://fake.org/x/y.git#egg=y')


### PR DESCRIPTION
#204

When `pip-compile` is given a relative editable dependency, like `-e ./some_module/`, it is resolved to the *full absolute path* by `pip` under the hood. This is not what we want or need in most cases.

As the path resolution happens inside `pip` and it might be a bit complicated to add a change in that project, this merge request works around the issue by modifying the `format_requirement` to check that if the editable dependency uses the `file:` scheme and if the *location* of the editable dependency exists within a subdirectory **of the current working directory** then we format the dependency using the relative path **from the current working directory**.

I think this is the best place to add this change and requires less potential breakage and internal changes. I'm not too sure on if we should use the current directory *or* the path from the **output file directory**, but that's a small detail.

I also did a small refactoring of the tests by adding fixtures to return the paths of the packages within the `tests/fixtures/` directory rather than duplicating various `os.path.join` calls everywhere.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
