### PR TITLE
Fix allow unsafe false pinning bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Features:
 
 Bug Fixes:
 - Fixed bug where unsafe packages would get pinned in generated requirements files
-when `--allow-unsafe` was set. ([#508](https://github.com/jazzband/pip-tools/pull/508)).
+when `--allow-unsafe` was not set. ([#508](https://github.com/jazzband/pip-tools/pull/508)).
 
 # 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.10.0rc1
+Features:
+-
+
+Bug Fixes:
+- Fixed bug where unsafe packages would get pinned in generated requirements files
+when `--allow-unsafe` was set. ([#508](https://github.com/jazzband/pip-tools/pull/508)).
+
 # 1.9.0
 
 Features:
@@ -25,7 +33,7 @@ Bug Fixes:
 # 1.8.1
 
 - Recalculate secondary dependencies between rounds (#378)
-- Calculated dependencies could be left with wrong candidates when 
+- Calculated dependencies could be left with wrong candidates when
   toplevel requirements happen to be also pinned in sub-dependencies (#450)
 - Fix duplicate entries that could happen in generated requirements.txt (#427)
 - Gracefully report invalid pip version (#457)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
-# 1.10.0rc1
-Features:
--
-
+# 1.9.1
 Bug Fixes:
 - Fixed bug where unsafe packages would get pinned in generated requirements files
 when `--allow-unsafe` was not set. ([#508](https://github.com/jazzband/pip-tools/pull/508)).

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -229,7 +229,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           default_index_url=repository.DEFAULT_INDEX_URL,
                           index_urls=repository.finder.index_urls,
                           trusted_hosts=pip_options.trusted_hosts,
-                          format_control=repository.finder.format_control)
+                          format_control=repository.finder.format_control,
+                          allow_unsafe=allow_unsafe)
     writer.write(results=results,
                  reverse_dependencies=reverse_dependencies,
                  primary_packages={key_from_req(ireq.req) for ireq in constraints if not ireq.constraint},

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -61,15 +61,27 @@ def make_install_requirement(name, version, extras, constraint=False):
     return InstallRequirement.from_line('{}{}=={}'.format(name, extras_string, str(version)), constraint=constraint)
 
 
-def format_requirement(ireq, marker=None):
+def _name_from_req(req):
+    """Get the name of the requirement."""
+    if hasattr(req, 'project_name'):
+        # pip 8.1.1 or below, using pkg_resources
+        return req.project_name
+    else:
+        # pip 8.1.2 or above, using packaging
+        return req.name
+
+
+def format_requirement(ireq, include_specifier=True, marker=None):
     """
     Generic formatter for pretty printing InstallRequirements to the terminal
     in a less verbose way than using its `__str__` method.
     """
     if ireq.editable:
         line = '-e {}'.format(ireq.link)
-    else:
+    elif include_specifier:
         line = str(ireq.req).lower()
+    else:
+        line = _name_from_req(ireq).lower()
 
     if marker:
         line = '{} ; {}'.format(line, marker)

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -106,12 +106,14 @@ class OutputWriter(object):
             yield comment('# The following packages are considered to be unsafe in a requirements file:')
 
             for ireq in unsafe_packages:
-                line = self._format_requirement(ireq,
-                                               reverse_dependencies,
-                                               primary_packages,
-                                               include_specifier=self.allow_unsafe,
-                                               marker=markers.get(ireq.req.name),
-                                               hashes=hashes if self.allow_unsafe else None)
+                line = self._format_requirement(
+                    ireq,
+                    reverse_dependencies,
+                    primary_packages,
+                    include_specifier=self.allow_unsafe,
+                    marker=markers.get(ireq.req.name),
+                    hashes=hashes if self.allow_unsafe else None
+                )
                 if not self.allow_unsafe:
                     yield comment('# {}'.format(line))
                 else:

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -11,7 +11,8 @@ from .utils import comment, format_requirement, dedup, UNSAFE_PACKAGES
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
                  emit_trusted_host, annotate, generate_hashes,
-                 default_index_url, index_urls, trusted_hosts, format_control):
+                 default_index_url, index_urls, trusted_hosts, format_control,
+                 allow_unsafe=False):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run
@@ -24,6 +25,7 @@ class OutputWriter(object):
         self.index_urls = index_urls
         self.trusted_hosts = trusted_hosts
         self.format_control = format_control
+        self.allow_unsafe = allow_unsafe
 
     def _sort_key(self, ireq):
         return (not ireq.editable, str(ireq.req).lower())
@@ -96,7 +98,7 @@ class OutputWriter(object):
         for ireq in packages:
             line = self._format_requirement(
                 ireq, reverse_dependencies, primary_packages,
-                markers.get(ireq.req.name), hashes=hashes)
+                marker=markers.get(ireq.req.name), hashes=hashes)
             yield line
 
         if unsafe_packages:
@@ -104,12 +106,16 @@ class OutputWriter(object):
             yield comment('# The following packages are considered to be unsafe in a requirements file:')
 
             for ireq in unsafe_packages:
-
-                yield self._format_requirement(ireq,
+                line = self._format_requirement(ireq,
                                                reverse_dependencies,
                                                primary_packages,
+                                               include_specifier=self.allow_unsafe,
                                                marker=markers.get(ireq.req.name),
-                                               hashes=hashes)
+                                               hashes=hashes if self.allow_unsafe else None)
+                if not self.allow_unsafe:
+                    yield comment('# {}'.format(line))
+                else:
+                    yield line
 
     def write(self, results, reverse_dependencies, primary_packages, markers, hashes):
         with ExitStack() as stack:
@@ -124,9 +130,12 @@ class OutputWriter(object):
                     f.write(unstyle(line).encode('utf-8'))
                     f.write(os.linesep.encode('utf-8'))
 
-    def _format_requirement(self, ireq, reverse_dependencies, primary_packages, marker=None, hashes=None):
-        line = format_requirement(ireq, marker=marker)
+    def _format_requirement(self, ireq, reverse_dependencies, primary_packages, **kwargs):
+        include_specifier = kwargs.get('include_specifier', True)
+        marker = kwargs.get('marker')
+        line = format_requirement(ireq, include_specifier=include_specifier, marker=marker)
 
+        hashes = kwargs.get('hashes')
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
         if ireq_hashes:
             for hash_ in sorted(ireq_hashes):

--- a/tests/test_minimal_upgrade.py
+++ b/tests/test_minimal_upgrade.py
@@ -1,15 +1,7 @@
 import pytest
+
 from piptools.repositories import LocalRequirementsRepository
-
-
-def name_from_req(req):
-    """Get the name of the requirement"""
-    if hasattr(req, 'project_name'):
-        # pip 8.1.1 or below, using pkg_resources
-        return req.project_name
-    else:
-        # pip 8.1.2 or above, using packaging
-        return req.name
+from piptools.utils import _name_from_req
 
 
 @pytest.mark.parametrize(
@@ -40,7 +32,7 @@ def test_no_upgrades(base_resolver, repository, from_line, input, pins, expected
     existing_pins = dict()
     for line in pins:
         ireq = from_line(line)
-        existing_pins[name_from_req(ireq.req)] = ireq
+        existing_pins[_name_from_req(ireq.req)] = ireq
     local_repository = LocalRequirementsRepository(existing_pins, repository)
     output = base_resolver(input, prereleases=False, repository=local_repository).resolve()
     output = {str(line) for line in output}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,31 @@
 from pytest import raises
 
 from piptools.utils import (
-    as_tuple, format_requirement, format_specifier, flat_map, dedup)
+    _name_from_req,
+    as_tuple,
+    dedup,
+    flat_map,
+    format_requirement,
+    format_specifier
+)
+
+
+def test_name_from_req__missing_project_name(from_line):
+    ireq = from_line('test==1.2')
+    delattr(ireq, 'project_name')
+    assert _name_from_req(ireq) == ireq.name
+
+
+def test_name_from_req__missing_project_name(from_line):
+    ireq = from_line('test==1.2')
+    setattr(ireq, 'project_name', 'foobar')
+    assert _name_from_req(ireq) == 'foobar'
 
 
 def test_format_requirement(from_line):
     ireq = from_line('test==1.2')
     assert format_requirement(ireq) == 'test==1.2'
+    assert format_requirement(ireq, include_specifier=False) == 'test'
 
 
 def test_format_requirement_editable(from_editable):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,11 +12,12 @@ from piptools.utils import (
 
 def test_name_from_req__missing_project_name(from_line):
     ireq = from_line('test==1.2')
-    delattr(ireq, 'project_name')
+    if hasattr(ireq, 'project_name'):
+        delattr(ireq, 'project_name')
     assert _name_from_req(ireq) == ireq.name
 
 
-def test_name_from_req__missing_project_name(from_line):
+def test_name_from_req__project_name(from_line):
     ireq = from_line('test==1.2')
     setattr(ireq, 'project_name', 'foobar')
     assert _name_from_req(ireq) == 'foobar'

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,4 @@
-from pytest import yield_fixture
+from pytest import fixture
 
 from pip.index import FormatControl
 from piptools.utils import comment, UNSAFE_PACKAGES
@@ -18,7 +18,7 @@ class Writer(object):
                             **kwargs)
 
 
-@yield_fixture
+@fixture
 def writer():
     yield Writer()
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,20 +1,26 @@
-from pytest import fixture
+from pytest import fixture, yield_fixture
 
 from pip.index import FormatControl
-from piptools.utils import comment
+from piptools.utils import comment, UNSAFE_PACKAGES
 from piptools.writer import OutputWriter
 
 
-@fixture
+class Writer(object):
+    def __call__(self, **kwargs):
+        return OutputWriter(src_files=["src_file", "src_file2"], dst_file="dst_file",
+                            dry_run=True,
+                            emit_header=True, emit_index=True, emit_trusted_host=True,
+                            annotate=True,
+                            generate_hashes=False,
+                            default_index_url=None, index_urls=[],
+                            trusted_hosts=[],
+                            format_control=FormatControl(set(), set()),
+                            **kwargs)
+
+
+@yield_fixture
 def writer():
-    return OutputWriter(src_files=["src_file", "src_file2"], dst_file="dst_file",
-                        dry_run=True,
-                        emit_header=True, emit_index=True, emit_trusted_host=True,
-                        annotate=True,
-                        generate_hashes=False,
-                        default_index_url=None, index_urls=[],
-                        trusted_hosts=[],
-                        format_control=FormatControl(set(), set()))
+    yield Writer()
 
 
 def test_format_requirement_annotation_editable(from_editable, writer):
@@ -22,7 +28,7 @@ def test_format_requirement_annotation_editable(from_editable, writer):
     ireq = from_editable('git+git://fake.org/x/y.git#egg=y')
     reverse_dependencies = {'y': ['xyz']}
 
-    assert (writer._format_requirement(ireq,
+    assert (writer()._format_requirement(ireq,
                                        reverse_dependencies,
                                        primary_packages=[]) ==
             '-e git+git://fake.org/x/y.git#egg=y  ' + comment('# via xyz'))
@@ -32,7 +38,7 @@ def test_format_requirement_annotation(from_line, writer):
     ireq = from_line('test==1.2')
     reverse_dependencies = {'test': ['xyz']}
 
-    assert (writer._format_requirement(ireq,
+    assert (writer()._format_requirement(ireq,
                                        reverse_dependencies,
                                        primary_packages=[]) ==
             'test==1.2                 ' + comment('# via xyz'))
@@ -42,7 +48,7 @@ def test_format_requirement_annotation_lower_case(from_line, writer):
     ireq = from_line('Test==1.2')
     reverse_dependencies = {'test': ['xyz']}
 
-    assert (writer._format_requirement(ireq,
+    assert (writer()._format_requirement(ireq,
                                        reverse_dependencies,
                                        primary_packages=[]) ==
             'test==1.2                 ' + comment('# via xyz'))
@@ -53,7 +59,7 @@ def test_format_requirement_not_for_primary(from_line, writer):
     ireq = from_line('test==1.2')
     reverse_dependencies = {'test': ['xyz']}
 
-    assert (writer._format_requirement(ireq,
+    assert (writer()._format_requirement(ireq,
                                        reverse_dependencies,
                                        primary_packages=['test']) ==
             'test==1.2')
@@ -64,8 +70,59 @@ def test_format_requirement_environment_marker(from_line, writer):
     ireq = from_line('test ; python_version == "2.7" and platform_python_implementation == "CPython"')
     reverse_dependencies = set()
 
-    result = writer._format_requirement(
+    result = writer()._format_requirement(
         ireq, reverse_dependencies, primary_packages=['test'],
         marker=ireq.markers)
     assert (result ==
             'test ; python_version == "2.7" and platform_python_implementation == "CPython"')
+
+
+def test_iter_lines__do_not_allow_unsafe_packages(mocker, from_line, writer):
+    unsafe_package = UNSAFE_PACKAGES.copy().pop()
+    unsafe_dep = '{}==1.2'.format(unsafe_package)
+    ireq = from_line(unsafe_dep)
+    w = writer(allow_unsafe=False)
+    mocker.patch.object(w, 'write_header', return_value=['header'])
+    mocker.patch.object(w, 'write_flags', return_value=['flags'])
+    mocker.patch.object(w, '_sort_key', return_value=(ireq.editable, str(ireq.req).lower()))
+    format_requirement = mocker.patch.object(
+        w, '_format_requirement', return_value='{}'.format(unsafe_package)
+    )
+    comment = mocker.patch(
+        'piptools.writer.comment', side_effect=['foobar', '# {}'.format(unsafe_package)])
+
+    expected_results = ['header', 'flags', '', 'foobar', '# pip']
+    result = w._iter_lines([ireq], False, [], {unsafe_package: 'marker'}, 'hashes')
+    for line in result:
+        assert line in expected_results
+
+    format_requirement.assert_called_once_with(
+        ireq, False, [], include_specifier=False, marker='marker', hashes=None)
+    comment.assert_any_call('# The following packages are considered to be unsafe in a requirements file:')
+    comment.assert_any_call('# pip')
+    assert comment.call_count == 2
+
+
+def test_iter_lines__allow_unsafe_packages(mocker, from_line, writer):
+    unsafe_package = UNSAFE_PACKAGES.copy().pop()
+    unsafe_dep = '{}==1.2'.format(unsafe_package)
+    ireq = from_line(unsafe_dep)
+    w = writer(allow_unsafe=True)
+    mocker.patch.object(w, 'write_header', return_value=['header'])
+    mocker.patch.object(w, 'write_flags', return_value=['flags'])
+    mocker.patch.object(w, '_sort_key', return_value=(ireq.editable, str(ireq.req).lower()))
+    format_requirement = mocker.patch.object(
+        w, '_format_requirement', return_value='{}==1.2'.format(unsafe_package)
+    )
+    comment = mocker.patch('piptools.writer.comment', return_value='foobar')
+
+    result = w._iter_lines([ireq], False, [], {unsafe_package: 'marker'}, 'hashes')
+    expected_results = ['header', 'flags', '', 'foobar', 'pip==1.2']
+    for line in result:
+        assert line in expected_results
+
+
+    format_requirement.assert_called_once_with(
+        ireq, False, [], include_specifier=True, marker='marker', hashes='hashes')
+    comment.assert_any_call('# The following packages are considered to be unsafe in a requirements file:')
+    assert comment.call_count == 1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -91,7 +91,7 @@ def test_iter_lines__do_not_allow_unsafe_packages(mocker, from_line, writer):
     comment = mocker.patch(
         'piptools.writer.comment', side_effect=['foobar', '# {}'.format(unsafe_package)])
 
-    expected_results = ['header', 'flags', '', 'foobar', '# pip']
+    expected_results = ['header', 'flags', '', 'foobar', '# {}'.format(unsafe_package)]
     result = w._iter_lines([ireq], False, [], {unsafe_package: 'marker'}, 'hashes')
     for line in result:
         assert line in expected_results
@@ -99,7 +99,7 @@ def test_iter_lines__do_not_allow_unsafe_packages(mocker, from_line, writer):
     format_requirement.assert_called_once_with(
         ireq, False, [], include_specifier=False, marker='marker', hashes=None)
     comment.assert_any_call('# The following packages are considered to be unsafe in a requirements file:')
-    comment.assert_any_call('# pip')
+    comment.assert_any_call('# {}'.format(unsafe_package))
     assert comment.call_count == 2
 
 
@@ -117,7 +117,7 @@ def test_iter_lines__allow_unsafe_packages(mocker, from_line, writer):
     comment = mocker.patch('piptools.writer.comment', return_value='foobar')
 
     result = w._iter_lines([ireq], False, [], {unsafe_package: 'marker'}, 'hashes')
-    expected_results = ['header', 'flags', '', 'foobar', 'pip==1.2']
+    expected_results = ['header', 'flags', '', 'foobar', unsafe_dep]
     for line in result:
         assert line in expected_results
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,4 @@
-from pytest import fixture, yield_fixture
+from pytest import yield_fixture
 
 from pip.index import FormatControl
 from piptools.utils import comment, UNSAFE_PACKAGES
@@ -29,8 +29,8 @@ def test_format_requirement_annotation_editable(from_editable, writer):
     reverse_dependencies = {'y': ['xyz']}
 
     assert (writer()._format_requirement(ireq,
-                                       reverse_dependencies,
-                                       primary_packages=[]) ==
+                                         reverse_dependencies,
+                                         primary_packages=[]) ==
             '-e git+git://fake.org/x/y.git#egg=y  ' + comment('# via xyz'))
 
 
@@ -39,8 +39,8 @@ def test_format_requirement_annotation(from_line, writer):
     reverse_dependencies = {'test': ['xyz']}
 
     assert (writer()._format_requirement(ireq,
-                                       reverse_dependencies,
-                                       primary_packages=[]) ==
+                                         reverse_dependencies,
+                                         primary_packages=[]) ==
             'test==1.2                 ' + comment('# via xyz'))
 
 
@@ -49,8 +49,8 @@ def test_format_requirement_annotation_lower_case(from_line, writer):
     reverse_dependencies = {'test': ['xyz']}
 
     assert (writer()._format_requirement(ireq,
-                                       reverse_dependencies,
-                                       primary_packages=[]) ==
+                                         reverse_dependencies,
+                                         primary_packages=[]) ==
             'test==1.2                 ' + comment('# via xyz'))
 
 
@@ -60,8 +60,8 @@ def test_format_requirement_not_for_primary(from_line, writer):
     reverse_dependencies = {'test': ['xyz']}
 
     assert (writer()._format_requirement(ireq,
-                                       reverse_dependencies,
-                                       primary_packages=['test']) ==
+                                         reverse_dependencies,
+                                         primary_packages=['test']) ==
             'test==1.2')
 
 
@@ -120,7 +120,6 @@ def test_iter_lines__allow_unsafe_packages(mocker, from_line, writer):
     expected_results = ['header', 'flags', '', 'foobar', unsafe_dep]
     for line in result:
         assert line in expected_results
-
 
     format_requirement.assert_called_once_with(
         ireq, False, [], include_specifier=True, marker='marker', hashes='hashes')

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     coverage
     mock
     pytest
+    pytest-mock
 install_command= python -m pip install {opts} {packages}
 commands =
     pip --version


### PR DESCRIPTION
Fix a bug introduced in [441](https://github.com/jazzband/pip-tools/pull/441) that pinned unsafe dependencies in generated requirements files when `--allow-unsafe` was `False`.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
