### PR TITLE
Replace custom logging with built-in version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Master
+
+Bug Fixes:
+- Logs are now emitted to stderr instead of stdout.
+
 # 1.9.0
 
 Features:

--- a/piptools/logging.py
+++ b/piptools/logging.py
@@ -2,34 +2,20 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import sys
+import logging
 
-from . import click
-
-
-class LogContext(object):
-    def __init__(self, verbose=False):
-        self.verbose = verbose
-
-    def log(self, *args, **kwargs):
-        click.secho(*args, **kwargs)
-
-    def debug(self, *args, **kwargs):
-        if self.verbose:
-            self.log(*args, **kwargs)
-
-    def info(self, *args, **kwargs):
-        self.log(*args, **kwargs)
-
-    def warning(self, *args, **kwargs):
-        kwargs.setdefault('fg', 'yellow')
-        kwargs.setdefault('file', sys.stderr)
-        self.log(*args, **kwargs)
-
-    def error(self, *args, **kwargs):
-        kwargs.setdefault('fg', 'red')
-        kwargs.setdefault('file', sys.stderr)
-        self.log(*args, **kwargs)
+import coloredlogs
 
 
-log = LogContext()
+def configure_logging(verbose=False):
+    """Setup a colored logger to write to the console."""
+    logger = logging.getLogger('piptools')
+    if verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    level_styles = dict(coloredlogs.DEFAULT_LEVEL_STYLES)
+    level_styles.update(debug={})   # reset debug to be the default style
+    fmt = '%(message)s'
+    coloredlogs.install(level=level, logger=logger, level_styles=level_styles,
+                        fmt=fmt)

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import logging
 import os
 import sys
 
@@ -9,13 +10,14 @@ import pip
 
 from .. import click, sync
 from ..exceptions import PipToolsError
-from ..logging import log
+from ..logging import configure_logging
 from ..utils import assert_compatible_pip_version, flat_map
 
 # Make sure we're using a compatible version of pip
 assert_compatible_pip_version()
 
 DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -29,21 +31,23 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 @click.argument('src_files', required=False, type=click.Path(exists=True), nargs=-1)
 def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_files):
     """Synchronize virtual environment with requirements.txt."""
+    configure_logging()
     if not src_files:
         if os.path.exists(DEFAULT_REQUIREMENTS_FILE):
             src_files = (DEFAULT_REQUIREMENTS_FILE,)
         else:
-            msg = 'No requirement files given and no {} found in the current directory'
-            log.error(msg.format(DEFAULT_REQUIREMENTS_FILE))
+            logger.error(
+                'No requirement files given and no %s found in the current directory',
+                DEFAULT_REQUIREMENTS_FILE)
             sys.exit(2)
 
     if any(src_file.endswith('.in') for src_file in src_files):
         msg = ('Some input files have the .in extension, which is most likely an error and can '
                'cause weird behaviour.  You probably meant to use the corresponding *.txt file?')
         if force:
-            log.warning('WARNING: ' + msg)
+            logger.warning(msg)
         else:
-            log.error('ERROR: ' + msg)
+            logger.error(msg)
             sys.exit(2)
 
     requirements = flat_map(lambda src: pip.req.parse_requirements(src, session=True),
@@ -52,7 +56,7 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_fi
     try:
         requirements = sync.merge(requirements, ignore_conflicts=force)
     except PipToolsError as e:
-        log.error(str(e))
+        logger.exception(str(e))
         sys.exit(2)
 
     installed_dists = pip.get_installed_distributions(skip=[])

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -1,10 +1,10 @@
+import click
 import os
 from itertools import chain
 
 from ._compat import ExitStack
 from .click import unstyle
 from .io import AtomicSaver
-from .logging import log
 from .utils import comment, format_requirement, dedup, UNSAFE_PACKAGES
 
 
@@ -119,7 +119,7 @@ class OutputWriter(object):
 
             for line in self._iter_lines(results, reverse_dependencies,
                                          primary_packages, markers, hashes):
-                log.info(line)
+                click.echo(line)
                 if f:
                     f.write(unstyle(line).encode('utf-8'))
                     f.write(os.linesep.encode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     setup_requires=['setuptools_scm'],
     install_requires=[
         'click>=6',
+        'coloredlogs',
         'first',
         'six',
         'setuptools'


### PR DESCRIPTION
Rather than write to stdout via click.echo, use Python's built-in logging
mechanism. This is a bit more conventional and could allow users to configure
logs more thoroughly. It should also resolve #362.

To match the ANSI colors, this now imports the coloredlogs module.

##### Contributor checklist

- [ ] ~Provided the tests for the changes~ (N/A, refactor)
- [x] Added the changes to CHANGELOG.md
- [ ] Requested (or received) a review from another contributor
