### PR TITLE
Use utils.UNSAFE_PACKAGES as source of truth

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -58,7 +58,7 @@ class PipCommand(pip.basecommand.Command):
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
 @click.option('--allow-unsafe', is_flag=True, default=False,
-              help="Pin packages considered unsafe: {}".format(list(UNSAFE_PACKAGES)))
+              help="Pin packages considered unsafe: {}".format(', '.join(sorted(UNSAFE_PACKAGES))))
 @click.option('--generate-hashes', is_flag=True, default=False,
               help="Generate pip 8 style hashes in the resulting requirements file.")
 @click.option('--max-rounds', default=10,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -15,8 +15,8 @@ from ..exceptions import PipToolsError
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..resolver import Resolver
-from ..utils import (assert_compatible_pip_version, is_pinned_requirement,
-                     key_from_req, dedup)
+from ..utils import (assert_compatible_pip_version, dedup, is_pinned_requirement,
+                     key_from_req, UNSAFE_PACKAGES)
 from ..writer import OutputWriter
 
 # Make sure we're using a compatible version of pip
@@ -58,7 +58,7 @@ class PipCommand(pip.basecommand.Command):
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
 @click.option('--allow-unsafe', is_flag=True, default=False,
-              help="Pin packages considered unsafe: pip, setuptools & distribute")
+              help="Pin packages considered unsafe: {}".format(list(UNSAFE_PACKAGES)))
 @click.option('--generate-hashes', is_flag=True, default=False,
               help="Generate pip 8 style hashes in the resulting requirements file.")
 @click.option('--max-rounds', default=10,


### PR DESCRIPTION
Update cli help for --allow-unsafe to use utils.UNSAFE_PACKAGES so this is only defined in one place.

```bash
  --allow-unsafe                  Pin packages considered unsafe: distribute,
                                  pip, setuptools
```
##### Contributor checklist

- [ ] Provided the tests for the changes
- [ ] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
