### PR TITLE
Fix allow unsafe false pinning bug v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.9.1
+
+Bug Fixes:
+- Fixed bug where unsafe packages would get pinned in generated requirements files
+when `--allow-unsafe` was not set. ([#517](https://github.com/jazzband/pip-tools/pull/517)).
+
 # 1.9.0
 
 Features:
@@ -25,7 +31,7 @@ Bug Fixes:
 # 1.8.1
 
 - Recalculate secondary dependencies between rounds (#378)
-- Calculated dependencies could be left with wrong candidates when 
+- Calculated dependencies could be left with wrong candidates when
   toplevel requirements happen to be also pinned in sub-dependencies (#450)
 - Fix duplicate entries that could happen in generated requirements.txt (#427)
 - Gracefully report invalid pip version (#457)

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -231,6 +231,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           trusted_hosts=pip_options.trusted_hosts,
                           format_control=repository.finder.format_control)
     writer.write(results=results,
+                 unsafe_requirements=resolver.unsafe_constraints,
                  reverse_dependencies=reverse_dependencies,
                  primary_packages={key_from_req(ireq.req) for ireq in constraints if not ireq.constraint},
                  markers={key_from_req(ireq.req): ireq.markers

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -236,7 +236,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                  primary_packages={key_from_req(ireq.req) for ireq in constraints if not ireq.constraint},
                  markers={key_from_req(ireq.req): ireq.markers
                           for ireq in constraints if ireq.markers},
-                 hashes=hashes)
+                 hashes=hashes,
+                 allow_unsafe=allow_unsafe)
 
     if dry_run:
         log.warning('Dry-run, so nothing updated.')

--- a/tests/fixtures/fake-index.json
+++ b/tests/fixtures/fake-index.json
@@ -7,6 +7,9 @@
     "2.0.2": {"": ["vine>=1.1.1"]},
     "2.1.4": {"": ["vine>=1.1.3"]}
   },
+  "appdirs": {
+    "1.4.9": {"": []}
+  },
   "arrow": {
     "0.5.0": {"": ["python-dateutil"]},
     "0.5.4": {"": ["python-dateutil"]}
@@ -44,6 +47,11 @@
   "fake-piptools-test-with-pinned-deps": {
     "0.1": {"": [
         "celery==3.1.18"
+    ]}
+  },
+  "fake-piptools-test-with-unsafe-deps": {
+    "0.1": {"": [
+        "setuptools==34.0.0"
     ]}
   },
   "flask": {
@@ -108,6 +116,9 @@
   },
   "markupsafe": {
     "0.23": {"": []}
+  },
+  "packaging": {
+    "16.8": {"": []}
   },
   "psycopg2": {
     "2.5.4": {"": []},

--- a/tests/fixtures/small_fake_package/setup.py
+++ b/tests/fixtures/small_fake_package/setup.py
@@ -5,5 +5,5 @@ setup(
     version=0.1,
     install_requires=[
         "six==1.10.0",
-        ],
+    ],
 )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -69,3 +69,22 @@ def test_format_requirement_environment_marker(from_line, writer):
         marker=ireq.markers)
     assert (result ==
             'test ; python_version == "2.7" and platform_python_implementation == "CPython"')
+
+
+def test_iter_lines__unsafe_dependencies(from_line, writer):
+    ireq = [from_line('test==1.2')]
+    unsafe_req = [from_line('setuptools')]
+    reverse_dependencies = {'test': ['xyz']}
+
+    lines = writer._iter_lines(ireq,
+                               unsafe_req,
+                               reverse_dependencies,
+                               ['test'],
+                               {},
+                               None)
+    str_lines = []
+    for line in lines:
+        str_lines.append(line)
+    assert comment('# The following packages are considered to be unsafe in a requirements file:') in str_lines
+    assert comment('# setuptools') in str_lines
+    assert 'test==1.2' in str_lines


### PR DESCRIPTION
Fix a bug introduced in #441 that pinned unsafe dependencies in generated requirements files when --allow-unsafe was False.

I will add the changes to the CHANGELOG if we agree this is the correct approach.

##### Contributor checklist

- [x] Provided the tests for the changes
- [ ] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
