### PR TITLE
Remove redundant check for editable

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -170,7 +170,7 @@ class PyPIRepository(BaseRepository):
         all of the files for a given requirement. It is not acceptable for an
         editable or unpinned requirement to be passed to this function.
         """
-        if ireq.editable or not is_pinned_requirement(ireq):
+        if not is_pinned_requirement(ireq):
             raise TypeError(
                 "Expected pinned requirement, not unpinned or editable, got {}".format(ireq))
 


### PR DESCRIPTION
The first line of is_pinned_requirement() checks the value of editable, don't need to do so on the same line as the call.