### PR TITLE
Remove unnecessary shadowing of click package

### DIFF
--- a/piptools/click.py
+++ b/piptools/click.py
@@ -1,6 +1,0 @@
-from __future__ import absolute_import
-
-import click
-click.disable_unicode_literals_warning = True
-
-from click import *  # noqa

--- a/piptools/locations.py
+++ b/piptools/locations.py
@@ -1,7 +1,7 @@
 import os
 from shutil import rmtree
 
-from .click import secho
+from click import secho
 from pip.utils.appdirs import user_cache_dir
 
 # The user_cache_dir helper comes straight from pip itself

--- a/piptools/logging.py
+++ b/piptools/logging.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import sys
 
-from . import click
+import click
 
 
 class LogContext(object):

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -7,10 +7,10 @@ from functools import partial
 from itertools import chain, count
 import os
 
+import click
 from first import first
 from pip.req import InstallRequirement
 
-from . import click
 from .cache import DependencyCache
 from .exceptions import UnsupportedConstraint
 from .logging import log

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -7,10 +7,10 @@ import os
 import sys
 import tempfile
 
+import click
 import pip
 from pip.req import InstallRequirement, parse_requirements
 
-from .. import click
 from ..exceptions import PipToolsError
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -5,9 +5,10 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import sys
 
+import click
 import pip
 
-from .. import click, sync
+from .. import sync
 from ..exceptions import PipToolsError
 from ..logging import log
 from ..utils import assert_compatible_pip_version, flat_map

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -3,7 +3,8 @@ import os
 import sys
 from subprocess import check_call
 
-from . import click
+import click
+
 from .exceptions import IncompatibleRequirements, UnsupportedConstraint
 from .utils import flat_map, format_requirement, key_from_req
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -9,9 +9,8 @@ from collections import OrderedDict
 import pip
 from pip.req import InstallRequirement
 
+from click import style
 from first import first
-
-from .click import style
 
 
 def safeint(s):

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -1,8 +1,9 @@
 import os
 from itertools import chain
 
+from click import unstyle
+
 from ._compat import ExitStack
-from .click import unstyle
 from .io import AtomicSaver
 from .logging import log
 from .utils import comment, format_requirement, dedup, UNSAFE_PACKAGES


### PR DESCRIPTION
Small cleanup. Just import click package directly in files that require
it.

As a result, removes override:

```python
click.disable_unicode_literals_warning = True
```