### PR TITLE
Remove unwanted annotations from primary packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug Fixes:
 when `--allow-unsafe` was not set. ([#517](https://github.com/jazzband/pip-tools/pull/517)). Thanks @dschaller
 - Fixed bug where editable PyPI dependencies would have a `download_dir` and be exposed to `git-checkout-index`,
 (thus losing their VCS directory) and `python setup.py egg_info` fails. ([#385](https://github.com/jazzband/pip-tools/pull/385#) and [#538](https://github.com/jazzband/pip-tools/pull/538)). Thanks @blueyed and @dfee
+- Fixed bug where some primary dependencies were annotated with "via" info comments. ([#542](https://github.com/jazzband/pip-tools/pull/542)). Thanks @quantus
 
 # 1.9.0 (2017-04-12)
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -137,7 +137,7 @@ class OutputWriter(object):
             for hash_ in sorted(ireq_hashes):
                 line += " \\\n    --hash={}".format(hash_)
 
-        if not self.annotate or ireq.name in primary_packages:
+        if not self.annotate or key_from_req(ireq.req) in primary_packages:
             return line
 
         # Annotate what packages this package is required by

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -59,6 +59,17 @@ def test_format_requirement_not_for_primary(from_line, writer):
             'test==1.2')
 
 
+def test_format_requirement_not_for_primary_lower_case(from_line, writer):
+    "Primary packages should not get annotated."
+    ireq = from_line('Test==1.2')
+    reverse_dependencies = {'test': ['xyz']}
+
+    assert (writer._format_requirement(ireq,
+                                       reverse_dependencies,
+                                       primary_packages=['test']) ==
+            'test==1.2')
+
+
 def test_format_requirement_environment_marker(from_line, writer):
     "Environment markers should get passed through to output."
     ireq = from_line('test ; python_version == "2.7" and platform_python_implementation == "CPython"')


### PR DESCRIPTION
`primary_packages` contains lower case package names where as `ireq.name` may contain upper case letters. This causes the primary packages to have the unwanted `# via XXX` annotations. In my case this issue was seen with packages `SQLAlchemy` and `Flask`.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
