### PR TITLE
Fix #512 - Isolate directories for generating hashes

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -195,8 +195,18 @@ class PyPIRepository(BaseRepository):
 
     def _get_file_hash(self, location):
         with TemporaryDirectory() as tmpdir:
+            # Some distributions have incompatible type of files with same name
+            # on the root directory. For example, matplotlib-2.0.2.tar.gz has a
+            # directory named "LICENSE" on the root, which may conflict many
+            # other distributions, causing errors like:
+            #
+            #   IOError: [Errno 20] Not a directory: u'/tmp/tmpz/LICENSE/LICENSE_STIX'
+            #
+            # So we need to isolate unpacking directory of each distributions.
+            isolated_build_dir = os.path.join(
+                self.build_dir, location.filename)
             unpack_url(
-                location, self.build_dir,
+                location, isolated_build_dir,
                 download_dir=tmpdir, only_download=True, session=self.session
             )
             files = os.listdir(tmpdir)

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -197,14 +197,19 @@ class PyPIRepository(BaseRepository):
         with TemporaryDirectory() as tmpdir:
             # Some distributions have incompatible type of files with same name
             # on the root directory. For example, matplotlib-2.0.2.tar.gz has a
-            # directory named "LICENSE" on the root, which may conflict many
+            # directory named "LICENSE" on the root, which may conflict with many
             # other distributions, causing errors like:
             #
             #   IOError: [Errno 20] Not a directory: u'/tmp/tmpz/LICENSE/LICENSE_STIX'
             #
-            # So we need to isolate unpacking directory of each distributions.
+            # So we need to isolate unpacking directory of each distributions,
+            # with fixed-length names (SHA-1).
+            h = hashlib.sha1()
+            h.update(location.filename.encode('utf-8'))
+            hashed_filename = h.hexdigest()
+
             isolated_build_dir = os.path.join(
-                self.build_dir, location.filename)
+                self.build_dir, hashed_filename)
             unpack_url(
                 location, isolated_build_dir,
                 download_dir=tmpdir, only_download=True, session=self.session

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -53,3 +53,12 @@ def test_generate_hashes_all_platforms(from_line):
     repository = PyPIRepository(pip_options, session)
     ireq = from_line('cffi==1.9.1')
     assert repository.get_hashes(ireq) == expected
+
+
+def test_generate_hashes_without_interfering_with_each_other(from_line):
+    pip_command = get_pip_command()
+    pip_options, _ = pip_command.parse_args([])
+    session = pip_command._build_session(pip_options)
+    repository = PyPIRepository(pip_options, session)
+    repository.get_hashes(from_line('cffi==1.9.1'))
+    repository.get_hashes(from_line('matplotlib==2.0.2'))


### PR DESCRIPTION
Some distributions have incompatible type of files with same name on the root directory. For example, `matplotlib-2.0.2.tar.gz` has a directory named "LICENSE" on the root, which may conflict with many other distributions, causing errors like:

`IOError: [Errno 20] Not a directory: u'/tmp/tmpz/LICENSE/LICENSE_STIX'
`

So we need to isolate unpacking directory of each distributions.

##### Contributor checklist

- [x] Provided the tests for the changes
- [ ] Added the changes to CHANGELOG.md
- [ ] Requested (or received) a review from another contributor
