### PR TITLE
Hash packages without unpacking (Fixes #512 and #544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ when `--allow-unsafe` was not set. ([#517](https://github.com/jazzband/pip-tools
 (thus losing their VCS directory) and `python setup.py egg_info` fails. ([#385](https://github.com/jazzband/pip-tools/pull/385#) and [#538](https://github.com/jazzband/pip-tools/pull/538)). Thanks @blueyed and @dfee
 - Fixed bug where some primary dependencies were annotated with "via" info comments. ([#542](https://github.com/jazzband/pip-tools/pull/542)). Thanks @quantus
 - Fixed bug where pkg-resources would be removed by pip-sync in Ubuntu. ([#555](https://github.com/jazzband/pip-tools/pull/555)). Thanks @cemsbr
+- Fixed package hashing doing unnecessary unpacking
 
 # 1.9.0 (2017-04-12)
 

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -53,3 +53,12 @@ def test_generate_hashes_all_platforms(from_line):
     repository = PyPIRepository(pip_options, session)
     ireq = from_line('cffi==1.9.1')
     assert repository.get_hashes(ireq) == expected
+
+
+def test_generate_hashes_without_interfering_with_each_other(from_line):
+    pip_command = get_pip_command()
+    pip_options, _ = pip_command.parse_args([])
+    session = pip_command._build_session(pip_options)
+    repository = PyPIRepository(pip_options, session)
+    repository.get_hashes(from_line('cffi==1.9.1'))
+    repository.get_hashes(from_line('matplotlib==2.0.2'))


### PR DESCRIPTION
The PyPIRepository._get_file_hash used to call unpack_url, when
generating the hash.  It only needed the side effect of the downloaded
package being left in the download directory and the unpacking part was
actually unnecessary.  Change it to just open the (local or remote)
package as a file object and hash the contents without unpacking.

This makes it faster and lighter, since unpacking consumes CPU cycles
and disk space, and more importantly, avoids problems which happen when
some distribution has a file with the same name as a directory in
another.  Unpacking both to packages to the same directory will then
fail.  E.g. matplotlib-2.0.2.tar.gz has a directory named LICENSE, but
many other packages have a file named LICENSE.

Fixes #512, #544

##### Contributor checklist

- [X] Provided the tests for the changes (Thanks @mete0r)
- [X] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
