### PR TITLE
Fixed bug breaking pip-sync on Python 3, raising TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.10.1 (UNRELEASED)
+
+Bug Fixes:
+- Fixed bug breaking `pip-sync` on Python 3, raising `TypeError: '<' not supported between instances of 'InstallRequirement' and 'InstallRequirement'` ([#570](https://github.com/jazzband/pip-tools/pull/570)).
+
 # 1.10.0 (2017-09-27)
 
 Features:
@@ -14,7 +19,7 @@ when `--allow-unsafe` was not set. ([#517](https://github.com/jazzband/pip-tools
 - Fixed bug where pkg-resources would be removed by pip-sync in Ubuntu. ([#555](https://github.com/jazzband/pip-tools/pull/555)). Thanks @cemsbr
 - Fixed bug where the resolver would sometime not stabilize on requirements specifying extras. ([#566](https://github.com/jazzband/pip-tools/pull/566)). Thanks @vphilippon
 - Fixed an unicode encoding error when distribution package contains non-ASCII file names ([#567](https://github.com/jazzband/pip-tools/pull/567)). Thanks @suutari
-- Fixed package hashing doing unnecessary unpacking
+- Fixed package hashing doing unnecessary unpacking ([#557](https://github.com/jazzband/pip-tools/pull/557)). Thanks @suutari-ai
 
 # 1.9.0 (2017-04-12)
 

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -15,17 +15,10 @@ from .cache import DependencyCache
 from .exceptions import UnsupportedConstraint
 from .logging import log
 from .utils import (format_requirement, format_specifier, full_groupby,
-                    is_pinned_requirement, key_from_req, UNSAFE_PACKAGES)
+                    is_pinned_requirement, key_from_ireq, key_from_req, UNSAFE_PACKAGES)
 
 green = partial(click.style, fg='green')
 magenta = partial(click.style, fg='magenta')
-
-
-def _dep_key(ireq):
-    if ireq.req is None and ireq.link is not None:
-        return str(ireq.link)
-    else:
-        return key_from_req(ireq.req)
 
 
 class RequirementSummary(object):
@@ -147,7 +140,7 @@ class Resolver(object):
             flask~=0.7
 
         """
-        for _, ireqs in full_groupby(constraints, key=_dep_key):
+        for _, ireqs in full_groupby(constraints, key=key_from_ireq):
             ireqs = list(ireqs)
             editable_ireq = first(ireqs, key=lambda ireq: ireq.editable)
             if editable_ireq:
@@ -178,7 +171,7 @@ class Resolver(object):
         configuration.
         """
         # Sort this list for readability of terminal output
-        constraints = sorted(self.constraints, key=_dep_key)
+        constraints = sorted(self.constraints, key=key_from_ireq)
         unsafe_constraints = []
         original_constraints = copy.copy(constraints)
         if not self.allow_unsafe:

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -5,7 +5,7 @@ from subprocess import check_call
 
 from . import click
 from .exceptions import IncompatibleRequirements, UnsupportedConstraint
-from .utils import flat_map, format_requirement, key_from_req
+from .utils import flat_map, format_requirement, key_from_ireq, key_from_req
 
 PACKAGES_TO_IGNORE = [
     'pip',
@@ -156,7 +156,7 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, pip_flags=None,
                 click.echo("  {}".format(format_requirement(ireq)))
         else:
             package_args = []
-            for ireq in sorted(to_install):
+            for ireq in sorted(to_install, key=key_from_ireq):
                 if ireq.editable:
                     package_args.extend(['-e', str(ireq.link or ireq.req)])
                 else:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -34,6 +34,14 @@ def assert_compatible_pip_version():
         sys.exit(4)
 
 
+def key_from_ireq(ireq):
+    """Get a standardized key for an InstallRequirement."""
+    if ireq.req is None and ireq.link is not None:
+        return str(ireq.link)
+    else:
+        return key_from_req(ireq.req)
+
+
 def key_from_req(req):
     """Get an all-lowercase version of the requirement's name."""
     if hasattr(req, 'key'):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -192,6 +192,21 @@ def test_diff_with_editable(fake_dist, from_editable):
     assert str(package.link) == _get_file_url(path_to_package)
 
 
+@pytest.mark.parametrize(
+    'lines',
+    [
+        ['django==1.8'],
+        ['django==1.8', 'click==4.0'],
+    ]
+)
+def test_sync_install(from_line, lines):
+    with mock.patch('piptools.sync.check_call') as check_call:
+        to_install = {from_line(line) for line in lines}
+
+        sync(to_install, set())
+        check_call.assert_called_once_with(['pip', 'install', '-q'] + sorted(lines))
+
+
 def test_sync_with_editable(from_editable):
     with mock.patch('piptools.sync.check_call') as check_call:
         path_to_package = os.path.join(os.path.dirname(__file__), 'fixtures', 'small_fake_package')


### PR DESCRIPTION
Fixes #569
Moved and renamed `resolver._dep_key` to `utils.key_from_ireq` and use it
for the `InstallRequirement`s sort in `sync.sync`.

In the future, we might want to change calls like
`key_from_req(ireq.req)` to `key_from_ireq(ireq)`, but I'll keep the
change to a minimum here for this bugfix before doing additional tests.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
