### PR TITLE
Respect platform's wheels for dependencies (Fixes #558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.10.2 (UNRELEASED)
+
+Bug Fixes:
+- Fixed bug causing dependencies from invalid wheels for the current platform to be included ([#571](https://github.com/jazzband/pip-tools/pull/571)).
+
 # 1.10.1 (2017-09-27)
 
 Bug Fixes:

--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager
 
 from six import add_metaclass
 
@@ -37,4 +38,11 @@ class BaseRepository(object):
         Given a pinned InstallRequire, returns a set of hashes that represent
         all of the files for a given requirement. It is not acceptable for an
         editable or unpinned requirement to be passed to this function.
+        """
+
+    @abstractmethod
+    @contextmanager
+    def allow_all_wheels(self):
+        """
+        Monkey patches pip.Wheel to allow wheels from all platforms and Python versions.
         """

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -2,6 +2,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from contextlib import contextmanager
+
 from piptools.utils import as_tuple, key_from_req, make_install_requirement
 from .base import BaseRepository
 
@@ -63,3 +65,8 @@ class LocalRequirementsRepository(BaseRepository):
 
     def get_hashes(self, ireq):
         return self.repository.get_hashes(ireq)
+
+    @contextmanager
+    def allow_all_wheels(self):
+        with self.repository.allow_all_wheels():
+            yield

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -28,24 +28,6 @@ except ImportError:
     from .._compat import TemporaryDirectory
 
 
-# Monkey patch pip's Wheel class to support all platform tags. This allows
-# pip-tools to generate hashes for all available distributions, not only the
-# one for the current platform.
-
-def _wheel_supported(self, tags=None):
-    # Ignore current platform. Support everything.
-    return True
-
-
-def _wheel_support_index_min(self, tags=None):
-    # All wheels are equal priority for sorting.
-    return 0
-
-
-Wheel.supported = _wheel_supported
-Wheel.support_index_min = _wheel_support_index_min
-
-
 class PyPIRepository(BaseRepository):
     DEFAULT_INDEX_URL = 'https://pypi.python.org/simple'
 
@@ -182,12 +164,13 @@ class PyPIRepository(BaseRepository):
 
         # We need to get all of the candidates that match our current version
         # pin, these will represent all of the files that could possibly
-        # satisify this constraint.
-        all_candidates = self.find_all_candidates(ireq.name)
-        candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version)
-        matching_versions = list(
-            ireq.specifier.filter((candidate.version for candidate in all_candidates)))
-        matching_candidates = candidates_by_version[matching_versions[0]]
+        # satisfy this constraint.
+        with self.allow_all_wheels():
+            all_candidates = self.find_all_candidates(ireq.name)
+            candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version)
+            matching_versions = list(
+                ireq.specifier.filter((candidate.version for candidate in all_candidates)))
+            matching_candidates = candidates_by_version[matching_versions[0]]
 
         return {
             self._get_file_hash(candidate.location)
@@ -200,6 +183,37 @@ class PyPIRepository(BaseRepository):
             for chunk in iter(lambda: fp.read(8096), b""):
                 h.update(chunk)
         return ":".join([FAVORITE_HASH, h.hexdigest()])
+
+    @contextmanager
+    def allow_all_wheels(self):
+        """
+        Monkey patches pip.Wheel to allow wheels from all platforms and Python versions.
+
+        This also saves the candidate cache and set a new one, or else the results from the
+        previous non-patched calls will interfere.
+        """
+        def _wheel_supported(self, tags=None):
+            # Ignore current platform. Support everything.
+            return True
+
+        def _wheel_support_index_min(self, tags=None):
+            # All wheels are equal priority for sorting.
+            return 0
+
+        original_wheel_supported = Wheel.supported
+        original_support_index_min = Wheel.support_index_min
+        original_cache = self._available_candidates_cache
+
+        Wheel.supported = _wheel_supported
+        Wheel.support_index_min = _wheel_support_index_min
+        self._available_candidates_cache = {}
+
+        try:
+            yield
+        finally:
+            Wheel.supported = original_wheel_supported
+            Wheel.support_index_min = original_support_index_min
+            self._available_candidates_cache = original_cache
 
 
 @contextmanager

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -165,12 +165,11 @@ class PyPIRepository(BaseRepository):
         # We need to get all of the candidates that match our current version
         # pin, these will represent all of the files that could possibly
         # satisfy this constraint.
-        with self.allow_all_wheels():
-            all_candidates = self.find_all_candidates(ireq.name)
-            candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version)
-            matching_versions = list(
-                ireq.specifier.filter((candidate.version for candidate in all_candidates)))
-            matching_candidates = candidates_by_version[matching_versions[0]]
+        all_candidates = self.find_all_candidates(ireq.name)
+        candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version)
+        matching_versions = list(
+            ireq.specifier.filter((candidate.version for candidate in all_candidates)))
+        matching_candidates = candidates_by_version[matching_versions[0]]
 
         return {
             self._get_file_hash(candidate.location)

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -68,7 +68,8 @@ class Resolver(object):
         """
         Finds acceptable hashes for all of the given InstallRequirements.
         """
-        return {ireq: self.repository.get_hashes(ireq) for ireq in ireqs}
+        with self.repository.allow_all_wheels():
+            return {ireq: self.repository.get_hashes(ireq) for ireq in ireqs}
 
     def resolve(self, max_rounds=10):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import contextmanager
 from functools import partial
 
 from pip._vendor.packaging.version import Version
@@ -48,6 +49,11 @@ class FakeRepository(BaseRepository):
         extras += ("",)
         dependencies = [dep for extra in extras for dep in self.index[name][version][extra]]
         return [InstallRequirement.from_line(dep, constraint=ireq.constraint) for dep in dependencies]
+
+    @contextmanager
+    def allow_all_wheels(self):
+        # No need to do an actual pip.Wheel mock here.
+        yield
 
 
 class FakeInstalledDistribution(object):

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -52,7 +52,8 @@ def test_generate_hashes_all_platforms(from_line):
     session = pip_command._build_session(pip_options)
     repository = PyPIRepository(pip_options, session)
     ireq = from_line('cffi==1.9.1')
-    assert repository.get_hashes(ireq) == expected
+    with repository.allow_all_wheels():
+        assert repository.get_hashes(ireq) == expected
 
 
 def test_generate_hashes_without_interfering_with_each_other(from_line):


### PR DESCRIPTION
Keep pip.Wheel monkey patch only in the get_hashes context.

Fixes #558 

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
