### PR TITLE
Support directories as input to pip-compile (fixes #207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 Bug Fixes:
 - Fixed bug causing dependencies from invalid wheels for the current platform to be included ([#571](https://github.com/jazzband/pip-tools/pull/571)).
 
+
 # 1.10.1 (2017-09-27)
 
 Bug Fixes:
 - Fixed bug breaking `pip-sync` on Python 3, raising `TypeError: '<' not supported between instances of 'InstallRequirement' and 'InstallRequirement'` ([#570](https://github.com/jazzband/pip-tools/pull/570)).
+
 
 # 1.10.0 (2017-09-27)
 
@@ -26,6 +28,7 @@ when `--allow-unsafe` was not set. ([#517](https://github.com/jazzband/pip-tools
 - Fixed an unicode encoding error when distribution package contains non-ASCII file names ([#567](https://github.com/jazzband/pip-tools/pull/567)). Thanks @suutari
 - Fixed package hashing doing unnecessary unpacking ([#557](https://github.com/jazzband/pip-tools/pull/557)). Thanks @suutari-ai
 
+
 # 1.9.0 (2017-04-12)
 
 Features:
@@ -43,12 +46,14 @@ Bug Fixes:
 - Fixed crash on editable requirements introduced in 1.8.2.
 - Fixed duplicated --trusted-host, --extra-index-url and --index-url in the generated requirements.
 
+
 # 1.8.2 (2017-03-28)
 
 - Regression fix: editable reqs were loosing their dependencies after first round ([#476](https://github.com/jazzband/pip-tools/pull/476))
   Thanks @mattlong
 - Remove duplicate index urls in generated requirements.txt ([#468](https://github.com/jazzband/pip-tools/pull/468))
   Thanks @majuscule
+
 
 # 1.8.1 (2017-03-22)
 
@@ -58,6 +63,7 @@ Bug Fixes:
 - Fix duplicate entries that could happen in generated requirements.txt (#427)
 - Gracefully report invalid pip version (#457)
 - Fix capitalization in the generated requirements.txt, packages will always be lowercased (#452)
+
 
 # 1.8.0 (2016-11-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.11.0 (UNRELEASED)
+
+Features:
+- `pip-compile` can now take directories of `*.in` files as input arguments ([#573](https://github.com/jazzband/pip-tools/pull/573)). Thanks @simlun
+
+
 # 1.10.2 (UNRELEASED)
 
 Bug Fixes:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -86,6 +86,9 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         if not output_file:
             raise click.BadParameter('--output-file is required if input is from stdin')
 
+    if any(map(os.path.isdir, src_files)) and not output_file:
+        raise click.BadParameter('--output-file is required if an input directory is given.')
+
     if len(src_files) > 1 and not output_file:
         raise click.BadParameter('--output-file is required if two or more input files are given.')
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -70,7 +70,11 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         client_cert, trusted_host, header, index, emit_trusted_host, annotate,
         upgrade, upgrade_packages, output_file, allow_unsafe, generate_hashes,
         src_files, max_rounds):
-    """Compiles requirements.txt from requirements.in specs."""
+    """
+    Compiles requirements.txt from requirements.in specs.
+
+    SRC_FILES may include directories of *.in files.
+    """
     log.verbose = verbose
 
     if len(src_files) == 0:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -3,6 +3,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import optparse
+from glob import glob
+
 import os
 import sys
 import tempfile
@@ -151,6 +153,17 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         log.debug('Configuration:')
         for find_link in repository.finder.find_links:
             log.debug('  -f {}'.format(find_link))
+
+    ###
+    # Find source files in input directories
+    ###
+
+    src_dirs = list(filter(os.path.isdir, src_files))
+    src_files = list(set(src_files) - set(src_dirs))
+
+    for d in src_dirs:
+        more_files = glob('{}/*.in'.format(d))
+        src_files += more_files
 
     ###
     # Parsing/collecting initial requirements

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,13 @@
-import os
-from textwrap import dedent
-from six.moves.urllib.request import pathname2url
 import subprocess
 import sys
+from textwrap import dedent
+
 import mock
-
-from click.testing import CliRunner
-
+import os
 import pytest
+from click.testing import CliRunner
+from six.moves.urllib.request import pathname2url
+
 from piptools.scripts.compile import cli
 from piptools.scripts.sync import cli as sync_cli
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,3 +292,37 @@ def test_upgrade_packages_option(tmpdir):
         assert out.exit_code == 0
         assert 'small-fake-a==0.1' in out.output
         assert 'small-fake-b==0.2' in out.output
+
+
+def test_directory_as_input_requires_setting_output_file(tmpdir):
+    """
+    piptools requires setting --output-file if directory is input.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.mkdir('requirements-dir')
+
+        out = runner.invoke(cli, ['requirements-dir'])
+
+        assert out.exit_code == 2
+        assert '--output-file is required if an input directory is given' in out.output
+
+
+def test_handle_directory_as_input(tmpdir):
+    """
+    piptools can take a directory as input, parsing all *.in files within it.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.mkdir('requirements-dir')
+        with open('requirements-dir/base.in', 'w') as req_in:
+            req_in.write('six==1.10.0')
+        with open('requirements-dir/test.in', 'w') as req_in:
+            req_in.write('pytest==3.2.3')
+
+        out = runner.invoke(cli, ['requirements-dir'])
+
+        assert out.exit_code == 0
+        assert '--output-file requirements.txt' in out.output
+        assert 'six==1.10.0' in out.output
+        assert 'pytest==3.2.3' in out.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -320,7 +320,7 @@ def test_handle_directory_as_input(tmpdir):
         with open('requirements-dir/test.in', 'w') as req_in:
             req_in.write('pytest==3.2.3')
 
-        out = runner.invoke(cli, ['requirements-dir'])
+        out = runner.invoke(cli, ['--output-file', 'requirements.txt', 'requirements-dir'])
 
         assert out.exit_code == 0
         assert '--output-file requirements.txt' in out.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,7 +305,7 @@ def test_directory_as_input_requires_setting_output_file(tmpdir):
         out = runner.invoke(cli, ['requirements-dir'])
 
         assert out.exit_code == 2
-        assert '--output-file is required if an input directory is given' in out.output
+        assert '--output-file is required if an input directory is given.' in out.output
 
 
 def test_handle_directory_as_input(tmpdir):


### PR DESCRIPTION
A first jab at implementing issue #207, passing a directory as input to pip-compile in addition to just files.

Any feedback is much appreciated :) Yay for [#hacktoberfest](https://hacktoberfest.digitalocean.com/)!

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
