### PR TITLE
support URLs as packages, fix #272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.12.0
+
+- Support URLs as packages ([#574](https://github.com/jazzband/pip-tools/pull/574)).
+
 # 1.11.0 (2017-11-30)
 
 Features:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from ..cache import CACHE_DIR
 from ..exceptions import NoCandidateFound
-from ..utils import (fs_str, is_pinned_requirement, lookup_table,
+from ..utils import (fs_str, is_pinned_requirement, is_url_requirement, lookup_table,
                      make_install_requirement, pip_version_info)
 from .base import BaseRepository
 
@@ -104,7 +104,7 @@ class PyPIRepository(BaseRepository):
         Returns a Version object that indicates the best match for the given
         InstallRequirement according to the external repository.
         """
-        if ireq.editable:
+        if ireq.editable or is_url_requirement(ireq, self):
             return ireq  # return itself as the best match
 
         all_candidates = self.find_all_candidates(ireq.name)
@@ -125,12 +125,12 @@ class PyPIRepository(BaseRepository):
 
     def get_dependencies(self, ireq):
         """
-        Given a pinned or an editable InstallRequirement, returns a set of
+        Given a pinned, an url, or an editable InstallRequirement, returns a set of
         dependencies (also InstallRequirements, but not necessarily pinned).
         They indicate the secondary dependencies for the given requirement.
         """
-        if not (ireq.editable or is_pinned_requirement(ireq)):
-            raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
+        if not (ireq.editable or is_url_requirement(ireq, self) or is_pinned_requirement(ireq)):
+            raise TypeError('Expected url, pinned or editable InstallRequirement, got {}'.format(ireq))
 
         if ireq not in self._dependencies_cache:
             if ireq.editable and (ireq.source_dir and os.path.exists(ireq.source_dir)):

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -15,7 +15,7 @@ from .cache import DependencyCache
 from .exceptions import UnsupportedConstraint
 from .logging import log
 from .utils import (format_requirement, format_specifier, full_groupby,
-                    is_pinned_requirement, key_from_ireq, key_from_req, UNSAFE_PACKAGES)
+                    is_pinned_requirement, is_url_requirement, key_from_ireq, key_from_req, UNSAFE_PACKAGES)
 
 green = partial(click.style, fg='green')
 magenta = partial(click.style, fg='magenta')
@@ -120,8 +120,8 @@ class Resolver(object):
     @staticmethod
     def check_constraints(constraints):
         for constraint in constraints:
-            if constraint.link is not None and not constraint.editable:
-                msg = ('pip-compile does not support URLs as packages, unless they are editable. '
+            if constraint.link is not None and constraint.link.url.startswith('file:') and not constraint.editable:
+                msg = ('pip-compile does not support file URLs as packages, unless they are editable. '
                        'Perhaps add -e option?')
                 raise UnsupportedConstraint(msg, constraint)
 
@@ -244,11 +244,7 @@ class Resolver(object):
             Flask==0.10.1 => Flask==0.10.1
 
         """
-        if ireq.editable:
-            # NOTE: it's much quicker to immediately return instead of
-            # hitting the index server
-            best_match = ireq
-        elif is_pinned_requirement(ireq):
+        if ireq.editable or is_url_requirement(ireq, self.repository) or is_pinned_requirement(ireq):
             # NOTE: it's much quicker to immediately return instead of
             # hitting the index server
             best_match = ireq
@@ -262,14 +258,14 @@ class Resolver(object):
 
     def _iter_dependencies(self, ireq):
         """
-        Given a pinned or editable InstallRequirement, collects all the
+        Given a pinned, an url, or editable InstallRequirement, collects all the
         secondary dependencies for them, either by looking them up in a local
         cache, or by reaching out to the repository.
 
         Editable requirements will never be looked up, as they may have
         changed at any time.
         """
-        if ireq.editable:
+        if ireq.editable or is_url_requirement(ireq, self.repository):
             for dependency in self.repository.get_dependencies(ireq):
                 yield dependency
             return
@@ -293,5 +289,5 @@ class Resolver(object):
             yield InstallRequirement.from_line(dependency_string, constraint=ireq.constraint)
 
     def reverse_dependencies(self, ireqs):
-        non_editable = [ireq for ireq in ireqs if not ireq.editable]
+        non_editable = [ireq for ireq in ireqs if not (ireq.editable or is_url_requirement(ireq, self.repository))]
         return self.dependency_cache.reverse_dependencies(non_editable)

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -70,8 +70,8 @@ def merge(requirements, ignore_conflicts):
     by_key = {}
 
     for ireq in requirements:
-        if ireq.link is not None and not ireq.editable:
-            msg = ('pip-compile does not support URLs as packages, unless they are editable. '
+        if ireq.link is not None and ireq.link.url.startswith('file:') and not ireq.editable:
+            msg = ('pip-compile does not support file URLs as packages, unless they are editable. '
                    'Perhaps add -e option?')
             raise UnsupportedConstraint(msg, ireq)
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -71,6 +71,18 @@ def make_install_requirement(name, version, extras, constraint=False):
         constraint=constraint)
 
 
+def is_url_requirement(ireq, repository=None):
+    """
+    Finds if a requirement is a URL
+    """
+    if not ireq.link or 'pypi.python.org' in ireq.link.url or ireq.link.url.startswith('file'):
+        return False
+    if repository is not None and hasattr(repository, 'finder'):
+        if any(index_url in ireq.link.url for index_url in repository.finder.index_urls):
+            return False
+    return True
+
+
 def format_requirement(ireq, marker=None):
     """
     Generic formatter for pretty printing InstallRequirements to the terminal
@@ -78,6 +90,8 @@ def format_requirement(ireq, marker=None):
     """
     if ireq.editable:
         line = '-e {}'.format(ireq.link)
+    elif is_url_requirement(ireq):
+        line = ireq.link.url
     else:
         line = str(ireq.req).lower()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,6 +278,18 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(tmpdir)
     assert not os.listdir(os.path.join(str(cache_dir), 'pkgs'))
 
 
+def test_url_package(tmpdir):
+    url_package = 'https://github.com/jazzband/pip-tools/archive/master.zip#egg=pip-tools'
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('requirements.in', 'w') as req_in:
+            req_in.write(url_package)
+        out = runner.invoke(cli, ['-n', '-r'])
+        assert out.exit_code == 0
+        assert url_package in out.output
+        assert 'click' in out.output  # dependency of pip-tools
+
+
 def test_input_file_without_extension(tmpdir):
     """
     piptools can compile a file without an extension,


### PR DESCRIPTION
Hi,

This PR adds a `is_url_requirement` util, which is used to let pip find the right dependencies for a package, as if the package was editable.