### PR TITLE
pip-compile must not archive the entire directory of a locally available editable requirement

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -133,7 +133,12 @@ class PyPIRepository(BaseRepository):
             raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
 
         if ireq not in self._dependencies_cache:
-            if ireq.link and not ireq.link.is_artifact:
+            if ireq.editable and (ireq.source_dir and os.path.exists(ireq.source_dir)):
+                # No download_dir for locally available editable requirements.
+                # If a download_dir is passed, pip will  unnecessarely
+                # archive the entire source directory
+                download_dir = None
+            elif ireq.link and not ireq.link.is_artifact:
                 # No download_dir for VCS sources.  This also works around pip
                 # using git-checkout-index, which gets rid of the .git dir.
                 download_dir = None


### PR DESCRIPTION
I'm using pip-compile for a project whose working dir is really large, and that project is passed as an editable requirement to pip-compile.
Unfortunately the code behind pip-compile which is imported from pip will make an archive of this entire large working dir even if this editable requirement is available locally.
The archive will be done in `%USERPROFILE%\AppData\Local\pip-tools\Cache\pkgs` or `~/.cache/pip-tools/Cache/pkgs`. I found out about this when this folder bloated to almost 10 gigs.
And another ugly side effect is that I'm experiencing really slow pip-compile times (that large project's dir contains many files, so it's about 5 minutes for me).

I've fixed this by copying some code from pip's `RequirementSet._prepare_file` inside `Resolver._iter_dependencies` to [avoid this call from pip](https://github.com/pypa/pip/blob/9.0.1/pip/req/req_set.py#L520) just for local editable reqs.

**I know this fix's approach is not that easily maintainable in the future**, and because of that I'm not expecting to have this merged in pip-tools, but I just wanted to share this PR anyway, just in case other people wish to use the fix just for them, like I do.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor

**CHANGELOG entry**:  `Fixed long compile durations with an locally available editable requirement`
