### PR TITLE
Fix environment marker support in pip-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Bug Fixes:
 - Fixed bug causing dependencies from invalid wheels for the current platform to be included ([#571](https://github.com/jazzband/pip-tools/pull/571)).
+- `pip-sync` will respect environment markers in the requirements.txt ([600](https://github.com/jazzband/pip-tools/pull/600)). Thanks @hazmat345
 
 # 1.10.1 (2017-09-27)
 

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -104,13 +104,13 @@ def diff(compiled_requirements, installed_dists):
     pkgs_to_ignore = get_dists_to_ignore(installed_dists)
     for dist in installed_dists:
         key = key_from_req(dist)
-        if key not in requirements_lut:
+        if key not in requirements_lut or not requirements_lut[key].match_markers():
             to_uninstall.add(key)
         elif requirements_lut[key].specifier.contains(dist.version):
             satisfied.add(key)
 
     for key, requirement in requirements_lut.items():
-        if key not in satisfied:
+        if key not in satisfied and requirement.match_markers():
             to_install.add(requirement)
 
     # Make sure to not uninstall any packages that should be ignored


### PR DESCRIPTION
This hopefully fixes the remaining part of #206 - adding support for environment markers in pip-sync.

##### Contributor checklist

- [x] Provided the tests for the changes
- [ ] Added the changes to CHANGELOG.md
- [x] Requested (or received) a review from another contributor
