### PR TITLE
Allow for CA bundles in CLI for pip-compile (rebased #365)

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -38,6 +38,7 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page", envvar='PIP_FIND_LINKS')  # noqa
 @click.option('-i', '--index-url', help="Change index URL (defaults to PyPI)", envvar='PIP_INDEX_URL')
 @click.option('--extra-index-url', multiple=True, help="Add additional index URL to search", envvar='PIP_EXTRA_INDEX_URL')  # noqa
+@click.option('--cert', help="Path to alternate CA bundle.")
 @click.option('--client-cert', help="Path to SSL client certificate, a single file containing the private key and the certificate in PEM format.")  # noqa
 @click.option('--trusted-host', multiple=True, envvar='PIP_TRUSTED_HOST',
               help="Mark this host as trusted, even though it does not have "
@@ -65,7 +66,7 @@ class PipCommand(pip.basecommand.Command):
               help="Maximum number of rounds before resolving the requirements aborts.")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
-        client_cert, trusted_host, header, index, emit_trusted_host, annotate,
+        cert, client_cert, trusted_host, header, index, emit_trusted_host, annotate,
         upgrade, upgrade_packages, output_file, allow_unsafe, generate_hashes,
         src_files, max_rounds):
     """Compiles requirements.txt from requirements.in specs."""
@@ -113,6 +114,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if extra_index_url:
         for extra_index in extra_index_url:
             pip_args.extend(['--extra-index-url', extra_index])
+    if cert:
+        pip_args.extend(['--cert', cert])
     if client_cert:
         pip_args.extend(['--client-cert', client_cert])
     if pre:


### PR DESCRIPTION
Rebased version of #365.
Thanks @khwilson for the original PR.

**Changelog-friendly one-liner**: Allow for CA bundles with ``pip-compile --cert``.
