### PR TITLE
Add '-markerlib' to the PACKAGES_TO_IGNORE

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -8,6 +8,7 @@ from .exceptions import IncompatibleRequirements, UnsupportedConstraint
 from .utils import flat_map, format_requirement, key_from_ireq, key_from_req
 
 PACKAGES_TO_IGNORE = [
+    '-markerlib',
     'pip',
     'pip-tools',
     'pip-review',


### PR DESCRIPTION
Completing what's in #368
Might help some debian users (finally).

**Changelog-friendly one-liner**: `pip-sync`: Add -markerlib to the list of PACKAGES_TO_IGNORE
