### PR TITLE
Slightly improved NoCandidateFound error message.

### DIFF
--- a/piptools/exceptions.py
+++ b/piptools/exceptions.py
@@ -3,9 +3,10 @@ class PipToolsError(Exception):
 
 
 class NoCandidateFound(PipToolsError):
-    def __init__(self, ireq, candidates_tried):
+    def __init__(self, ireq, candidates_tried, index_urls):
         self.ireq = ireq
         self.candidates_tried = candidates_tried
+        self.index_urls = index_urls
 
     def __str__(self):
         sorted_versions = sorted(c.version for c in self.candidates_tried)
@@ -13,6 +14,12 @@ class NoCandidateFound(PipToolsError):
             'Could not find a version that matches {}'.format(self.ireq),
             'Tried: {}'.format(', '.join(str(version) for version in sorted_versions) or '(no version found at all)')
         ]
+        if sorted_versions:
+            lines.append('There are incompatible versions in the resolved dependencies.')
+        else:
+            lines.append('{} {} reachable?'.format(
+                'Were' if len(self.index_urls) > 1 else 'Was', ' or '.join(self.index_urls))
+            )
         return '\n'.join(lines)
 
 

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -115,7 +115,7 @@ class PyPIRepository(BaseRepository):
         # Reuses pip's internal candidate sort key to sort
         matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
         if not matching_candidates:
-            raise NoCandidateFound(ireq, all_candidates)
+            raise NoCandidateFound(ireq, all_candidates, self.finder.index_urls)
         best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
 
         # Turn the candidate into a pinned InstallRequirement

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ class FakeRepository(BaseRepository):
         versions = list(ireq.specifier.filter(self.index[key_from_req(ireq.req)],
                                               prereleases=prereleases))
         if not versions:
-            raise NoCandidateFound(ireq, self.index[key_from_req(ireq.req)])
+            raise NoCandidateFound(ireq, self.index[key_from_req(ireq.req)], ['https://fake.url.foo'])
         best_version = max(versions, key=Version)
         return make_install_requirement(key_from_req(ireq.req), best_version, ireq.extras, constraint=ireq.constraint)
 


### PR DESCRIPTION
This should help a little, making the message less cryptic.
Still no "source of conflict" yet.
Fixes #352

**Changelog-friendly one-liner**: Slightly improved the NoCandidateFound error message.

##### Contributor checklist

- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
