### PR TITLE
tests: Do not download Django from Git

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,10 +324,13 @@ def test_upgrade_packages_option(tmpdir):
 
 
 def test_generate_hashes_with_editable():
+    small_fake_package_dir = os.path.join(
+        os.path.split(__file__)[0], 'fixtures', 'small_fake_package')
+    small_fake_package_url = 'file:' + pathname2url(small_fake_package_dir)
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open('requirements.in', 'w') as fp:
-            fp.write('-e git+https://github.com/django/django.git@1.11.1#egg=django\n')
+            fp.write('-e {}\n'.format(small_fake_package_url))
             fp.write('pytz==2017.2\n')
         out = runner.invoke(cli, ['--generate-hashes'])
     expected = (
@@ -337,10 +340,10 @@ def test_generate_hashes_with_editable():
         '#\n'
         '#    pip-compile --generate-hashes --output-file requirements.txt requirements.in\n'
         '#\n'
-        '-e git+https://github.com/django/django.git@1.11.1#egg=django\n'
+        '-e {}\n'
         'pytz==2017.2 \\\n'
         '    --hash=sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n'
         '    --hash=sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589\n'
-    )
+    ).format(small_fake_package_url)
     assert out.exit_code == 0
     assert expected in out.output


### PR DESCRIPTION
This test takes a very long time, because it downloads Django from
GitHub.  There should be no reason to do that, since we can use local
packages as well.

On my machine this change makes the total test time drop from 90s to 20s.
  