### PR TITLE
Pass python_requires argument to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     description=__doc__.strip(),
     long_description=read_file('README.rst'),
     packages=find_packages(exclude=['tests']),
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     setup_requires=['setuptools_scm'],
     install_requires=[
         'click>=6',


### PR DESCRIPTION
Helps pip decide what version of the library to install.

https://packaging.python.org/tutorials/distributing-packages/#python-requires

> If your project only runs on certain Python versions, setting the
> python_requires argument to the appropriate PEP 440 version specifier
> string will prevent pip from installing the project on other Python
> versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440)
> for the Python version, used to specify the Requires-Python defined in
> PEP 345.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!--- One-liner description here --->

##### Contributor checklist

- [ ] Provided the tests for the changes
- [ ] Requested (or received) a review from another contributor
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
