### PR TITLE
Add pip-sync option to restrict attention to user-local directory.

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -27,8 +27,9 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 @click.option('--extra-index-url', multiple=True, help="Add additional index URL to search", envvar='PIP_EXTRA_INDEX_URL')  # noqa
 @click.option('--no-index', is_flag=True, help="Ignore package index (only looking at --find-links URLs instead)")
 @click.option('-q', '--quiet', default=False, is_flag=True, help="Give less output")
+@click.option('--user-only', is_flag=True, help="Restrict attention to user directory")
 @click.argument('src_files', required=False, type=click.Path(exists=True), nargs=-1)
-def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, quiet, src_files):
+def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, quiet, user_only, src_files):
     """Synchronize virtual environment with requirements.txt."""
     if not src_files:
         if os.path.exists(DEFAULT_REQUIREMENTS_FILE):
@@ -56,7 +57,7 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, quiet,
         log.error(str(e))
         sys.exit(2)
 
-    installed_dists = pip.get_installed_distributions(skip=[])
+    installed_dists = pip.get_installed_distributions(skip=[], user_only=user_only)
     to_install, to_uninstall = sync.diff(requirements, installed_dists)
 
     install_flags = []

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -27,7 +27,7 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 @click.option('--extra-index-url', multiple=True, help="Add additional index URL to search", envvar='PIP_EXTRA_INDEX_URL')  # noqa
 @click.option('--no-index', is_flag=True, help="Ignore package index (only looking at --find-links URLs instead)")
 @click.option('-q', '--quiet', default=False, is_flag=True, help="Give less output")
-@click.option('--user-only', is_flag=True, help="Restrict attention to user directory")
+@click.option('--user', 'user_only', is_flag=True, help="Restrict attention to user directory")
 @click.argument('src_files', required=False, type=click.Path(exists=True), nargs=-1)
 def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, quiet, user_only, src_files):
     """Synchronize virtual environment with requirements.txt."""
@@ -70,6 +70,8 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, quiet,
     if extra_index_url:
         for extra_index in extra_index_url:
             install_flags.extend(['--extra-index-url', extra_index])
+    if user_only:
+        install_flags.append('--user')
 
     sys.exit(sync.sync(to_install, to_uninstall, verbose=(not quiet), dry_run=dry_run,
                        install_flags=install_flags))


### PR DESCRIPTION
I'm setting up Python code in Docker images, setting a project-local `PYTHONUSERBASE` environment variable and installing packages with `pip install --user ...`. This is instead of using a virtual environment, as described in [this article](http://blog.theodo.fr/2015/04/docker-and-virtualenv-a-clean-way-to-locally-install-python-dependencies-with-pip-in-docker/).

Currently pip-tools almost works with `--user`-installed packages: if `PYTHONUSERBASE` is set then pip-sync will run, but it will look at all packages. This PR is essentially a one-line change to add support for managing packages installed in a user-local directory.

I'd appreciate advice on adding a test. It doesn't look like there's currently much coverage for how the `pip-sync` CLI tool operates.

**Changelog-friendly one-liner**: Adds pip-sync option to restrict attention to user-local directory.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
