### PR TITLE
Remove setuptools dependency

### DIFF
--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -6,7 +6,7 @@ import json
 import os
 import sys
 
-from pkg_resources import Requirement
+from pip._vendor.packaging.requirements import Requirement
 
 from .exceptions import PipToolsError
 from .locations import CACHE_DIR
@@ -159,6 +159,6 @@ class DependencyCache(object):
         """
         # First, collect all the dependencies into a sequence of (parent, child) tuples, like [('flake8', 'pep8'),
         # ('flake8', 'mccabe'), ...]
-        return lookup_table((key_from_req(Requirement.parse(dep_name)), name)
+        return lookup_table((key_from_req(Requirement(dep_name)), name)
                             for name, version_and_extras in cache_keys
                             for dep_name in self.cache[name][version_and_extras])

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'click>=6',
         'first',
         'six',
-        'setuptools'
     ],
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
Setuptools is still required for pip-sync if pip needs it,
but pip-tools code itself doesn't require it anymore.
A pip-compile can be completed without setuptools.

**Changelog-friendly one-liner**: Removed the hard dependency on setuptools.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
