### PR TITLE
Filter pip environment markers

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -174,6 +174,10 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
             constraints.extend(parse_requirements(
                 src_file, finder=repository.finder, session=repository.session, options=pip_options))
 
+    # Filter out pip environment markers which do not match (PEP496)
+    constraints = [req for req in constraints
+                   if req.markers is None or req.markers.evaluate()]
+
     # Check the given base set of constraints first
     Resolver.check_constraints(constraints)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -347,3 +347,22 @@ def test_generate_hashes_with_editable():
     ).format(small_fake_package_url)
     assert out.exit_code == 0
     assert expected in out.output
+
+
+def test_filter_pip_markes():
+    """
+    Check that pip-compile works with pip environment markers (PEP496)
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('requirements', 'w') as req_in:
+            req_in.write(
+                "six==1.10.0\n"
+                "unknown_package==0.1; python_version == '1'")
+
+        out = runner.invoke(cli, ['-n', 'requirements'])
+
+        assert out.exit_code == 0
+        assert '--output-file requirements.txt' in out.output
+        assert 'six==1.10.0' in out.output
+        assert 'unknown_package' not in out.output


### PR DESCRIPTION
Add filter for pip environment markers

**Changelog-friendly one-liner**: Bugfix: Handling of pip environment markers

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
