### PR TITLE
Change a misleading example about version pinning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ To update a specific package to the latest or a specific version use the
 
     $ pip-compile --upgrade-package flask  # only update the flask package
     $ pip-compile --upgrade-package flask --upgrade-package requests  # update both the flask and requests packages
-    $ pip-compile -P flask -P requests==2.0.0  # update the flask package to the latest, and requests to v2.0.0
+    $ pip-compile -P flask -P requests  # same as above, but shorter
 
 If you use multiple Python versions, you can run ``pip-compile`` as
 ``py -X.Y -m piptools compile ...`` on Windows and


### PR DESCRIPTION
Specified version constraint during package upgrade with `-P` is ignored.
I've changed the README example to something more useful.

This PR is intended to resolve a confusion reported in #649

**Changelog-friendly one-liner**: Changed a misleading example about version pinning with `-P` flag

 ##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
