### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ even when you've pinned them.  `You do pin them, right?`_
    :target: https://jazzband.co/
 .. |pypi| image:: https://img.shields.io/pypi/v/pip-tools.svg
    :alt: PyPI
-   :target: https://pypi.python.org/pypi/pip-tools/
+   :target: https://pypi.org/project/pip-tools/
 .. _You do pin them, right?: http://nvie.com/posts/pin-your-packages/
 
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

<!--- Describe the changes here. --->

Update pypi.python.org URLs to pypi.org

##### Contributor checklist

- [ ] Provided the tests for the changes (N/A)
- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
