### PR TITLE
WIP: Can't uninstall editable packages with Python 2.7

### DIFF
--- a/tests/test_data/check_module_not_importable.py
+++ b/tests/test_data/check_module_not_importable.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import sys
+
+try:
+    module = __import__(sys.argv[1])
+except ImportError as err:
+    print("OK: {}".format(err))
+else:
+    raise SystemExit("FAIL: {}".format(module))

--- a/tests/test_data/small_fake_package/setup.py
+++ b/tests/test_data/small_fake_package/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='small_fake_with_deps',
@@ -6,4 +6,5 @@ setup(
     install_requires=[
         "six==1.10.0",
     ],
+    packages=find_packages(),
 )

--- a/tests/test_data/small_fake_package/small_fake_module/__init__.py
+++ b/tests/test_data/small_fake_package/small_fake_module/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal importable module."""

--- a/tests/test_data/writelines.py
+++ b/tests/test_data/writelines.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import os
+import sys
+
+DIR = os.path.dirname(sys.argv[1])
+if not os.path.exists(DIR):
+    os.makedirs(DIR)
+
+open(
+    sys.argv[1], 'wt',
+).write(
+    "\n".join(sys.argv[2:])
+)

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,15 @@ install_command= python -m pip install {opts} {packages}
 commands =
     pip --version
     coverage run -m pytest --strict --doctest-modules {posargs:tests/ piptools/}
+    {toxinidir}/tests/test_data/check_module_not_importable.py small_fake_module
+    {toxinidir}/tests/test_data/writelines.py "{envtmpdir}/requirements.in" {[testenv]deps} "-e tests/test_data/small_fake_package"
+    {envbindir}/pip-compile -o {envtmpdir}/requirements.txt {envtmpdir}/requirements.in
+    {envbindir}/pip-sync {envtmpdir}/requirements.txt
+    python -c 'import small_fake_module; print("OK: %s" % small_fake_module)'
+    {toxinidir}/tests/test_data/writelines.py "{envtmpdir}/requirements.in" {[testenv]deps}
+    {envbindir}/pip-compile -o {envtmpdir}/requirements.txt {envtmpdir}/requirements.in
+    {envbindir}/pip-sync {envtmpdir}/requirements.txt
+    {toxinidir}/tests/test_data/check_module_not_importable.py small_fake_module
     coverage report -m
     coverage html
 


### PR DESCRIPTION
With Python 2.7, the `pip-sync` command fails to uninstall editable packages.  I'm filing this bug here since `pip-sync` is the front-end tool I'm using, but this is likely due to [a bug with pip](https://github.com/pypa/pip/issues/5193).

I've added a test that shows the issue, I don't know where to start on a fix though.  Consider this PR as a starting point for developing a fix.

**Changelog-friendly one-liner**: Fix bug allowing uninstall of editable packages under Python 2.7

##### Contributor checklist

- [ ] Provided the tests for the changes
- [ ] Requested (or received) a review from another contributor
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
