### PR TITLE
Remove dependency first

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -7,7 +7,6 @@ from functools import partial
 from itertools import chain, count
 import os
 
-from first import first
 from ._compat import InstallRequirement
 
 from . import click
@@ -143,7 +142,7 @@ class Resolver(object):
         """
         for _, ireqs in full_groupby(constraints, key=key_from_ireq):
             ireqs = list(ireqs)
-            editable_ireq = first(ireqs, key=lambda ireq: ireq.editable)
+            editable_ireq = next((ireq for ireq in ireqs if ireq.editable), None)
             if editable_ireq:
                 yield editable_ireq  # ignore all the other specs: the editable one is the one that counts
                 continue

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -10,8 +10,6 @@ from contextlib import contextmanager
 
 from ._compat import InstallRequirement
 
-from first import first
-
 from .click import style
 
 
@@ -105,7 +103,7 @@ def is_pinned_requirement(ireq):
     if len(ireq.specifier._specs) != 1:
         return False
 
-    op, version = first(ireq.specifier._specs)._spec
+    op, version = next(iter(ireq.specifier._specs))._spec
     return (op == '==' or op == '===') and not version.endswith('.*')
 
 
@@ -117,7 +115,7 @@ def as_tuple(ireq):
         raise TypeError('Expected a pinned InstallRequirement, got {}'.format(ireq))
 
     name = key_from_req(ireq.req)
-    version = first(ireq.specifier._specs)._spec[1]
+    version = next(iter(ireq.specifier._specs))._spec[1]
     extras = tuple(sorted(ireq.extras))
     return name, version, extras
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     setup_requires=['setuptools_scm'],
     install_requires=[
         'click>=6',
-        'first',
         'six',
     ],
     zip_safe=False,


### PR DESCRIPTION
The `first()` function duplicates built-in Python behavior. Can simply use standard Python functions and avoid an unnecessary dependency.