### PR TITLE
Use \n instead of os.linesep in writer

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -127,7 +127,7 @@ class OutputWriter(object):
                 log.info(line)
                 if f:
                     f.write(unstyle(line).encode('utf-8'))
-                    f.write(os.linesep.encode('utf-8'))
+                    f.write('\n'.encode('utf-8'))
 
     def _format_requirement(self, ireq, reverse_dependencies, primary_packages, marker=None, hashes=None):
         line = format_requirement(ireq, marker=marker)


### PR DESCRIPTION
With this change, the generated requirements.txt uses \n line endings instead of \r\n on Windows.
I don't see any advantage to using the OS-specific line separator, and it is annoying when the requirements.txt is checked into git with \n line endings (you have to manually change the line endings back to \n).

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: When writing requirements.txt, `\n` line endings are now used everywhere instead of OS-specific line endings.

##### Contributor checklist

- [ ] Provided the tests for the changes
- [ ] Requested (or received) a review from another contributor
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
