### PR TITLE
Update Travis CI build matrix for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,6 @@ jobs:
         on:
           tags: true
           repo: jazzband/pip-tools
+
+  allow_failures:
+    - env: PIP=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,20 @@ script:
 
 jobs:
   include:
+    # Python 3.7 in Travis: https://github.com/travis-ci/travis-ci/issues/9815
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PIP=10.0.1
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PIP=latest
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PIP=master
+
     - stage: flake8
       python: 2.7
       env: TOXENV=flake8


### PR DESCRIPTION
- Include Python 3.7 as documented in [a Travis CI issue](https://github.com/travis-ci/travis-ci/issues/9815).
- Allow tests from pip master to fail without failing the status.

**Update Travis CI build matrix for Python 3.7**

##### Contributor checklist

- [x] Provided the tests for the changes
- [ ] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
