### PR TITLE
Support of pip 18.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,8 @@ environment:
           PIP: 9.0.3
         - TOXENV: py27-pip10.0.1
           PIP: 10.0.1
+        - TOXENV: py27-pip18.0
+          PIP: 18.0
         - TOXENV: py27-pipmaster
           PIP: master
         - TOXENV: py27-piplatest
@@ -21,6 +23,8 @@ environment:
           PIP: 9.0.3
         - TOXENV: py34-pip10.0.1
           PIP: 10.0.1
+        - TOXENV: py34-pip18.0
+          PIP: 18.0
         - TOXENV: py34-pipmaster
           PIP: master
         - TOXENV: py34-piplatest
@@ -33,6 +37,8 @@ environment:
           PIP: 9.0.3
         - TOXENV: py35-pip10.0.1
           PIP: 10.0.1
+        - TOXENV: py35-pip18.0
+          PIP: 18.0
         - TOXENV: py35-pipmaster
           PIP: master
         - TOXENV: py35-piplatest
@@ -45,6 +51,8 @@ environment:
           PIP: 9.0.3
         - TOXENV: py36-pip10.0.1
           PIP: 10.0.1
+        - TOXENV: py36-pip18.0
+          PIP: 18.0
         - TOXENV: py36-pipmaster
           PIP: master
         - TOXENV: py36-piplatest
@@ -57,6 +65,8 @@ environment:
           PIP: 9.0.3
         - TOXENV: py37-pip10.0.1
           PIP: 10.0.1
+        - TOXENV: py37-pip18.0
+          PIP: 18.0
         - TOXENV: py37-pipmaster
           PIP: master
         - TOXENV: py37-piplatest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - PIP=9.0.1
   - PIP=9.0.3
   - PIP=10.0.1
+  - PIP=18.0
   - PIP=master
   - PIP=latest
 
@@ -40,6 +41,10 @@ jobs:
       dist: xenial
       sudo: true
       env: PIP=10.0.1
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PIP=18.0
     - python: 3.7
       dist: xenial
       sudo: true

--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -27,4 +27,6 @@ from .pip_compat import (
     cmdoptions,
     get_installed_distributions,
     PyPI,
+    install_req_from_line,
+    install_req_from_editable,
 )

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -1,6 +1,9 @@
 # -*- coding=utf-8 -*-
 import importlib
 
+import pip
+import pkg_resources
+
 def do_import(module_path, subimport=None, old_path=None):
     old_path = old_path or module_path
     prefixes = ["pip._internal", "pip"]
@@ -32,3 +35,11 @@ Command = do_import('cli.base_command', 'Command', old_path='basecommand')
 cmdoptions = do_import('cli.cmdoptions', old_path='cmdoptions')
 get_installed_distributions = do_import('utils.misc', 'get_installed_distributions', old_path='utils')
 PyPI = do_import('models.index', 'PyPI')
+
+# pip 18.1 has refactored InstallRequirement constructors use by pip-tools.
+if pkg_resources.parse_version(pip.__version__) < pkg_resources.parse_version('18.1'):
+    install_req_from_line = InstallRequirement.from_line
+    install_req_from_editable = InstallRequirement.from_editable
+else:
+    install_req_from_line = do_import('req.constructors', 'install_req_from_line')
+    install_req_from_editable = do_import('req.constructors', 'install_req_from_editable')

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -7,7 +7,7 @@ from functools import partial
 from itertools import chain, count
 import os
 
-from ._compat import InstallRequirement
+from ._compat import install_req_from_line
 
 from . import click
 from .cache import DependencyCache
@@ -289,7 +289,7 @@ class Resolver(object):
         log.debug('  {:25} requires {}'.format(format_requirement(ireq),
                                                ', '.join(sorted(dependency_strings, key=lambda s: s.lower())) or '-'))
         for dependency_string in dependency_strings:
-            yield InstallRequirement.from_line(dependency_string, constraint=ireq.constraint)
+            yield install_req_from_line(dependency_string, constraint=ireq.constraint)
 
     def reverse_dependencies(self, ireqs):
         non_editable = [ireq for ireq in ireqs if not ireq.editable]

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 
 from .._compat import (
-    InstallRequirement,
+    install_req_from_line,
     parse_requirements,
     cmdoptions,
     Command,
@@ -134,7 +134,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if not upgrade and os.path.exists(dst_file):
         ireqs = parse_requirements(dst_file, finder=repository.finder, session=repository.session, options=pip_options)
         # Exclude packages from --upgrade-package/-P from the existing pins: We want to upgrade.
-        upgrade_pkgs_key = {key_from_req(InstallRequirement.from_line(pkg).req) for pkg in upgrade_packages}
+        upgrade_pkgs_key = {key_from_req(install_req_from_line(pkg).req) for pkg in upgrade_packages}
         existing_pins = {key_from_req(ireq.req): ireq
                          for ireq in ireqs
                          if is_pinned_requirement(ireq) and key_from_req(ireq.req) not in upgrade_pkgs_key}

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -8,7 +8,7 @@ from itertools import chain, groupby
 from collections import OrderedDict
 from contextlib import contextmanager
 
-from ._compat import InstallRequirement
+from ._compat import install_req_from_line
 
 from .click import style
 
@@ -48,7 +48,7 @@ def make_install_requirement(name, version, extras, constraint=False):
         # Sort extras for stability
         extras_string = "[{}]".format(",".join(sorted(extras)))
 
-    return InstallRequirement.from_line(
+    return install_req_from_line(
         str('{}{}=={}'.format(name, extras_string, version)),
         constraint=constraint)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from functools import partial
 
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
-from piptools._compat import InstallRequirement
+from piptools._compat import install_req_from_line, install_req_from_editable
 from pytest import fixture
 
 from piptools.cache import DependencyCache
@@ -48,7 +48,7 @@ class FakeRepository(BaseRepository):
         # Store non-extra dependencies under the empty string
         extras += ("",)
         dependencies = [dep for extra in extras for dep in self.index[name][version][extra]]
-        return [InstallRequirement.from_line(dep, constraint=ireq.constraint) for dep in dependencies]
+        return [install_req_from_line(dep, constraint=ireq.constraint) for dep in dependencies]
 
     @contextmanager
     def allow_all_wheels(self):
@@ -106,9 +106,9 @@ def base_resolver(depcache):
 
 @fixture
 def from_line():
-    return InstallRequirement.from_line
+    return install_req_from_line
 
 
 @fixture
 def from_editable():
-    return InstallRequirement.from_editable
+    return install_req_from_editable

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,7 +1,7 @@
 from mock import MagicMock, patch
 from pip._vendor.packaging.version import parse as parse_version
 from pip import __version__ as pip_version
-from piptools._compat import PackageFinder, InstallRequirement
+from piptools._compat import PackageFinder, install_req_from_line
 
 from piptools.repositories.pypi import PyPIRepository
 from piptools.scripts.compile import get_pip_command
@@ -30,7 +30,7 @@ def test_pypirepo_calls_reqset_with_str_paths():
     """
     with patch('piptools.repositories.pypi.RequirementSet') as mocked_init:
         repo = get_pypi_repository()
-        ireq = InstallRequirement.from_line('ansible==2.4.0.0')
+        ireq = install_req_from_line('ansible==2.4.0.0')
 
         # Setup a mock object to be returned from the RequirementSet call
         mocked_reqset = MagicMock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,py}-pip{8.1.1,9.0.1,9.0.3,10.0.1,latest,master}
+    py{27,34,35,36,37,py}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,latest,master}
     flake8
     readme
 skip_missing_interpreters = True
@@ -13,6 +13,7 @@ deps =
     pip9.0.1: pip==9.0.1
     pip9.0.3: pip==9.0.3
     pip10.0.1: pip==10.0.1
+    pip18.0: pip==18.0
     coverage
     mock
     pytest
@@ -23,6 +24,7 @@ setenv =
     pip9.0.1: PIP=9.0.1
     pip9.0.3: PIP=9.0.3
     pip10.0.1: PIP=10.0.1
+    pip18.0: PIP=18.0
 install_command= python -m pip install {opts} {packages}
 commands =
     pip --version
@@ -45,5 +47,6 @@ PIP =
     9.0.1: pip9.0.1
     9.0.3: pip9.0.3
     10.0.1: pip10.0.1
+    18.0: pip18.0
     latest: piplatest
     master: pipmaster


### PR DESCRIPTION
Added shims for the move of `InstallRequirement.from_line` and`InstallRequirement.from_editable` to
`constructors.install_req_from_line` and `constructors.install_req_from_editable`.

Fixes #688

**Changelog-friendly one-liner**: Added support of pip 18.1.

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
