### PR TITLE
Add CLI flag for rendering non-VCS files as relative paths.

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -64,11 +64,15 @@ class PipCommand(Command):
               help="Generate pip 8 style hashes in the resulting requirements file.")
 @click.option('--max-rounds', default=10,
               help="Maximum number of rounds before resolving the requirements aborts.")
+@click.option('--files-relative-to',
+              help="Render file:// requirements relative to this path. "
+              "By default, absolute paths are used.",
+              type=click.Path(resolve_path=True))
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         cert, client_cert, trusted_host, header, index, emit_trusted_host, annotate,
         upgrade, upgrade_packages, output_file, allow_unsafe, generate_hashes,
-        src_files, max_rounds):
+        src_files, max_rounds, files_relative_to):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -241,7 +245,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           default_index_url=repository.DEFAULT_INDEX_URL,
                           index_urls=repository.finder.index_urls,
                           trusted_hosts=pip_options.trusted_hosts,
-                          format_control=repository.finder.format_control)
+                          format_control=repository.finder.format_control,
+                          files_relative_to=files_relative_to)
     writer.write(results=results,
                  unsafe_requirements=resolver.unsafe_constraints,
                  reverse_dependencies=reverse_dependencies,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -11,7 +11,8 @@ from .utils import comment, dedup, format_requirement, key_from_req, UNSAFE_PACK
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
                  emit_trusted_host, annotate, generate_hashes,
-                 default_index_url, index_urls, trusted_hosts, format_control):
+                 default_index_url, index_urls, trusted_hosts, format_control,
+                 files_relative_to):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run
@@ -24,6 +25,7 @@ class OutputWriter(object):
         self.index_urls = index_urls
         self.trusted_hosts = trusted_hosts
         self.format_control = format_control
+        self.files_relative_to = files_relative_to
 
     def _sort_key(self, ireq):
         return (not ireq.editable, str(ireq.req).lower())
@@ -130,7 +132,7 @@ class OutputWriter(object):
                     f.write(os.linesep.encode('utf-8'))
 
     def _format_requirement(self, ireq, reverse_dependencies, primary_packages, marker=None, hashes=None):
-        line = format_requirement(ireq, marker=marker)
+        line = format_requirement(ireq, marker=marker, files_relative_to=self.files_relative_to)
 
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
         if ireq_hashes:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -14,7 +14,8 @@ def writer():
                         generate_hashes=False,
                         default_index_url=None, index_urls=[],
                         trusted_hosts=[],
-                        format_control=FormatControl(set(), set()))
+                        format_control=FormatControl(set(), set()),
+                        files_relative_to=None)
 
 
 def test_format_requirement_annotation_editable(from_editable, writer):


### PR DESCRIPTION
This is another stab at solving https://github.com/jazzband/pip-tools/issues/204.

Adds a new --files-relative-to flag that can be used to tell pip-compile to
render paths relative to the given directory. In the interest of backwards
compatibility, the current behavior (rendering absolute paths using `file:///`)
remains unchanged by default.

The main idea here is the same as @orf's changes in https://github.com/jazzband/pip-tools/pull/507. Given the current architecture of pip-tools' interactions with pip, it's difficult to maintain context of the original path that was provided in a `requirements.in`. What we **can** do relatively easily, however,
is change the logic for rendering `file://`-dependencies to write them relative to a given directory.

#### 
<details>
<summary>Current Behavior (Unchanged by Default)
</summary>

```
(pip-tools) [~/quantopian/pip-tools]@(relative-file-paths:014ef1825b)$ pip-compile dev-requirements.txt -o tmp.txt
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file tmp.txt dev-requirements.txt
#
-e file:///home/ssanderson/quantopian/pip-tools   # <--- This is the thing I'm trying to change.
atomicwrites==1.2.1       # via pytest
attrs==18.2.0             # via pytest
click==7.0
mock==2.0.0
more-itertools==4.3.0     # via pytest
pbr==5.1.1                # via mock
pluggy==0.8.0             # via pytest
py==1.7.0                 # via pytest
pytest==4.0.2
six==1.12.0               # via mock, more-itertools, pytest
wheel==0.32.3
```

</details>

<details>

<summary>Behavior with New Flag</summary>

```
(pip-tools) [~/quantopian/pip-tools]@(relative-file-paths:014ef1825b)$ pip-compile dev-requirements.txt -o tmp.txt --files-relative-to=.
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file tmp.txt dev-requirements.txt
#
-e .
atomicwrites==1.2.1       # via pytest
attrs==18.2.0             # via pytest
click==7.0
mock==2.0.0
more-itertools==4.3.0     # via pytest
pbr==5.1.1                # via mock
pluggy==0.8.0             # via pytest
py==1.7.0                 # via pytest
pytest==4.0.2
six==1.12.0               # via mock, more-itertools, pytest
wheel==0.32.3
```

</details>

#### Differences relative to https://github.com/jazzband/pip-tools/pull/507:

- https://github.com/jazzband/pip-tools/pull/507 assumes that all `file://` dependencies should be rendered relative to `os.cwd()`. In https://github.com/jazzband/pip-tools/pull/507#discussion_r116371073, @davidovich expressed some concern that that might not be correct in all cases. In the spirit of refusing the temptation to guess, this PR makes relative path rendering an explicit opt-in choice via a new `--files-relative-to` CLI flag (I'm not particularly attached to that name if others have ideas for it).
- https://github.com/jazzband/pip-tools/pull/507 wrote file relative urls using `file://` syntax. Most of the functions in urllib seem to really want to write absolute paths, so rather than implement my own url formatting, this currently just renders `-e <path>` without any url scheme. This seems to work for me locally but I'm not sure what the implications are for, e.g., windows.

**Changelog-friendly one-liner**: Added support for writing non-VCS directories using relative paths.

##### Contributor checklist

- [ ] Provided the tests for the changes. (I haven't done this yet. Happy to do so if there's interest in this feature.)
- [ ] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).

