### PR TITLE
Add support for --find-links in pip-compile input

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -143,18 +143,6 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                          if is_pinned_requirement(ireq) and key_from_req(ireq.req) not in upgrade_install_reqs}
         repository = LocalRequirementsRepository(existing_pins, repository)
 
-    log.debug('Using indexes:')
-    # remove duplicate index urls before processing
-    repository.finder.index_urls = list(dedup(repository.finder.index_urls))
-    for index_url in repository.finder.index_urls:
-        log.debug('  {}'.format(index_url))
-
-    if repository.finder.find_links:
-        log.debug('')
-        log.debug('Configuration:')
-        for find_link in repository.finder.find_links:
-            log.debug('  -f {}'.format(find_link))
-
     ###
     # Parsing/collecting initial requirements
     ###
@@ -186,6 +174,20 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     # Filter out pip environment markers which do not match (PEP496)
     constraints = [req for req in constraints
                    if req.markers is None or req.markers.evaluate()]
+
+    log.debug('Using indexes:')
+    # remove duplicate index urls before processing
+    repository.finder.index_urls = list(dedup(repository.finder.index_urls))
+    for index_url in repository.finder.index_urls:
+        log.debug('  {}'.format(index_url))
+
+    # remove duplicate find links before processing
+    repository.finder.find_links = list(dedup(repository.finder.find_links))
+    if repository.finder.find_links:
+        log.debug('')
+        log.debug('Configuration:')
+        for find_link in repository.finder.find_links:
+            log.debug('  -f {}'.format(find_link))
 
     # Check the given base set of constraints first
     Resolver.check_constraints(constraints)
@@ -240,6 +242,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           generate_hashes=generate_hashes,
                           default_index_url=repository.DEFAULT_INDEX_URL,
                           index_urls=repository.finder.index_urls,
+                          find_links=repository.finder.find_links,
                           trusted_hosts=pip_options.trusted_hosts,
                           format_control=repository.finder.format_control)
     writer.write(results=results,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -11,7 +11,8 @@ from .utils import comment, dedup, format_requirement, key_from_req, UNSAFE_PACK
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
                  emit_trusted_host, annotate, generate_hashes,
-                 default_index_url, index_urls, trusted_hosts, format_control):
+                 default_index_url, index_urls, find_links, trusted_hosts,
+                 format_control):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run
@@ -22,6 +23,7 @@ class OutputWriter(object):
         self.generate_hashes = generate_hashes
         self.default_index_url = default_index_url
         self.index_urls = index_urls
+        self.find_links = find_links
         self.trusted_hosts = trusted_hosts
         self.format_control = format_control
 
@@ -60,6 +62,10 @@ class OutputWriter(object):
                 flag = '--index-url' if index == 0 else '--extra-index-url'
                 yield '{} {}'.format(flag, index_url)
 
+    def write_find_links(self):
+        for find_link in self.find_links:
+            yield '--find-links {}'.format(find_link)
+
     def write_trusted_hosts(self):
         if self.emit_trusted_host:
             for trusted_host in dedup(self.trusted_hosts):
@@ -74,6 +80,7 @@ class OutputWriter(object):
     def write_flags(self):
         emitted = False
         for line in chain(self.write_index_options(),
+                          self.write_find_links(),
                           self.write_trusted_hosts(),
                           self.write_format_controls()):
             emitted = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,12 +103,12 @@ def test_find_links_option(pip_conf):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        with open('requirements.in', 'w'):
-            pass
+        with open('requirements.in', 'w') as in_req:
+            in_req.write('-f ./libs3')
         out = runner.invoke(cli, ['-v', '-f', './libs1', '-f', './libs2'])
 
         # Check that find-links has been passed to pip
-        assert 'Configuration:\n  -f ./libs1\n  -f ./libs2' in out.output
+        assert 'Configuration:\n  -f ./libs1\n  -f ./libs2\n  -f ./libs3' in out.output
 
 
 def test_extra_index_option(pip_conf):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -13,6 +13,7 @@ def writer():
                         annotate=True,
                         generate_hashes=False,
                         default_index_url=None, index_urls=[],
+                        find_links=[],
                         trusted_hosts=[],
                         format_control=FormatControl(set(), set()))
 


### PR DESCRIPTION
This adds support to pip-compile for the `-f, --find-links <url>` flag in the input `requirements.in`.

Let me know if there should be a corresponding `--emit-find-links / --no-emit-find-links` as I wasn't sure.

I also took the liberty of moving down the deduplication of `repository.finder.index_urls/find_links` so that it's after the last `parse_requirements` call, otherwise dupes creep in after the deduplication.

**Changelog-friendly one-liner**: Add support for --find-links in pip-compile input

@nvie @vphilippon @davidovich
