### PR TITLE
Fix pip-sync to check hashes

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -1,11 +1,12 @@
 import collections
 import os
 import sys
+import tempfile
 from subprocess import check_call
 
 from . import click
 from .exceptions import IncompatibleRequirements, UnsupportedConstraint
-from .utils import flat_map, format_requirement, key_from_ireq, key_from_req
+from .utils import flat_map, format_requirement, key_from_ireq, key_from_req, get_hashes_from_ireq
 
 PACKAGES_TO_IGNORE = [
     '-markerlib',
@@ -156,11 +157,16 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, pip_flags=None,
             for ireq in to_install:
                 click.echo("  {}".format(format_requirement(ireq)))
         else:
-            package_args = []
+            # prepare requirement lines
+            req_lines = []
             for ireq in sorted(to_install, key=key_from_ireq):
-                if ireq.editable:
-                    package_args.extend(['-e', str(ireq.link or ireq.req)])
-                else:
-                    package_args.append(str(ireq.req))
-            check_call([pip, 'install'] + pip_flags + install_flags + package_args)
+                ireq_hashes = get_hashes_from_ireq(ireq)
+                req_lines.append(format_requirement(ireq, hashes=ireq_hashes))
+
+            # save requirement lines to a temporary file
+            with tempfile.NamedTemporaryFile(mode='wt') as tmp_req_file:
+                tmp_req_file.write('\n'.join(req_lines))
+                tmp_req_file.flush()
+
+                check_call([pip, 'install', '-r', tmp_req_file.name] + pip_flags + install_flags)
     return 0

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -53,7 +53,7 @@ def make_install_requirement(name, version, extras, constraint=False):
         constraint=constraint)
 
 
-def format_requirement(ireq, marker=None):
+def format_requirement(ireq, marker=None, hashes=None):
     """
     Generic formatter for pretty printing InstallRequirements to the terminal
     in a less verbose way than using its `__str__` method.
@@ -62,6 +62,10 @@ def format_requirement(ireq, marker=None):
         line = '-e {}'.format(ireq.link)
     else:
         line = str(ireq.req).lower()
+
+    if hashes:
+        for hash_ in sorted(hashes):
+            line += " \\\n    --hash={}".format(hash_)
 
     if marker:
         line = '{} ; {}'.format(line, marker)
@@ -249,3 +253,16 @@ def temp_environ():
     finally:
         os.environ.clear()
         os.environ.update(environ)
+
+
+def get_hashes_from_ireq(ireq):
+    """
+    Given an InstallRequirement, return a list of string hashes in the format "{algorithm}:{hash}".
+    Return an empty list if there are no hashes in the requirement options.
+    """
+    result = []
+    ireq_hashes = ireq.options.get('hashes', {})
+    for algorithm, hexdigests in ireq_hashes.items():
+        for hash_ in hexdigests:
+            result.append("{}:{}".format(algorithm, hash_))
+    return result

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -130,12 +130,9 @@ class OutputWriter(object):
                     f.write(os.linesep.encode('utf-8'))
 
     def _format_requirement(self, ireq, reverse_dependencies, primary_packages, marker=None, hashes=None):
-        line = format_requirement(ireq, marker=marker)
-
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
-        if ireq_hashes:
-            for hash_ in sorted(ireq_hashes):
-                line += " \\\n    --hash={}".format(hash_)
+
+        line = format_requirement(ireq, marker=marker, hashes=ireq_hashes)
 
         if not self.annotate or key_from_req(ireq.req) in primary_packages:
             return line


### PR DESCRIPTION
Fix pip-sync to check hashes when installing packages.
Fixes #619.

**Changelog-friendly one-liner**: Fix pip-sync to check hashes

##### Contributor checklist

- [x] Provided the tests for the changes
- [x] Requested (or received) a review from another contributor
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
