### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 python:
@@ -5,7 +6,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+  - "3.7"
+  - "pypy2.7-6.0"
+  - "pypy3.5-6.0"
 
 env:
   - PIP=8.1.1
@@ -13,8 +16,8 @@ env:
   - PIP=9.0.3
   - PIP=10.0.1
   - PIP=18.0
-  - PIP=master
   - PIP=latest
+  - PIP=master
 
 cache: pip
 install:
@@ -23,37 +26,10 @@ script:
   - tox
 
 jobs:
-  include:
-    # Python 3.7 in Travis: https://github.com/travis-ci/travis-ci/issues/9815
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  exclude:
+    - python: "pypy3.5-6.0"
       env: PIP=8.1.1
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PIP=9.0.1
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PIP=9.0.3
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PIP=10.0.1
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PIP=18.0
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PIP=latest
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PIP=master
-
+  include:
     - stage: flake8
       python: 2.7
       env: TOXENV=flake8
@@ -75,6 +51,5 @@ jobs:
         on:
           tags: true
           repo: jazzband/pip-tools
-
   allow_failures:
     - env: PIP=master

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: System :: Systems Administration',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,py}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,latest,master}
+    py{27,34,35,36,37,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,latest,master}
     flake8
     readme
 skip_missing_interpreters = True


### PR DESCRIPTION
Allows using Python 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release

Include tests for PyPy3 as well and document all supported versions/environments as trove classifiers.