### PR TITLE
[#627] Add option --quiet to pip-compile

### DIFF
--- a/piptools/logging.py
+++ b/piptools/logging.py
@@ -8,18 +8,19 @@ from . import click
 
 
 class LogContext(object):
-    def __init__(self, verbose=False):
-        self.verbose = verbose
+    def __init__(self, verbosity=0):
+        self.verbosity = verbosity
 
     def log(self, *args, **kwargs):
         click.secho(*args, **kwargs)
 
     def debug(self, *args, **kwargs):
-        if self.verbose:
+        if self.verbosity >= 1:
             self.log(*args, **kwargs)
 
     def info(self, *args, **kwargs):
-        self.log(*args, **kwargs)
+        if self.verbosity >= 0:
+            self.log(*args, **kwargs)
 
     def warning(self, *args, **kwargs):
         kwargs.setdefault('fg', 'yellow')

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -31,7 +31,8 @@ class PipCommand(Command):
 
 @click.command()
 @click.version_option()
-@click.option('-v', '--verbose', is_flag=True, help="Show more output")
+@click.option('-v', '--verbose', count=True, help="Show more output")
+@click.option('-q', '--quiet', count=True, help="Give less output")
 @click.option('-n', '--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
 @click.option('-p', '--pre', is_flag=True, default=None, help="Allow resolving to prereleases (default is not)")
 @click.option('-r', '--rebuild', is_flag=True, help="Clear any caches upfront, rebuild from scratch")
@@ -65,12 +66,12 @@ class PipCommand(Command):
 @click.option('--max-rounds', default=10,
               help="Maximum number of rounds before resolving the requirements aborts.")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
-def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
+def cli(verbose, quiet, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         cert, client_cert, trusted_host, header, index, emit_trusted_host, annotate,
         upgrade, upgrade_packages, output_file, allow_unsafe, generate_hashes,
         src_files, max_rounds):
     """Compiles requirements.txt from requirements.in specs."""
-    log.verbose = verbose
+    log.verbosity = verbose - quiet
 
     if len(src_files) == 0:
         if os.path.exists(DEFAULT_REQUIREMENTS_FILE):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -357,6 +357,16 @@ def test_upgrade_packages_version_option(tmpdir):
         assert 'small-fake-b==0.2' in out.output
 
 
+def test_quiet_option(tmpdir):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('requirements', 'w'):
+            pass
+        out = runner.invoke(cli, ['--quiet', '-n', 'requirements'])
+        # Pinned requirements result has not been written to output
+        assert 'Dry-run, so nothing updated.' == out.output.strip()
+
+
 def test_generate_hashes_with_editable():
     small_fake_package_dir = os.path.join(
         os.path.split(__file__)[0], 'test_data', 'small_fake_package')


### PR DESCRIPTION
With `--quiet`, the output file is not logged.
Fixes #627.

**Changelog-friendly one-liner**: Add option --quiet to pip-compile

##### Contributor checklist

- [x] Provided the tests for the changes
- [X] Requested (or received) a review from another contributor
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).