### PR TITLE
Fix sync with a temp file on Windows

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -163,9 +163,13 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, pip_flags=None,
                 req_lines.append(format_requirement(ireq, hashes=ireq_hashes))
 
             # save requirement lines to a temporary file
-            with tempfile.NamedTemporaryFile(mode='wt') as tmp_req_file:
-                tmp_req_file.write('\n'.join(req_lines))
-                tmp_req_file.flush()
+            tmp_req_file = tempfile.NamedTemporaryFile(mode='wt', delete=False)
+            tmp_req_file.write('\n'.join(req_lines))
+            tmp_req_file.close()
 
+            try:
                 check_call([pip, 'install', '-r', tmp_req_file.name] + pip_flags + install_flags)
+            finally:
+                os.unlink(tmp_req_file.name)
+
     return 0


### PR DESCRIPTION
Fixes #722

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Fix sync with a temporary requirement file on Windows

##### Contributor checklist

- [X] Provided the tests for the changes
- [X] Requested (or received) a review from another contributor
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
