### PR TITLE
Added the release process to the Contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 ##### Contributor checklist
 
-- [ ] Provided the tests for the changes
-- [ ] Requested (or received) a review from another contributor
-- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).
+- [ ] Provided the tests for the changes.
+- [ ] Requested a review from another contributor.
+- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
+- [ ] Assign the PR to an existing or new milestone for the target version (respecting Semantic Versioning).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 - [ ] Provided the tests for the changes.
 - [ ] Requested a review from another contributor.
 - [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
-- [ ] Assign the PR to an existing or new milestone for the target version (respecting Semantic Versioning).
+- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To help keeping track of the releases and their changes, here's the current rele
   Check the previous release changelog format for an example. Don't forget the "Thanks @contributor" mentions.
 - Make sure that the tests/CI still pass.
 - Once ready, go to `Github pip-tools Homepage > releases tab > Draft a new release` and type in:
-  - *Tag version:* The exact version number. *Ex: 3.4.0*
+  - *Tag version:* The exact version number, following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/). *Ex: 3.4.0*
   - *Target:* master. As a general rule, the HEAD commit of the master branch should be the release target.
   - *Release title:* Same as the tag. *Ex: 3.4.0*
   - *Describe this release:* Copy of this release's changelog segment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,10 @@ To help keeping track of the releases and their changes, here's the current rele
   - *Release title:* Same as the tag. *Ex: 3.4.0*
   - *Describe this release:* Copy of this release's changelog segment.
 - Publish release. This will push a tag on the HEAD of master, trigger the CI pipeline and
-  deploy a pip-tools release in **Jazzband private package index** upon success.
+  deploy a pip-tools release in the **Jazzband private package index** upon success.
 - The pip-tools "lead" project members will receive an email notification to review the release and
-  deploy it to the public PyPi if all is correct.
-- Once the release to the public PyPi is confirmed, close the milestone.
+  deploy it to the public PyPI if all is correct.
+- Once the release to the public PyPI is confirmed, close the milestone.
 
 Please be mindful of other before and when performing a release, and use this access responsibly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,41 @@ This is a [Jazzband](https://jazzband.co/) project. By contributing you agree
 to abide by the [Contributor Code of Conduct](https://jazzband.co/about/conduct)
 and follow the [guidelines](https://jazzband.co/about/guidelines).
 
-Also, here are a few additional or emphasized guidelines to follow:
+## Project Contribution Guidelines
+
+Here are a few additional or emphasized guidelines to follow when contributing to pip-tools:
 - Always provide tests for your changes.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
+- Before merging, assign the PR to a milestone for a version to help with the release process.
 
 The only exception to those guidelines is for trivial changes, such as
 documentation corrections or contributions that do not change pip-tools itself.
 
 Contributions following these guidelines are always welcomed, encouraged and appreciated.
+
+## Project Release Process
+
+Jazzband aims to give full access to all members, including performing releases, as described in the
+[Jazzband Releases documentation](https://jazzband.co/about/releases).
+
+To help keeping track of the releases and their changes, here's the current release process:
+- Check to see if any recently merged PRs are missing from the milestone of the version about to be released.
+- Push an update to the [CHANGELOG](CHANGELOG.md) with the version, date and using the one-line descriptions
+  from the PRs included in the milestone of the version.
+  Check the previous release changelog format for an example. Don't forget the "Thanks @contributor" mentions.
+- Make sure that the tests/CI still pass.
+- Once ready, go to `Github pip-tools Homepage > releases tab > Draft a new release` and type in:
+  - *Tag version:* The exact version number. *Ex: 3.4.0*
+  - *Target:* master. As a general rule, the HEAD commit of the master branch should be the release target.
+  - *Release title:* Same as the tag. *Ex: 3.4.0*
+  - *Describe this release:* Copy of this release's changelog segment.
+- Publish release. This will push a tag on the HEAD of master, trigger the CI pipeline and
+  deploy a pip-tools release in **Jazzband private package index** upon success.
+- The pip-tools "lead" project members will receive an email notification to review the release and
+  deploy it to the public PyPi if all is correct.
+- Once the release to the public PyPi is confirmed, close the milestone.
+
+Please be mindful of other before and when performing a release, and use this access responsibly.
+
+Do not hesitate to ask questions if you have any before performing a release.


### PR DESCRIPTION
Added the release process I currently follow to the contributing guide to help other Jazzband members in making releases.

I also added a step to the PR contribution checklist to help in tracking changes (as I've done so far).

**Changelog-friendly one-liner**: N/A
##### Contributor checklist

- [x] ~Provided the tests for the changes~
- [x] Requested a review from another contributor
- [x] ~Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md afterwards).~
- [x] ~Assign the PR to an existing or new milestone for the target version (respecting Semantic Versioning).~