### PR TITLE
Add python3.8-dev to Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ jobs:
     - python: "pypy3.5-6.0"
       env: PIP=8.1.1
   include:
+    - python: 3.8-dev
+      env: PIP=latest
     - stage: flake8
       python: 2.7
       env: TOXENV=flake8
@@ -60,6 +62,7 @@ jobs:
           repo: jazzband/pip-tools
   allow_failures:
     - env: PIP=master
+    - python: 3.8-dev
 
 notifications:
   webhooks: https://coveralls.io/webhook

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,latest,master}
+    py{27,34,35,36,37,38,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,latest,master}
     flake8
     readme
 skip_missing_interpreters = True


### PR DESCRIPTION
- Add py38 to tox
- Add py38-dev job to Travis

FTR: Appveyor [doesn't support](https://www.appveyor.com/docs/windows-images-software/#python) python 3.8 yet. 

**Changelog-friendly one-liner**: Add python3.8-dev to Travis jobs

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
