### PR TITLE
Show default index url provided by pip

### DIFF
--- a/piptools/pip.py
+++ b/piptools/pip.py
@@ -1,0 +1,30 @@
+import optparse
+
+from ._compat import Command, cmdoptions
+
+
+class PipCommand(Command):
+    name = 'PipCommand'
+
+
+def get_pip_command():
+    # Use pip's parser for pip.conf management and defaults.
+    # General options (find_links, index_url, extra_index_url, trusted_host,
+    # and pre) are defered to pip.
+    pip_command = PipCommand()
+    pip_command.parser.add_option(cmdoptions.no_binary())
+    pip_command.parser.add_option(cmdoptions.only_binary())
+    index_opts = cmdoptions.make_option_group(
+        cmdoptions.index_group,
+        pip_command.parser,
+    )
+    pip_command.parser.insert_option_group(0, index_opts)
+    pip_command.parser.add_option(optparse.Option('--pre', action='store_true', default=False))
+
+    return pip_command
+
+
+pip_command = get_pip_command()
+
+# Get default values of the pip's options (including options from pip.conf).
+pip_defaults = pip_command.parser.get_default_values()

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -382,3 +382,19 @@ def test_no_candidates_pre():
 
         assert out.exit_code == 2
         assert 'Tried pre-versions:' in out.output
+
+
+@pytest.mark.usefixtures('pip_conf')
+def test_default_index_url():
+    status, output = invoke([sys.executable, '-m', 'piptools', 'compile', '--help'])
+    output = output.decode('utf-8')
+
+    # Click's subprocess output has \r\r\n line endings on win py27. Fix it.
+    output = output.replace('\r\r', '\r')
+
+    assert status == 0
+    expected = (
+        '  -i, --index-url TEXT            Change index URL (defaults to' + os.linesep +
+        '                                  http://example.com)' + os.linesep
+    )
+    assert expected in output

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -4,7 +4,7 @@ from pip import __version__ as pip_version
 from piptools._compat import PackageFinder, install_req_from_line
 
 from piptools.repositories.pypi import PyPIRepository
-from piptools.scripts.compile import get_pip_command
+from piptools.pip import get_pip_command
 import pytest
 
 

--- a/tests/test_repository_local.py
+++ b/tests/test_repository_local.py
@@ -1,7 +1,7 @@
-from piptools.scripts.compile import get_pip_command
 from piptools.repositories.local import LocalRequirementsRepository
 from piptools.repositories.pypi import PyPIRepository
 from piptools.utils import name_from_req
+from piptools.pip import get_pip_command
 
 EXPECTED = {
     'sha256:04b133ef629ae2bc05f83d0b079a964494a9cd17914943e690c57209b44aae20',

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -1,4 +1,4 @@
-from piptools.scripts.compile import get_pip_command
+from piptools.pip import get_pip_command
 from piptools.repositories.pypi import PyPIRepository
 
 

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 from piptools.repositories import PyPIRepository
-from piptools.scripts.compile import get_pip_command
+from piptools.pip import get_pip_command
 
 
 class MockedPyPIRepository(PyPIRepository):


### PR DESCRIPTION
Closes #705.

**Changelog-friendly one-liner**: Show default index url provided by pip

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
