### PR TITLE
Fix pip-sync to use pip script depending on a python version

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -133,20 +133,13 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, pip_flags=None,
     if not verbose:
         pip_flags += ['-q']
 
-    if os.environ.get('VIRTUAL_ENV'):
-        # find pip via PATH
-        pip = 'pip'
-    else:
-        # find pip in same directory as pip-sync entry-point script
-        pip = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), 'pip')
-
     if to_uninstall:
         if dry_run:
             click.echo("Would uninstall:")
             for pkg in to_uninstall:
                 click.echo("  {}".format(pkg))
         else:
-            check_call([pip, 'uninstall', '-y'] + pip_flags + sorted(to_uninstall))
+            check_call([sys.executable, '-m', 'pip', 'uninstall', '-y'] + pip_flags + sorted(to_uninstall))
 
     if to_install:
         if install_flags is None:
@@ -168,7 +161,9 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, pip_flags=None,
             tmp_req_file.close()
 
             try:
-                check_call([pip, 'install', '-r', tmp_req_file.name] + pip_flags + install_flags)
+                check_call(
+                    [sys.executable, '-m', 'pip', 'install', '-r', tmp_req_file.name] + pip_flags + install_flags
+                )
             finally:
                 os.unlink(tmp_req_file.name)
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -230,7 +230,9 @@ def test_sync_install_temporary_requirement_file(from_line, from_editable, mocke
     with mock.patch('piptools.sync.check_call') as check_call:
         to_install = {from_line('django==1.8')}
         sync(to_install, set())
-        check_call.assert_called_once_with(['pip', 'install', '-r', mocked_tmp_req_file.name, '-q'])
+        check_call.assert_called_once_with(
+            [sys.executable, '-m', 'pip', 'install', '-r', mocked_tmp_req_file.name, '-q']
+        )
 
 
 def test_temporary_requirement_file_deleted(from_line, from_editable, mocked_tmp_file):
@@ -304,3 +306,13 @@ def test_sync_requirement_file_with_hashes(from_line, from_editable, mocked_tmp_
             '    --hash=sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589'
         )
         mocked_tmp_req_file.write.assert_called_once_with(expected)
+
+
+@mock.patch('piptools.sync.check_call')
+def test_sync_uninstall_pip_command(check_call):
+    to_uninstall = ['six', 'django', 'pytz', 'click']
+
+    sync(set(), to_uninstall)
+    check_call.assert_called_once_with(
+        [sys.executable, '-m', 'pip', 'uninstall', '-y', '-q'] + sorted(to_uninstall)
+    )


### PR DESCRIPTION
Fixes #734.

**Changelog-friendly one-liner**: Fix pip-sync to use pip script depending on a python version

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
