### PR TITLE
Split test_cli.py

### DIFF
--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -1,0 +1,38 @@
+import sys
+
+import mock
+from click.testing import CliRunner
+
+from piptools.scripts.sync import cli
+from .utils import invoke
+
+
+def test_run_as_module_sync():
+    """piptools can be run as ``python -m piptools ...``."""
+
+    status, output = invoke([
+        sys.executable, '-m', 'piptools', 'sync', '--help',
+    ])
+
+    # Should have run pip-compile successfully.
+    output = output.decode('utf-8')
+    assert output.startswith('Usage:')
+    assert 'Synchronize virtual environment with' in output
+    assert status == 0
+
+
+def test_quiet_option(tmpdir):
+    """sync command can be run with `--quiet` or `-q` flag."""
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('requirements.txt', 'w') as req_in:
+            req_in.write('six==1.10.0')
+
+        with mock.patch('piptools.sync.check_call') as check_call:
+            out = runner.invoke(cli, ['-q'])
+            assert out.output == ''
+            assert out.exit_code == 0
+            # for every call to pip ensure the `-q` flag is set
+            for call in check_call.call_args_list:
+                assert '-q' in call[0][0]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,16 @@
+import subprocess
+
+
+def invoke(command):
+    """Invoke sub-process."""
+    try:
+        output = subprocess.check_output(
+            command,
+            stderr=subprocess.STDOUT,
+        )
+        status = 0
+    except subprocess.CalledProcessError as error:
+        output = error.output
+        status = error.returncode
+
+    return status, output


### PR DESCRIPTION
Splits test_cli.py into two files for compile and sync modules. I'm going to add more tests to test_cli_sync.py, let's split them at first.