### PR TITLE
Show progressbar on generation hashes in verbose mode

### DIFF
--- a/piptools/_compat/contextlib.py
+++ b/piptools/_compat/contextlib.py
@@ -1,0 +1,18 @@
+# Ported from python 3.7 contextlib.py
+class nullcontext(object):
+    """Context manager that does no additional processing.
+    Used as a stand-in for a normal context manager, when a particular
+    block of code is only sometimes used with a normal context manager:
+    cm = optional_cm if condition else nullcontext()
+    with cm:
+        # Perform operation, using optional_cm if condition is True
+    """
+
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *excinfo):
+        pass

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -43,6 +43,8 @@ get_installed_distributions = do_import(
 PyPI = do_import("models.index", "PyPI")
 stdlib_pkgs = do_import("utils.compat", "stdlib_pkgs", old_path="compat")
 DEV_PKGS = do_import("commands.freeze", "DEV_PKGS")
+Link = do_import("models.link", "Link", old_path="index")
+Session = do_import("_vendor.requests.sessions", "Session")
 
 # pip 18.1 has refactored InstallRequirement constructors use by pip-tools.
 if pkg_resources.parse_version(pip.__version__) < pkg_resources.parse_version("18.1"):

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -48,7 +48,7 @@ except ImportError:
     from pip.wheel import WheelCache
 
 FILE_CHUNK_SIZE = 4096
-FileStream = collections.namedtuple("File", "stream size")
+FileStream = collections.namedtuple("FileStream", "stream size")
 
 
 class PyPIRepository(BaseRepository):

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -352,7 +352,7 @@ def open_local_or_remote_file(link, session):
     :type link: pip.index.Link
     :type session: requests.Session
     :raises ValueError: If link points to a local directory.
-    :return: a context manager to the opened file-like object
+    :return: a context manager to a FileStream with the opened file-like object
     """
     url = link.url_without_fragment
 
@@ -371,9 +371,10 @@ def open_local_or_remote_file(link, session):
         response = session.get(url, headers=headers, stream=True)
 
         # Content length must be int or None
-        content_length = response.headers.get("content-length")
-        if content_length is not None:
-            content_length = int(content_length)
+        try:
+            content_length = int(response.headers["content-length"])
+        except (ValueError, KeyError, TypeError):
+            content_length = None
 
         try:
             yield FileStream(stream=response.raw, size=content_length)

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -82,6 +82,8 @@ class Resolver(object):
         """
         Finds acceptable hashes for all of the given InstallRequirements.
         """
+        log.debug("")
+        log.debug("Generating hashes:")
         with self.repository.allow_all_wheels():
             return {ireq: self.repository.get_hashes(ireq) for ireq in ireqs}
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -343,6 +343,19 @@ def test_generate_hashes_with_editable(runner):
     assert expected in out.output
 
 
+def test_generate_hashes_verbose(runner):
+    """
+    The hashes generation process should show a progress.
+    """
+    with open("requirements.in", "w") as fp:
+        fp.write("pytz==2017.2")
+
+    out = runner.invoke(cli, ["--generate-hashes", "-v"])
+
+    expected_verbose_text = "Generating hashes:\n  pytz\n"
+    assert expected_verbose_text in out.output
+
+
 @fail_below_pip9
 def test_filter_pip_markers(runner):
     """

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -111,7 +111,7 @@ def test_open_local_or_remote_file__directory(tmpdir):
 
     with pytest.raises(ValueError, match="Cannot open directory for read"):
         with open_local_or_remote_file(link, session):
-            pass
+            pass  # pragma: no cover
 
 
 @pytest.mark.parametrize(

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -1,5 +1,9 @@
+import mock
+import pytest
+
+from piptools._compat.pip_compat import Link, Session, path_to_url
 from piptools.pip import get_pip_command
-from piptools.repositories.pypi import PyPIRepository
+from piptools.repositories.pypi import PyPIRepository, open_local_or_remote_file
 
 
 def test_generate_hashes_all_platforms(from_line):
@@ -78,3 +82,62 @@ def test_get_hashes_editable_empty_set(from_editable):
     repository = PyPIRepository(pip_options, session)
     ireq = from_editable("git+https://github.com/django/django.git#egg=django")
     assert repository.get_hashes(ireq) == set()
+
+
+@pytest.mark.parametrize("content, content_length", [(b"foo", 3), (b"foobar", 6)])
+def test_open_local_or_remote_file__local_file(tmp_path, content, content_length):
+    """
+    Test the `open_local_or_remote_file` returns a context manager to a FileStream
+    for a given `Link` to a local file.
+    """
+    local_file_path = tmp_path / "foo.txt"
+    local_file_path.write_bytes(content)
+
+    link = Link(local_file_path.as_uri())
+    session = Session()
+
+    with open_local_or_remote_file(link, session) as file_stream:
+        assert file_stream.stream.read() == content
+        assert file_stream.size == content_length
+
+
+def test_open_local_or_remote_file__directory(tmpdir):
+    """
+    Test the `open_local_or_remote_file` raises a ValueError for a given `Link`
+    to a directory.
+    """
+    link = Link(path_to_url(tmpdir.strpath))
+    session = Session()
+
+    with pytest.raises(ValueError, match="Cannot open directory for read"):
+        with open_local_or_remote_file(link, session):
+            pass
+
+
+@pytest.mark.parametrize(
+    "content, content_length, expected_content_length",
+    [(b"foo", 3, 3), (b"bar", None, None), (b"kek", "invalid-content-length", None)],
+)
+def test_open_local_or_remote_file__remote_file(
+    tmp_path, content, content_length, expected_content_length
+):
+    """
+    Test the `open_local_or_remote_file` returns a context manager to a FileStream
+    for a given `Link` to a remote file.
+    """
+    link = Link("https://example.com/foo.txt")
+    session = Session()
+
+    response_file_path = tmp_path / "foo.txt"
+    response_file_path.write_bytes(content)
+
+    mock_response = mock.Mock()
+    mock_response.raw = response_file_path.open("rb")
+    mock_response.headers = {"content-length": content_length}
+
+    with mock.patch.object(session, "get", return_value=mock_response):
+        with open_local_or_remote_file(link, session) as file_stream:
+            assert file_stream.stream.read() == content
+            assert file_stream.size == expected_content_length
+
+    mock_response.close.assert_called_once()


### PR DESCRIPTION
Shows a progressbar on a slow hashes generation. Uses a bar provided by `click` package.

Example:
```
$ echo "numpy" > requirements.in
$ pip-compile -v --generate-hashes
```

<details>
<summary>See stdout</summary>

```
Using indexes:
  https://pypi.org/simple

                          ROUND 1
Current constraints:
  numpy

Finding the best candidates:
  found candidate numpy==1.16.2 (constraint was <any>)

Finding secondary dependencies:
  numpy==1.16.2 not in cache, need to check index
  numpy==1.16.2             requires -
------------------------------------------------------------
Result of round 1: stable, done

Generating hashes:
  numpy
    Hashing https://files.pythonhosted.org/packages/61/be/b4d697563d4a211596a350414a87612204a8bb987c4c1b34598cd4904f55/numpy-1.16.2-cp37-cp37m-win32.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/7c/61/e0affb3a94043d493cbd3abaeb1ed75d9b2a2426ecdfd3bc985f75df1803/numpy-1.16.2-cp27-cp27m-win32.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/a6/6f/cb20ccd8f0f8581e0e090775c0e3c3e335b037818416e6fa945d924397d2/numpy-1.16.2-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/91/e7/6c780e612d245cca62bc3ba8e263038f7c144a96a54f877f3714a0e8427e/numpy-1.16.2-cp37-cp37m-manylinux1_x86_64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/bc/90/3e71b5392bd81d8559917ee38857bb2e4b92c88e87211a68e339127b86f5/numpy-1.16.2-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/ed/29/d97b6252591da5f8add0d25eecda296ea72729a0aad7998edba1981b47c8/numpy-1.16.2-cp36-cp36m-win_amd64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/66/8f/2f32f7283aae2a351feb5b39f0df53d62ee2845479ce5d2a3a5da6717d60/numpy-1.16.2-cp37-cp37m-manylinux1_i686.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/cf/8d/6345b4f32b37945fedc1e027e83970005fc9c699068d2f566b82826515f2/numpy-1.16.2.zip
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/6e/b9/3bab7c9a5fc02b6c8b659502c3a4c1779f0faf65b1c59b34ef2ae5fa94c6/numpy-1.16.2-cp27-cp27m-manylinux1_i686.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/5b/0f/a93ea6864511e121a31fb15ac6fcd85fcaef64ce1f995661cc29ea5f1814/numpy-1.16.2-cp27-cp27mu-manylinux1_i686.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/0b/be/7933dd42e95044624ed8ea200a392a965b6bf9e89ea36944e59ddbd579c2/numpy-1.16.2-cp35-cp35m-win_amd64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/45/04/7a738e489a25a9638520a43a0cbfcc4be3ed056266e3110a330a905b36b5/numpy-1.16.2-cp35-cp35m-manylinux1_i686.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/e3/18/4f013c3c3051f4e0ffbaa4bf247050d6d5e527fe9cb1907f5975b172f23f/numpy-1.16.2-cp35-cp35m-manylinux1_x86_64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/7f/65/a5a0ca3695bb3358faef4bd2131c8174aef78c4b2182d8cae404312bcc26/numpy-1.16.2-cp27-cp27m-win_amd64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/35/d5/4f8410ac303e690144f0a0603c4b8fd3b986feb2749c435f7cdbb288f17e/numpy-1.16.2-cp36-cp36m-manylinux1_x86_64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/c4/33/8ec8dcdb4ede5d453047bbdbd01916dbaccdb63e98bba60989718f5f0876/numpy-1.16.2-cp27-cp27mu-manylinux1_x86_64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/3f/a2/e8762e3c31366c53bf122afbc23edc150881f8d87c6ca23dc2e2b21e4cbe/numpy-1.16.2-cp35-cp35m-win32.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/3a/3c/515afabfe4f29bfc0a67037efaf518c33d0076b32d22ba865241cee295c4/numpy-1.16.2-cp37-cp37m-win_amd64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/5e/aa/2b8df68ba219718ce016f624610b08179a3f9ed2566b2c2b61224c58db5d/numpy-1.16.2-cp36-cp36m-manylinux1_i686.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/65/9e/f7fe595f62b8f7fcc154afb20df19b58ddf2723ca2e21dbbf749cd1b8e0c/numpy-1.16.2-cp27-cp27m-manylinux1_x86_64.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/b3/84/41c7af95bab850819bddbc13e3e10317dacd3e28e2a0a5f14d8dbdc1c725/numpy-1.16.2-cp36-cp36m-win32.whl
    [####################################]  100%
    Hashing https://files.pythonhosted.org/packages/93/0e/30aaa357c3065957344b240482818eef31d4080f73dfa5f1ef7dcd8744d2/numpy-1.16.2-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
    Hashing https://files.pythonhosted.org/packages/0e/65/a27186c1692901f7b451572857f6d8d0031b6928500fa479c30a489afeed/numpy-1.16.2-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
    [####################################]  100%

#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile -v --generate-hashes
#
numpy==1.16.2 \
    --hash=sha256:1980f8d84548d74921685f68096911585fee393975f53797614b34d4f409b6da \
    --hash=sha256:22752cd809272671b273bb86df0f505f505a12368a3a5fc0aa811c7ece4dfd5c \
    --hash=sha256:23cc40313036cffd5d1873ef3ce2e949bdee0646c5d6f375bf7ee4f368db2511 \
    --hash=sha256:2b0b118ff547fecabc247a2668f48f48b3b1f7d63676ebc5be7352a5fd9e85a5 \
    --hash=sha256:3a0bd1edf64f6a911427b608a894111f9fcdb25284f724016f34a84c9a3a6ea9 \
    --hash=sha256:3f25f6c7b0d000017e5ac55977a3999b0b1a74491eacb3c1aa716f0e01f6dcd1 \
    --hash=sha256:4061c79ac2230594a7419151028e808239450e676c39e58302ad296232e3c2e8 \
    --hash=sha256:560ceaa24f971ab37dede7ba030fc5d8fa173305d94365f814d9523ffd5d5916 \
    --hash=sha256:62be044cd58da2a947b7e7b2252a10b42920df9520fc3d39f5c4c70d5460b8ba \
    --hash=sha256:6c692e3879dde0b67a9dc78f9bfb6f61c666b4562fd8619632d7043fb5b691b0 \
    --hash=sha256:6f65e37b5a331df950ef6ff03bd4136b3c0bbcf44d4b8e99135d68a537711b5a \
    --hash=sha256:7a78cc4ddb253a55971115f8320a7ce28fd23a065fc33166d601f51760eecfa9 \
    --hash=sha256:80a41edf64a3626e729a62df7dd278474fc1726836552b67a8c6396fd7e86760 \
    --hash=sha256:893f4d75255f25a7b8516feb5766c6b63c54780323b9bd4bc51cdd7efc943c73 \
    --hash=sha256:972ea92f9c1b54cc1c1a3d8508e326c0114aaf0f34996772a30f3f52b73b942f \
    --hash=sha256:9f1d4865436f794accdabadc57a8395bd3faa755449b4f65b88b7df65ae05f89 \
    --hash=sha256:9f4cd7832b35e736b739be03b55875706c8c3e5fe334a06210f1a61e5c2c8ca5 \
    --hash=sha256:adab43bf657488300d3aeeb8030d7f024fcc86e3a9b8848741ea2ea903e56610 \
    --hash=sha256:bd2834d496ba9b1bdda3a6cf3de4dc0d4a0e7be306335940402ec95132ad063d \
    --hash=sha256:d20c0360940f30003a23c0adae2fe50a0a04f3e48dc05c298493b51fd6280197 \
    --hash=sha256:d3b3ed87061d2314ff3659bb73896e622252da52558f2380f12c421fbdee3d89 \
    --hash=sha256:dc235bf29a406dfda5790d01b998a1c01d7d37f449128c0b1b7d1c89a84fae8b \
    --hash=sha256:fb3c83554f39f48f3fa3123b9c24aecf681b1c289f9334f8215c1d3c8e2f6e5b
```

</details>

Progressbar is shown for the packages which hashes generate operation took a time more that 0.5 secs (default click's behavior).

Context manager `nullcontext` added for conditional with statements.

Refs #521.

**Changelog-friendly one-liner**: Show progressbar on generation hashes in verbose mode

##### Contributor checklist

- [x] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
