### PR TITLE
Use pytest-cov plugin

### DIFF
--- a/piptools/__main__.py
+++ b/piptools/__main__.py
@@ -12,5 +12,5 @@ cli.add_command(sync.cli, 'sync')
 
 
 # Enable ``python -m piptools ...``.
-if __name__ == '__main__':  # pragma: no cover
+if __name__ == '__main__':  # pragma: no branch
     cli()

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ deps =
     pip10.0.1: pip==10.0.1
     pip18.0: pip==18.0
     pip19.0: pip==19.0
-    coverage
     mock
     pytest
+    pytest-cov
 setenv =
     piplatest: PIP=latest
     pipmaster: PIP=master
@@ -30,9 +30,7 @@ setenv =
 install_command= python -m pip install {opts} {packages}
 commands =
     pip --version
-    coverage run -m pytest --strict --doctest-modules {posargs:tests/ piptools/}
-    coverage report -m
-    coverage html
+    pytest --strict --doctest-modules --cov --cov-report html --cov-report term-missing {posargs:tests/ piptools/}
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
The benefit is the [subprocess support](https://pytest-cov.readthedocs.io/en/latest/readme.html?highlight=subprocess). Since the piptools uses subprocess module in the tests it allows to cover `__main__.py`.