### PR TITLE
ci: codecov: remove flags, add OS name to job name

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,4 +100,4 @@ test_script:
 
 after_test:
     - pip install codecov
-    - codecov -n %TOXENV%
+    - codecov -n %TOXENV%-windows

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,7 +91,7 @@ matrix:
 
 install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - pip install tox codecov
+    - pip install tox
 
 build: false
 
@@ -99,4 +99,5 @@ test_script:
     - tox
 
 after_test:
-    - codecov -F windows -n %TOXENV%
+    - pip install codecov
+    - codecov -n %TOXENV%

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,9 @@ env:
 
 cache: pip
 install:
-  - travis_retry pip install tox-travis codecov coveralls
+  - travis_retry pip install tox-travis
 script:
   - tox
-after_success:
-  - codecov -F $TRAVIS_OS_NAME -n "py$TRAVIS_PYTHON_VERSION-pip$PIP"
-  - "COVERALLS_PARALLEL=true coveralls"
 
 stages:
 - baseline
@@ -85,6 +82,11 @@ jobs:
   allow_failures:
     - env: PIP=master
     - python: 3.8-dev
+
+after_success:
+  - travis_retry pip install codecov coveralls
+  - codecov -n "py${TRAVIS_PYTHON_VERSION}-pip${PIP}-${TRAVIS_OS_NAME}"
+  - "COVERALLS_PARALLEL=true coveralls"
 
 notifications:
   webhooks: https://coveralls.io/webhook


### PR DESCRIPTION
While pip-tools is not (yet?) that much affected by timeouts on
codecov.io's backend, it is certainly rather slow in general.

As it turned out with pytest (where it was constantly timing out), this
is due to the usage of flags.

Therefore this removes flags for now, but adds TRAVIS_OS_NAME to the
upload's name.

This also moves the after_success section to the end of the config
(Where you would expect it), and only installs codecov/coveralls when
necessary.