### PR TITLE
Revisit coverage reporting

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ environment:
       PYTHON: "C:\\Python36"
 
     matrix:
-        - TOXENV: py27-pip8.1.1
+        - TOXENV: py27-pip8.1.1-coverage
           PIP: 8.1.1
         - TOXENV: py27-pip9.0.1
           PIP: 9.0.1
@@ -17,13 +17,14 @@ environment:
           PIP: 19.0
         - TOXENV: py27-pipmaster
           PIP: master
-        - TOXENV: py27-piplatest
+        - TOXENV: py27-piplatest-coverage
           PIP: latest
+
         - TOXENV: py34-pip8.1.1
           PIP: 8.1.1
         - TOXENV: py34-pip9.0.1
           PIP: 9.0.1
-        - TOXENV: py34-pip9.0.3
+        - TOXENV: py34-pip9.0.3-coverage
           PIP: 9.0.3
         - TOXENV: py34-pip10.0.1
           PIP: 10.0.1
@@ -35,6 +36,7 @@ environment:
           PIP: master
         - TOXENV: py34-piplatest
           PIP: latest
+
         - TOXENV: py35-pip8.1.1
           PIP: 8.1.1
         - TOXENV: py35-pip9.0.1
@@ -43,7 +45,7 @@ environment:
           PIP: 9.0.3
         - TOXENV: py35-pip10.0.1
           PIP: 10.0.1
-        - TOXENV: py35-pip18.0
+        - TOXENV: py35-pip18.0-coverage
           PIP: 18.0
         - TOXENV: py35-pip19.0
           PIP: 19.0
@@ -51,6 +53,7 @@ environment:
           PIP: master
         - TOXENV: py35-piplatest
           PIP: latest
+
         - TOXENV: py36-pip8.1.1
           PIP: 8.1.1
         - TOXENV: py36-pip9.0.1
@@ -61,12 +64,13 @@ environment:
           PIP: 10.0.1
         - TOXENV: py36-pip18.0
           PIP: 18.0
-        - TOXENV: py36-pip19.0
+        - TOXENV: py36-pip19.0-coverage
           PIP: 19.0
         - TOXENV: py36-pipmaster
           PIP: master
         - TOXENV: py36-piplatest
           PIP: latest
+
         - TOXENV: py37-pip8.1.1
           PIP: 8.1.1
         - TOXENV: py37-pip9.0.1
@@ -79,9 +83,9 @@ environment:
           PIP: 18.0
         - TOXENV: py37-pip19.0
           PIP: 19.0
-        - TOXENV: py37-pipmaster
+        - TOXENV: py37-pipmaster-coverage
           PIP: master
-        - TOXENV: py37-piplatest
+        - TOXENV: py37-piplatest-coverage
           PIP: latest
 
 matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -103,5 +103,10 @@ test_script:
     - tox
 
 after_test:
-    - pip install codecov
-    - codecov -n %TOXENV%-windows
+  # Add tox environment to PATH.
+  - "SET PATH=%CD%\\.tox\\%TOXENV%\\scripts;%PATH%"
+  - IF NOT "x%TOXENV:-coverage=%"=="x%TOXENV%" (
+      pip install codecov &&
+      coverage xml &&
+      codecov --required -X gcov pycov search -f coverage.xml -n %TOXENV%-windows
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ license_file = LICENSE
 
 [tool:pytest]
 norecursedirs = .* build dist venv test_data piptools/_compat/* piptools/_vendored/*
+testpaths = tests piptools

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .travis.yml for tox-travis.
-    py{27,34,35,36,37,38,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,19.0,latest,master}
+    py{27,34,35,36,37,38,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,19.0,latest,master}-coverage
     flake8
     readme
 skip_missing_interpreters = True
@@ -18,7 +18,7 @@ deps =
     pip19.0: pip==19.0
     mock
     pytest
-    pytest-cov
+    coverage: pytest-cov
 setenv =
     piplatest: PIP=latest
     pipmaster: PIP=master
@@ -28,10 +28,11 @@ setenv =
     pip10.0.1: PIP=10.0.1
     pip18.0: PIP=18.0
     pip19.0: PIP==19.0
+
+    coverage: _PIPTOOLS_TOX_COMMAND=coverage run -m pytest
+    coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 install_command= python -m pip install {opts} {packages}
-commands =
-    pip --version
-    pytest --strict --doctest-modules --cov --cov-report html --cov-report term-missing {posargs:tests/ piptools/}
+commands = {env:_PIPTOOLS_TOX_COMMAND:python -m pytest} {posargs}
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,9 @@ setenv =
     pip18.0: PIP=18.0
     pip19.0: PIP==19.0
 
-    coverage: _PIPTOOLS_TOX_COMMAND=coverage run -m pytest
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 install_command= python -m pip install {opts} {packages}
-commands = {env:_PIPTOOLS_TOX_COMMAND:python -m pytest} {posargs}
+commands = pytest {posargs}
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
* tox: add coverage factor

This is used via tox-travis automatically.
With AppVeyor, only selected envs are run with coverage.
