### PR TITLE
Add an option to allow enabling/disabling build isolation

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -49,9 +49,10 @@ class PyPIRepository(BaseRepository):
     config), but any other PyPI mirror can be used if index_urls is
     changed/configured on the Finder.
     """
-    def __init__(self, pip_options, session):
+    def __init__(self, pip_options, session, build_isolation=False):
         self.session = session
         self.pip_options = pip_options
+        self.build_isolation = build_isolation
 
         index_urls = [pip_options.index_url] + pip_options.extra_index_urls
         if pip_options.no_index:
@@ -161,7 +162,7 @@ class PyPIRepository(BaseRepository):
                 'download_dir': download_dir,
                 'wheel_download_dir': self._wheel_download_dir,
                 'progress_bar': 'off',
-                'build_isolation': False
+                'build_isolation': self.build_isolation,
             }
             resolver_kwargs = {
                 'finder': self.finder,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -61,10 +61,14 @@ DEFAULT_REQUIREMENTS_OUTPUT_FILE = 'requirements.txt'
 @click.option('--max-rounds', default=10,
               help="Maximum number of rounds before resolving the requirements aborts.")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
+@click.option('--build-isolation/--no-build-isolation', is_flag=True, default=False,
+              help="Enable isolation when building a modern source distribution. "
+                   "Build dependencies specified by PEP 518 must be already installed "
+                   "if build isolation is disabled.")
 def cli(verbose, quiet, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         cert, client_cert, trusted_host, header, index, emit_trusted_host, annotate,
         upgrade, upgrade_packages, output_file, allow_unsafe, generate_hashes,
-        src_files, max_rounds):
+        src_files, max_rounds, build_isolation):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbosity = verbose - quiet
 
@@ -122,7 +126,7 @@ def cli(verbose, quiet, dry_run, pre, rebuild, find_links, index_url, extra_inde
     pip_options, _ = pip_command.parse_args(pip_args)
 
     session = pip_command._build_session(pip_options)
-    repository = PyPIRepository(pip_options, session)
+    repository = PyPIRepository(pip_options, session, build_isolation)
 
     upgrade_install_reqs = {}
     # Proxy with a LocalRequirementsRepository if --upgrade is not specified

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -534,3 +534,23 @@ def test_cert_option(MockPyPIRepository, runner, option, attr, expected):
     for call in MockPyPIRepository.call_args_list:
         pip_options = call[0][0]
         assert getattr(pip_options, attr) == expected
+
+
+@pytest.mark.parametrize('option, expected', [
+    ('--build-isolation', True),
+    ('--no-build-isolation', False),
+])
+@mock.patch('piptools.scripts.compile.PyPIRepository')
+def test_build_isolation_option(MockPyPIRepository, runner, option, expected):
+    """
+    A value of the --build-isolation/--no-build-isolation flag must be passed to the PyPIRepository.
+    """
+    with open('requirements.in', 'w'):
+        pass
+
+    runner.invoke(cli, [option])
+
+    # Ensure the build_isolation in PyPIRepository has have the expected option
+    for call in MockPyPIRepository.call_args_list:
+        build_isolation = call[0][2]
+        assert build_isolation is expected

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -551,6 +551,4 @@ def test_build_isolation_option(MockPyPIRepository, runner, option, expected):
     runner.invoke(cli, [option])
 
     # Ensure the build_isolation option in PyPIRepository has the expected value.
-    for call in MockPyPIRepository.call_args_list:
-        build_isolation = call[0][2]
-        assert build_isolation is expected
+    assert [call[0][2] for call in MockPyPIRepository.call_args_list] == [expected]

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -550,7 +550,7 @@ def test_build_isolation_option(MockPyPIRepository, runner, option, expected):
 
     runner.invoke(cli, [option])
 
-    # Ensure the build_isolation in PyPIRepository has have the expected option
+    # Ensure the build_isolation option in PyPIRepository has the expected value.
     for call in MockPyPIRepository.call_args_list:
         build_isolation = call[0][2]
         assert build_isolation is expected


### PR DESCRIPTION
Closes #721.

**Changelog-friendly one-liner**: Add an option to allow enabling/disabling build isolation

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
