### PR TITLE
Add 'requirements.txt.vim' to the other tools section of the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,5 +235,7 @@ Other useful tools
 ==================
 
 - `pipdeptree`_ to print the dependency tree of the installed packages.
+- `requirements.txt.vim`_ more easily for editing ``requirements.in`` and ``requirements.txt`` with Vim.
 
 .. _pipdeptree: https://github.com/naiquevin/pipdeptree
+.. _requirements.txt.vim: https://github.com/raimon49/requirements.txt.vim


### PR DESCRIPTION
Hi, I'm a heavy user of `pip-tools`.

And I can provide other useful tools to Vim users.

Example of editing `requirements.in`:
![requirements in](https://user-images.githubusercontent.com/221802/54085629-77ba8500-4383-11e9-818a-7606d438ae0d.png)

Example of editing `requirements.txt`:
![requirements txt](https://user-images.githubusercontent.com/221802/54085636-8143ed00-4383-11e9-96a4-a12bf66c720d.png)

Thanks to continuous development of the `pip-tools` maintainers.

**Changelog-friendly one-liner**: Add 'requirements.txt.vim' to the other tools section of the README

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
