### PR TITLE
Write markers before hashes to fix issues.

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -61,12 +61,12 @@ def format_requirement(ireq, marker=None, hashes=None):
     else:
         line = str(ireq.req).lower()
 
+    if marker:
+        line = '{} ; {}'.format(line, marker)
+
     if hashes:
         for hash_ in sorted(hashes):
             line += " \\\n    --hash={}".format(hash_)
-
-    if marker:
-        line = '{} ; {}'.format(line, marker)
 
     return line
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,22 @@ def test_format_requirement_ireq_with_hashes(from_line):
     assert format_requirement(ireq, hashes=ireq_hashes) == expected
 
 
+def test_format_requirement_ireq_with_hashes_and_markers(from_line):
+    ireq = from_line('pytz==2017.2')
+    marker = 'python_version<"3.0"'
+    ireq_hashes = [
+        'sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67',
+        'sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589',
+    ]
+
+    expected = (
+        'pytz==2017.2 ; python_version<"3.0" \\\n'
+        '    --hash=sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n'
+        '    --hash=sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589'
+    )
+    assert format_requirement(ireq, marker, hashes=ireq_hashes) == expected
+
+
 def test_format_specifier(from_line):
     ireq = from_line('foo')
     assert format_specifier(ireq) == '<any>'


### PR DESCRIPTION
Fixes issue with generated lock file when hashes and markers are used together.

**Changelog-friendly one-liner**:  Fix order issue with generated lock file when hashes and markers are used together.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
