### PR TITLE
Show less output on sync with quiet option

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -125,7 +125,9 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, install_flags=N
     Install and uninstalls the given sets of modules.
     """
     if not to_uninstall and not to_install:
-        click.echo("Everything up-to-date")
+        if verbose:
+            click.echo("Everything up-to-date")
+        return 0
 
     pip_flags = []
     if not verbose:

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -39,6 +39,22 @@ def test_quiet_option(tmpdir):
                 assert '-q' in call[0][0]
 
 
+@mock.patch('piptools.sync.check_call')
+def test_quiet_option_when_up_to_date(check_call, runner):
+    """
+    Sync should output nothing when everything is up to date and quiet option is set.
+    """
+    with open('requirements.txt', 'w'):
+        pass
+
+    with mock.patch('piptools.sync.diff', return_value=(set(), set())):
+        out = runner.invoke(cli, ['-q'])
+
+    assert out.output == ''
+    assert out.exit_code == 0
+    check_call.assert_not_called()
+
+
 def test_no_requirements_file(runner):
     """
     It should raise an error if there are no input files

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -328,7 +328,7 @@ def test_sync_up_to_date(echo):
     """
     Everything up-to-date should be printed.
     """
-    sync(set(), set())
+    sync(set(), set(), verbose=True)
     echo.assert_called_once_with('Everything up-to-date')
 
 


### PR DESCRIPTION
Doesn't show "Everything up-to-date" if quiet option is set.

**Changelog-friendly one-liner**: Show less output on sync with quiet option

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
