### PR TITLE
List the Python extension for VS Code as supporting requirements.txt syntax highlighting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,7 +235,11 @@ Other useful tools
 ==================
 
 - `pipdeptree`_ to print the dependency tree of the installed packages.
-- `requirements.txt.vim`_ more easily for editing ``requirements.in`` and ``requirements.txt`` with Vim.
+- ``requirements.in``/``requirements.txt`` syntax highlighting:
+
+  * `requirements.txt.vim`_ for Vim.
+  * `Python extension for VS Code`_ for VS Code.
 
 .. _pipdeptree: https://github.com/naiquevin/pipdeptree
 .. _requirements.txt.vim: https://github.com/raimon49/requirements.txt.vim
+.. _Python extension for VS Code: https://marketplace.visualstudio.com/items?itemName=ms-python.python


### PR DESCRIPTION
<!--- Describe the changes here. --->
Mention requirements.txt syntax highlighting support for VS Code in the README.

**Changelog-friendly one-liner**: 
Mention requirements.txt syntax highlighting support for VS Code in the README.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Requested a review from another contributor.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
