### PR TITLE
Enable bandit security linter

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: tests,.tox,.eggs
+exclude: tests,.tox,.eggs,.venv,.git

--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: tests,.tox,.eggs

--- a/.fussyfox.yml
+++ b/.fussyfox.yml
@@ -1,2 +1,3 @@
+- bandit
 - isort
 - flake8

--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -33,7 +33,8 @@ def read_cache_file(cache_file_path):
             raise CorruptCacheError(cache_file_path)
 
         # Check version and load the contents
-        assert doc["__format__"] == 1, "Unknown cache file format"
+        if doc["__format__"] != 1:
+            raise AssertionError("Unknown cache file format")
         return doc["dependencies"]
 
 

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -2,7 +2,7 @@ import collections
 import os
 import sys
 import tempfile
-from subprocess import check_call
+from subprocess import check_call  # nosec
 
 from . import click
 from .exceptions import IncompatibleRequirements, UnsupportedConstraint
@@ -148,7 +148,7 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, install_flags=N
             for pkg in to_uninstall:
                 click.echo("  {}".format(pkg))
         else:
-            check_call(
+            check_call(  # nosec
                 [sys.executable, "-m", "pip", "uninstall", "-y"]
                 + pip_flags
                 + sorted(to_uninstall)
@@ -174,7 +174,7 @@ def sync(to_install, to_uninstall, verbose=False, dry_run=False, install_flags=N
             tmp_req_file.close()
 
             try:
-                check_call(
+                check_call(  # nosec
                     [sys.executable, "-m", "pip", "install", "-r", tmp_req_file.name]
                     + pip_flags
                     + install_flags

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -245,7 +245,8 @@ def fs_str(string):
     """
     if isinstance(string, str):
         return string
-    assert not isinstance(string, bytes)
+    if isinstance(string, bytes):
+        raise AssertionError
     return string.encode(_fs_encoding)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,10 +40,12 @@ deps =
     flake8==3.7.7
     black==19.3b0
     isort==4.3.16
+    bandit==1.5.1
 commands =
     black --check --diff .
     isort --recursive --check-only --diff .
     flake8 piptools tests
+    bandit -r .
 
 [testenv:readme]
 deps = readme_renderer


### PR DESCRIPTION
Enable bandit security linter and address related concernts.

**Changelog-friendly one-liner**: Add bandit security linter

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).