### PR TITLE
Support the flag --trusted-host in pip-sync.

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -42,6 +42,11 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     envvar="PIP_EXTRA_INDEX_URL",
 )  # noqa
 @click.option(
+    "--trusted-host",
+    multiple=True,
+    help="Mark this host as trusted, even though it does not have valid or any HTTPS.",
+)
+@click.option(
     "--no-index",
     is_flag=True,
     help="Ignore package index (only looking at --find-links URLs instead)",
@@ -57,6 +62,7 @@ def cli(
     find_links,
     index_url,
     extra_index_url,
+    trusted_host,
     no_index,
     quiet,
     user_only,
@@ -106,6 +112,9 @@ def cli(
     if extra_index_url:
         for extra_index in extra_index_url:
             install_flags.extend(["--extra-index-url", extra_index])
+    if trusted_host:
+        for host in trusted_host:
+            install_flags.extend(["--trusted-host", host])
     if user_only:
         install_flags.append("--user")
 

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -118,6 +118,14 @@ def test_merge_error(runner):
             ["--extra-index-url", "https://foo", "--extra-index-url", "https://bar"],
             ["--extra-index-url", "https://foo", "--extra-index-url", "https://bar"],
         ),
+        (
+            ["--trusted-host", "https://foo", "--trusted-host", "https://bar"],
+            ["--trusted-host", "https://foo", "--trusted-host", "https://bar"],
+        ),
+        (
+            ["--extra-index-url", "https://foo", "--trusted-host", "https://bar"],
+            ["--extra-index-url", "https://foo", "--trusted-host", "https://bar"],
+        ),
         (["--user"], ["--user"]),
     ],
 )


### PR DESCRIPTION
**Changelog-friendly one-liner**: Support the flag --trusted-host in pip-sync.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).


