### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    - id: black
+      language_version: python3.7
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.16
+    hooks:
+    - id: isort
+      language_version: python3.7
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.7
+    hooks:
+    - id: flake8
+      language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ jobs:
     - env: TOXENV=checkqa
       python: 3.7
       after_success: skip  # No need coverage
+      cache:
+        directories:
+          - $HOME/.cache/pre-commit
     - env: TOXENV=readme
       python: 2.7
       after_success: skip  # No need coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 ## Project Contribution Guidelines
 
 Here are a few additional or emphasized guidelines to follow when contributing to pip-tools:
+- Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
 - Always provide tests for your changes.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,9 @@ commands = pytest {posargs}
 basepython = python3
 ignore_errors = true
 deps =
-    flake8
-    black
-    isort
+    flake8==3.7.7
+    black==19.3b0
+    isort==4.3.16
 commands =
     black --check --diff .
     isort --recursive --check-only --diff .


### PR DESCRIPTION
- pins flake8/black/isort packages to make sure that QA is deterministic
- adds `pre-commit` configuration
- adds a note to [contributing](https://github.com/jazzband/pip-tools/blob/497c128fb2952e227b3b17ec6d3e98aa08e547cc/CONTRIBUTING.md) guide