### PR TITLE
Validate readme via twine check command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     author_email="me@nvie.com",
     description=__doc__.strip(),
     long_description=read_file("README.rst"),
+    long_description_content_type="text/x-rst",
     packages=find_packages(exclude=["tests"]),
     package_data={},
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",

--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,8 @@ commands =
     bandit -r .
 
 [testenv:readme]
-deps = readme_renderer
-commands = python setup.py check --restructuredtext --strict
-
+deps = twine
+commands = twine check {distdir}/*
 
 [travis:env]
 PIP =


### PR DESCRIPTION
Fixes [this warning](https://travis-ci.org/jazzband/pip-tools/jobs/516513828#L211):
```
readme runtests: commands[0] | python setup.py check --restructuredtext --strict
running check
warning: Check: This command has been deprecated. Use `twine check` instead: https://packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup
```
