### PR TITLE
Check QA via pre-commit in tox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,9 @@ repos:
     hooks:
     - id: flake8
       language_version: python3.7
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.6.0
+    hooks:
+    - id: bandit
+      language_version: python3.7
+      exclude: ^(tests|\.tox|\.eggs|\.venv|\.git)

--- a/tox.ini
+++ b/tox.ini
@@ -35,17 +35,9 @@ commands = pytest {posargs}
 
 [testenv:checkqa]
 basepython = python3
-ignore_errors = true
-deps =
-    flake8==3.7.7
-    black==19.3b0
-    isort==4.3.16
-    bandit==1.5.1
-commands =
-    black --check --diff .
-    isort --recursive --check-only --diff .
-    flake8 piptools tests
-    bandit -r .
+skip_install = True
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:readme]
 deps = twine


### PR DESCRIPTION
TODO
- [X] run `pre-commit` in checkqa tox env.
- [x] add `bandit` to pre-commit, wait for https://github.com/PyCQA/bandit/issues/468

Also updates bandit to `1.6.0` for being able use bandit in pre-commit hooks.