### PR TITLE
Add support for --find-links in pip-compile output

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -280,18 +280,6 @@ def cli(
         }
         repository = LocalRequirementsRepository(existing_pins, repository)
 
-    log.debug("Using indexes:")
-    # remove duplicate index urls before processing
-    repository.finder.index_urls = list(dedup(repository.finder.index_urls))
-    for index_url in repository.finder.index_urls:
-        log.debug("  {}".format(index_url))
-
-    if repository.finder.find_links:
-        log.debug("")
-        log.debug("Configuration:")
-        for find_link in repository.finder.find_links:
-            log.debug("  -f {}".format(find_link))
-
     ###
     # Parsing/collecting initial requirements
     ###
@@ -337,6 +325,18 @@ def cli(
     constraints = [
         req for req in constraints if req.markers is None or req.markers.evaluate()
     ]
+
+    log.debug("Using indexes:")
+    # remove duplicate index urls before processing
+    repository.finder.index_urls = list(dedup(repository.finder.index_urls))
+    for index_url in repository.finder.index_urls:
+        log.debug("  {}".format(index_url))
+
+    if repository.finder.find_links:
+        log.debug("")
+        log.debug("Configuration:")
+        for find_link in repository.finder.find_links:
+            log.debug("  -f {}".format(find_link))
 
     # Check the given base set of constraints first
     Resolver.check_constraints(constraints)
@@ -405,6 +405,7 @@ def cli(
         trusted_hosts=pip_options.trusted_hosts,
         format_control=repository.finder.format_control,
         allow_unsafe=allow_unsafe,
+        find_links=repository.finder.find_links,
     )
     writer.write(
         results=results,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -23,6 +23,7 @@ class OutputWriter(object):
         trusted_hosts,
         format_control,
         allow_unsafe,
+        find_links,
     ):
         self.src_files = src_files
         self.dst_file = dst_file
@@ -37,6 +38,7 @@ class OutputWriter(object):
         self.trusted_hosts = trusted_hosts
         self.format_control = format_control
         self.allow_unsafe = allow_unsafe
+        self.find_links = find_links
 
     def _sort_key(self, ireq):
         return (not ireq.editable, str(ireq.req).lower())
@@ -75,10 +77,15 @@ class OutputWriter(object):
         for ob in dedup(self.format_control.only_binary):
             yield "--only-binary {}".format(ob)
 
+    def write_find_links(self):
+        for find_link in dedup(self.find_links):
+            yield "--find-links {}".format(find_link)
+
     def write_flags(self):
         emitted = False
         for line in chain(
             self.write_index_options(),
+            self.write_find_links(),
             self.write_trusted_hosts(),
             self.write_format_controls(),
         ):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -124,12 +124,20 @@ def test_command_line_setuptools_output_file(pip_conf, options, expected_output_
 
 
 def test_find_links_option(pip_conf, runner):
-    with open("requirements.in", "w"):
-        pass
+    with open("requirements.in", "w") as req_in:
+        req_in.write("-f ./libs3")
+
     out = runner.invoke(cli, ["-v", "-f", "./libs1", "-f", "./libs2"])
 
     # Check that find-links has been passed to pip
-    assert "Configuration:\n  -f ./libs1\n  -f ./libs2" in out.output
+    assert "Configuration:\n  -f ./libs1\n  -f ./libs2\n  -f ./libs3\n" in out.output
+
+    # Check that find-links has been written to a requirements.txt
+    with open("requirements.txt", "r") as req_txt:
+        assert (
+            "--find-links ./libs1\n--find-links ./libs2\n--find-links ./libs3\n"
+            in req_txt.read()
+        )
 
 
 def test_extra_index_option(pip_conf, runner):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -21,6 +21,7 @@ def writer(tmp_file):
         trusted_hosts=[],
         format_control=FormatControl(set(), set()),
         allow_unsafe=False,
+        find_links=[],
     )
 
 
@@ -259,3 +260,19 @@ def test_write_index_options_no_emit_index(writer):
     writer.emit_index = False
     with raises(StopIteration):
         next(writer.write_index_options())
+
+
+@mark.parametrize(
+    "find_links, expected_lines",
+    (
+        [[], []],
+        [["./foo"], ["--find-links ./foo"]],
+        [["./foo", "./bar"], ["--find-links ./foo", "--find-links ./bar"]],
+    ),
+)
+def test_write_find_links(writer, find_links, expected_lines):
+    """
+    Test write_find_links method.
+    """
+    writer.find_links = find_links
+    assert list(writer.write_find_links()) == expected_lines


### PR DESCRIPTION
This adds support to pip-compile for the -f, --find-links <url> flag in the input requirements.in. Rebased #704 and adjusted tests. **Thanks @estan for the contribution!**

**Changelog-friendly one-liner**: Add support for `--find-links` in `pip-compile` output.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
