### PR TITLE
Fix pip>=19.1 compatibility

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -144,7 +144,16 @@ class PyPIRepository(BaseRepository):
         matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
         if not matching_candidates:
             raise NoCandidateFound(ireq, all_candidates, self.finder)
-        best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
+
+        # pip <= 19.0.3
+        if hasattr(self.finder, "_candidate_sort_key"):
+            best_candidate = max(
+                matching_candidates, key=self.finder._candidate_sort_key
+            )
+        # pip >= 19.1
+        else:
+            evaluator = self.finder.candidate_evaluator
+            best_candidate = evaluator.get_best_candidate(matching_candidates)
 
         # Turn the candidate into a pinned InstallRequirement
         return make_install_requirement(


### PR DESCRIPTION
Closes issue #794.

**Changelog-friendly one-liner**: Fix pip>=19.1 compatibility

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
