### PR TITLE
Add options --cert and --client-cert to pip-sync

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -55,6 +55,12 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 @click.option(
     "--user", "user_only", is_flag=True, help="Restrict attention to user directory"
 )
+@click.option("--cert", help="Path to alternate CA bundle.")
+@click.option(
+    "--client-cert",
+    help="Path to SSL client certificate, a single file containing "
+    "the private key and the certificate in PEM format.",
+)
 @click.argument("src_files", required=False, type=click.Path(exists=True), nargs=-1)
 def cli(
     dry_run,
@@ -66,6 +72,8 @@ def cli(
     no_index,
     quiet,
     user_only,
+    cert,
+    client_cert,
     src_files,
 ):
     """Synchronize virtual environment with requirements.txt."""
@@ -117,6 +125,10 @@ def cli(
             install_flags.extend(["--trusted-host", host])
     if user_only:
         install_flags.append("--user")
+    if cert:
+        install_flags.extend(["--cert", cert])
+    if client_cert:
+        install_flags.extend(["--client-cert", client_cert])
 
     sys.exit(
         sync.sync(

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -129,6 +129,8 @@ def test_merge_error(runner):
             ["--extra-index-url", "https://foo", "--trusted-host", "https://bar"],
         ),
         (["--user"], ["--user"]),
+        (["--cert", "foo.crt"], ["--cert", "foo.crt"]),
+        (["--client-cert", "foo.pem"], ["--client-cert", "foo.pem"]),
     ],
 )
 @mock.patch("piptools.sync.check_call")


### PR DESCRIPTION
Closes #713.

**Changelog-friendly one-liner**: Add options `--cert` and `--client-cert` to `pip-sync`

##### Contributor checklist

- [X] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
