### PR TITLE
Fix replacing password to asterisks in pip-compile

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -54,7 +54,7 @@ def format_requirement(ireq, marker=None, hashes=None):
     in a less verbose way than using its `__str__` method.
     """
     if ireq.editable:
-        line = "-e {}".format(ireq.link)
+        line = "-e {}".format(ireq.link.url)
     else:
         line = str(ireq.req).lower()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,9 +19,21 @@ def test_format_requirement(from_line):
     assert format_requirement(ireq) == "test==1.2"
 
 
-def test_format_requirement_editable(from_editable):
+def test_format_requirement_editable_vcs(from_editable):
     ireq = from_editable("git+git://fake.org/x/y.git#egg=y")
     assert format_requirement(ireq) == "-e git+git://fake.org/x/y.git#egg=y"
+
+
+def test_format_requirement_editable_vcs_with_password(from_editable):
+    ireq = from_editable("git+git://user:password@fake.org/x/y.git#egg=y")
+    assert (
+        format_requirement(ireq) == "-e git+git://user:password@fake.org/x/y.git#egg=y"
+    )
+
+
+def test_format_requirement_editable_local_path(from_editable):
+    ireq = from_editable("file:///home/user/package")
+    assert format_requirement(ireq) == "-e file:///home/user/package"
 
 
 def test_format_requirement_ireq_with_hashes(from_line):


### PR DESCRIPTION
Fixes #801

**Changelog-friendly one-liner**: Fix replacing password to asterisks in `pip-compile`.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
