### PR TITLE
Update Black URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/python/black
     rev: 19.3b0
     hooks:
     - id: black


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190