### PR TITLE
Respect --pre option in requirements.in file

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -348,7 +348,7 @@ def cli(
         resolver = Resolver(
             constraints,
             repository,
-            prereleases=pre,
+            prereleases=repository.finder.allow_all_prereleases or pre,
             clear_caches=rebuild,
             allow_unsafe=allow_unsafe,
         )


### PR DESCRIPTION
Fixes #819.

**Changelog-friendly one-liner**: Respect `--pre` option in a `requirements.in` file

##### Contributor checklist

- [X] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
