### PR TITLE
Print provenance information when pip-compile fails

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -9,6 +9,7 @@ from .pip_compat import (
     FAVORITE_HASH,
     Command,
     FormatControl,
+    InstallationCandidate,
     InstallRequirement,
     Link,
     PackageFinder,

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -25,6 +25,9 @@ def do_import(module_path, subimport=None, old_path=None):
 
 
 InstallRequirement = do_import("req.req_install", "InstallRequirement")
+InstallationCandidate = do_import(
+    "models.candidate", "InstallationCandidate", old_path="index"
+)
 parse_requirements = do_import("req.req_file", "parse_requirements")
 RequirementSet = do_import("req.req_set", "RequirementSet")
 user_cache_dir = do_import("utils.appdirs", "user_cache_dir")

--- a/piptools/exceptions.py
+++ b/piptools/exceptions.py
@@ -35,8 +35,10 @@ class NoCandidateFound(PipToolsError):
 
         if versions or pre_versions:
             lines.append(
-                "There are incompatible versions in the resolved dependencies."
+                "There are incompatible versions in the resolved dependencies:"
             )
+            source_ireqs = getattr(self.ireq, "_source_ireqs", [])
+            lines.extend("  {}".format(ireq) for ireq in source_ireqs)
         else:
             lines.append("No versions found")
             lines.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,11 @@ from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
 from pytest import fixture
 
-from piptools._compat import install_req_from_editable, install_req_from_line
+from piptools._compat import (
+    InstallationCandidate,
+    install_req_from_editable,
+    install_req_from_line,
+)
 from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
 from piptools.repositories.base import BaseRepository
@@ -40,9 +44,11 @@ class FakeRepository(BaseRepository):
             )
         )
         if not versions:
-            raise NoCandidateFound(
-                ireq, self.index[key_from_req(ireq.req)], ["https://fake.url.foo"]
-            )
+            tried_versions = [
+                InstallationCandidate(ireq.name, version, "https://fake.url.foo")
+                for version in self.index[key_from_req(ireq.req)]
+            ]
+            raise NoCandidateFound(ireq, tried_versions, ["https://fake.url.foo"])
         best_version = max(versions, key=Version)
         return make_install_requirement(
             key_from_req(ireq.req),

--- a/tests/test_minimal_upgrade.py
+++ b/tests/test_minimal_upgrade.py
@@ -21,12 +21,12 @@ from piptools.utils import name_from_req
                 [
                     # Add flask and upgrade werkzeug from incompatible 0.6
                     "flask==0.10.1",
-                    "itsdangerous==0.24",
+                    "itsdangerous==0.24 (from flask==0.10.1)",
                     "werkzeug==0.10.4",
                     # Other requirements are unchanged from
                     # the original requirements.txt
                     "jinja2==2.7.3",
-                    "markupsafe==0.23",
+                    "markupsafe==0.23 (from jinja2==2.7.3)",
                 ],
             )
         ]


### PR DESCRIPTION
For motivation, see #836

For the following ``requirements.in`` file:
```
tensorflow-data-validation
google-cloud-bigquery~=1.14.0
```
Before this change, the output is this:
```bash
$ python -m piptools compile requirements.in
Could not find a version that matches google-cloud-bigquery<1.7.0,>=1.6.0,~=1.14.0
Tried: 0.20.0, 0.20.0, 0.21.0, 0.21.0, 0.22.0, 0.22.0, 0.22.1, 0.22.1, 0.23.0, 0.23.0, 0.24.0, 0.24.0, 0.25.0, 0.25.0, 0.26.0, 0.26.0, 0.27.0, 0.27.0, 0.28.0, 0.28.0, 0.29.0, 0.29.0, 0.30.0, 0.30.0, 0.31.0, 0.31.0, 0.32.0, 0.32.0, 1.0.0, 1.0.0, 1.1.0, 1.1.0, 1.2.0, 1.2.0, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 1.5.0, 1.5.0, 1.5.1, 1.5.1, 1.6.0, 1.6.0, 1.6.1, 1.6.1, 1.7.0, 1.7.0, 1.8.0, 1.8.0, 1.8.1, 1.8.1, 1.9.0, 1.9.0, 1.10.0, 1.10.0, 1.11.1, 1.11.1, 1.11.2, 1.11.2, 1.11.3, 1.11.3, 1.12.0, 1.12.0, 1.12.1, 1.12.1, 1.13.0, 1.13.0, 1.14.0, 1.14.0, 1.15.0, 1.15.0
There are incompatible versions in the resolved dependencies.
```
With this change, the output is this:
```bash
$ python -m piptools compile requirements.in
Could not find a version that matches google-cloud-bigquery<1.7.0,>=1.6.0,~=1.14.0 (from -r requirements.in (line 2))
Tried: 0.20.0, 0.20.0, 0.21.0, 0.21.0, 0.22.0, 0.22.0, 0.22.1, 0.22.1, 0.23.0, 0.23.0, 0.24.0, 0.24.0, 0.25.0, 0.25.0, 0.26.0, 0.26.0, 0.27.0, 0.27.0, 0.28.0, 0.28.0, 0.29.0, 0.29.0, 0.30.0, 0.30.0, 0.31.0, 0.31.0, 0.32.0, 0.32.0, 1.0.0, 1.0.0, 1.1.0, 1.1.0, 1.2.0, 1.2.0, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 1.5.0, 1.5.0, 1.5.1, 1.5.1, 1.6.0, 1.6.0, 1.6.1, 1.6.1, 1.7.0, 1.7.0, 1.8.0, 1.8.0, 1.8.1, 1.8.1, 1.9.0, 1.9.0, 1.10.0, 1.10.0, 1.11.1, 1.11.1, 1.11.2, 1.11.2, 1.11.3, 1.11.3, 1.12.0, 1.12.0, 1.12.1, 1.12.1, 1.13.0, 1.13.0, 1.14.0, 1.14.0, 1.15.0, 1.15.0
There are incompatible versions in the resolved dependencies:
  google-cloud-bigquery~=1.14.0 (from -r requirements.in (line 2))
  google-cloud-bigquery<1.7.0,>=1.6.0 (from apache-beam[gcp]==2.13.0->tensorflow-data-validation==0.13.1->-r requirements.in (line 1))
```

This involves adding a piptools-specific attribute to combined ``InstallRequirements`` objects. This might be cleaner if we used a class-based approach (defining, e.g. a ``CombinedInstallRequirements`` class) but this is difficult to do cleanly because pip's ``InstallRequirements`` class is an internal implementation that changes often between pip versions.

**Changelog-friendly one-liner**: Print provenance information when pip-compile fails (Fixes #836)

##### Contributor checklist

- [X] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).