### PR TITLE
Use pip-tools repo itself for VCS tests

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -237,17 +237,16 @@ def test_editable_package(runner):
 
 def test_editable_package_vcs(runner):
     vcs_package = (
-        "git+git://github.com/pytest-dev/pytest-django"
-        "@21492afc88a19d4ca01cd0ac392a5325b14f95c7"
-        "#egg=pytest-django"
+        "git+git://github.com/jazzband/pip-tools@"
+        "f97e62ecb0d9b70965c8eff952c001d8e2722e94"
+        "#egg=pip-tools"
     )
     with open("requirements.in", "w") as req_in:
         req_in.write("-e " + vcs_package)
     out = runner.invoke(cli, ["-n", "--rebuild"])
-    print(out.output)
     assert out.exit_code == 0
     assert vcs_package in out.output
-    assert "pytest" in out.output  # dependency of pytest-django
+    assert "click" in out.output  # dependency of pip-tools
 
 
 def test_locally_available_editable_package_is_not_archived_in_cache_dir(


### PR DESCRIPTION
* Fixes failing tests on AppVeyour https://ci.appveyor.com/project/jazzband/pip-tools/builds/25670236/job/8elgo24tsbmsm6m8
* Increases speed of `test_editable_package_vcs`, since `pip-tools` has only two dependencies (`pytest-django` has 12 dependencies).

PS
I was trying to figure out what's wrong with `pathlib2>=2.2.0;python_version<"3.6"` in pytest's `setup.py` but had no luck. Looks like pip==8.1.1 suddenly cannot parse `;` in package name in AppVeyour. Also there was similar issues in the past, see #390 and #435. I've given up and just fixed the test.
