### PR TITLE
Fix output file update on dry-run compile

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from itertools import chain, groupby
 
 import six
+from click.utils import LazyFile
 from six.moves import shlex_quote
 
 from ._compat import install_req_from_line
@@ -339,11 +340,7 @@ def get_compile_command(click_ctx):
             continue
 
         # Use a file name for file-like objects
-        if (
-            hasattr(value, "write")
-            and hasattr(value, "read")
-            and hasattr(value, "name")
-        ):
+        if isinstance(value, LazyFile):
             value = value.name
 
         # Convert value to the list


### PR DESCRIPTION
Fixes #841 

**Changelog-friendly one-liner**: Fix output file update in dry-run mode in `pip-compile`

##### Contributor checklist

- [X] Provided the tests for the changes.
- [ ] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
