### PR TITLE
Ignore deprecation warnings from pip module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ license_file = LICENSE
 [tool:pytest]
 norecursedirs = .* build dist venv test_data piptools/_compat/* piptools/_vendored/*
 testpaths = tests piptools
+filterwarnings = ignore::PendingDeprecationWarning:pip[.*]
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Hides a deprecation warnings that happen in code that `piptools` has no control over. 

```
pip/_vendor/msgpack/fallback.py:222: PendingDeprecationWarning: encoding is deprecated, Use raw=False instead.
    PendingDeprecationWarning)
```

Reduces `tox` output:

- before -  https://travis-ci.org/jazzband/pip-tools/jobs/554999138
- after - https://travis-ci.org/atugushev/pip-tools/jobs/556739390