### PR TITLE
Add option to preserve original inline comments (using best effort)

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -640,6 +640,28 @@ def test_annotate_option(pip_conf, runner, option, expected):
 
 @pytest.mark.parametrize(
     "option, expected",
+    [
+        (
+            "--preserve-inline-comments",
+            "six==1.10.0               # via small-fake-with-deps\n",
+        )
+    ],
+)
+def test_preserve_inline_comments_option(pip_conf, runner, option, expected):
+    """
+    The output lines have inline comments preserved if option is turned on.
+    """
+    with open("requirements.in", "w") as req_in:
+        req_in.write("small_fake_with_deps")
+
+    out = runner.invoke(cli, [option, "-n", "-f", MINIMAL_WHEELS_PATH])
+
+    assert expected in out.stderr
+    assert out.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "option, expected",
     [("--allow-unsafe", "\nsetuptools=="), (None, "\n# setuptools==")],
 )
 def test_allow_unsafe_option(runner, option, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,6 +245,7 @@ def test_force_text(value, expected_text):
         (["--generate-hashes"], "pip-compile --generate-hashes"),
         (["--pre"], "pip-compile --pre"),
         (["--allow-unsafe"], "pip-compile --allow-unsafe"),
+        (["--preserve-inline-comments"], "pip-compile --preserve-inline-comments"),
         # Check negative flags
         (["--no-index"], "pip-compile --no-index"),
         (["--no-emit-trusted-host"], "pip-compile --no-emit-trusted-host"),

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -41,6 +41,8 @@ def writer(tmpdir_cwd):
             format_control=FormatControl(set(), set()),
             allow_unsafe=False,
             find_links=[],
+            preserve_inline_comments=False,
+            comment_collection={},
         )
         yield writer
 


### PR DESCRIPTION
Resolves #391

Add `--preserve-inline-comments` option to preserve inline comments from `requirements.in` files.
This allows tooling that requires such annotations to operate properly.

**Changelog-friendly one-liner**:  Add option to preserve original inline comments (using best effort)

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Requested a review from another contributor.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
