### PR TITLE
[WIP] tox: add -U option to install_command

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,6 +43,9 @@ environment:
 
         - TOXENV: py36-pip8.1.1
           PIP: 8.1.1
+          # Turn off --upgrade option for pip==8.1.1.
+          # See https://github.com/pypa/pip/issues/3964
+          PIP_INSTALL_OPTS: ""
         - TOXENV: py36-pip9.0.1
           PIP: 9.0.1
         - TOXENV: py36-pip9.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ setenv =
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
-install_command= python -m pip install -U {opts} {packages}
+install_command= python -m pip install {env:PIP_INSTALL_OPTS:-U} {opts} {packages}
 commands =
     pip --version
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ setenv =
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
+passenv = PYTEST_ADDOPTS PIP_INSTALL_OPTS
 install_command= python -m pip install {env:PIP_INSTALL_OPTS:-U} {opts} {packages}
 commands =
     pip --version

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,10 @@ setenv =
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
-install_command= python -m pip install {opts} {packages}
-commands = pytest {posargs}
+install_command= python -m pip install -U {opts} {packages}
+commands =
+    pip --version
+    pytest {posargs}
 
 [testenv:checkqa]
 basepython = python3


### PR DESCRIPTION
There was an issue with PIP=latest because of cache. See #858 for details. To fix it i've added to pip upgrade option to make sure that pip package (without explicit version) upgraded to a latest version.

Also print pip version explicitly for debugging. Now you know exactly which version of pip was installed with PIP=latest. 

Closes #858.