### PR TITLE
Prevent dry-run log message from being printed with --quiet option

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -415,4 +415,4 @@ def cli(
     )
 
     if dry_run:
-        log.warning("Dry-run, so nothing updated.")
+        log.info("Dry-run, so nothing updated.")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -465,15 +465,15 @@ def test_quiet_option(runner):
 def test_dry_run_noisy_option(runner):
     with open("requirements", "w"):
         pass
-    out = runner.invoke(cli, ["--dry-run", "-n", "requirements"])
     # Dry-run massage has been written to output
     assert "Dry-run, so nothing updated." in out.stderr.strip()
+    out = runner.invoke(cli, ["--dry-run", "requirements"])
 
 
 def test_dry_run_quiet_option(runner):
     with open("requirements", "w"):
         pass
-    out = runner.invoke(cli, ["--dry-run", "--quiet", "-n", "requirements"])
+    out = runner.invoke(cli, ["--dry-run", "--quiet", "requirements"])
     # Dry-run message has not been written to output.
     assert b"" == out.stderr_bytes
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -458,8 +458,12 @@ def test_quiet_option(runner):
     with open("requirements", "w"):
         pass
     out = runner.invoke(cli, ["--quiet", "-n", "requirements"])
-    # Pinned requirements result has not been written to output
-    assert "" == out.stderr.strip()
+    # Pinned requirements result has not been written to output. (An empty
+    # out.stderr results in a ValueError raised by Click)
+    try:
+        assert "" == out.stderr.strip()
+    except ValueError:
+        pass
 
 
 def test_dry_run_noisy_option(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -459,7 +459,27 @@ def test_quiet_option(runner):
         pass
     out = runner.invoke(cli, ["--quiet", "-n", "requirements"])
     # Pinned requirements result has not been written to output
-    assert "Dry-run, so nothing updated." == out.stderr.strip()
+    assert "" == out.stderr.strip()
+
+
+def test_dry_run_noisy_option(runner):
+    with open("requirements", "w"):
+        pass
+    out = runner.invoke(cli, ["--dry-run", "-n", "requirements"])
+    # Dry-run massage has been written to output
+    assert "Dry-run, so nothing updated." in out.stderr.strip()
+
+
+def test_dry_run_quiet_option(runner):
+    with open("requirements", "w"):
+        pass
+    out = runner.invoke(cli, ["--dry-run", "--quiet", "-n", "requirements"])
+    # Dry-run massage has not been written to output. (An empty out.stderr
+    # results in a ValueError raised by Click)
+    try:
+        assert "Dry-run, so nothing updated." not in out.stderr.strip()
+    except ValueError:
+        pass
 
 
 def test_generate_hashes_with_editable(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -459,7 +459,7 @@ def test_quiet_option(runner):
         pass
     out = runner.invoke(cli, ["--quiet", "-n", "requirements"])
     # Pinned requirements result has not been written to output.
-    assert b"" == out.stderr_bytes
+    assert not out.stderr_bytes
 
 
 def test_dry_run_noisy_option(runner):
@@ -475,7 +475,7 @@ def test_dry_run_quiet_option(runner):
         pass
     out = runner.invoke(cli, ["--dry-run", "--quiet", "requirements"])
     # Dry-run message has not been written to output.
-    assert b"" == out.stderr_bytes
+    assert not out.stderr_bytes
 
 
 def test_generate_hashes_with_editable(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -466,8 +466,8 @@ def test_dry_run_noisy_option(runner):
     with open("requirements", "w"):
         pass
     # Dry-run massage has been written to output
-    assert "Dry-run, so nothing updated." in out.stderr.strip()
     out = runner.invoke(cli, ["--dry-run", "requirements"])
+    assert "Dry-run, so nothing updated." in out.stderr.splitlines()
 
 
 def test_dry_run_quiet_option(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -465,8 +465,8 @@ def test_quiet_option(runner):
 def test_dry_run_noisy_option(runner):
     with open("requirements", "w"):
         pass
-    # Dry-run massage has been written to output
     out = runner.invoke(cli, ["--dry-run", "requirements"])
+    # Dry-run message has been written to output
     assert "Dry-run, so nothing updated." in out.stderr.splitlines()
 
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -458,12 +458,8 @@ def test_quiet_option(runner):
     with open("requirements", "w"):
         pass
     out = runner.invoke(cli, ["--quiet", "-n", "requirements"])
-    # Pinned requirements result has not been written to output. (An empty
-    # out.stderr results in a ValueError raised by Click)
-    try:
-        assert "" == out.stderr.strip()
-    except ValueError:
-        pass
+    # Pinned requirements result has not been written to output.
+    assert b"" == out.stderr_bytes
 
 
 def test_dry_run_noisy_option(runner):
@@ -478,12 +474,8 @@ def test_dry_run_quiet_option(runner):
     with open("requirements", "w"):
         pass
     out = runner.invoke(cli, ["--dry-run", "--quiet", "-n", "requirements"])
-    # Dry-run massage has not been written to output. (An empty out.stderr
-    # results in a ValueError raised by Click)
-    try:
-        assert "Dry-run, so nothing updated." not in out.stderr.strip()
-    except ValueError:
-        pass
+    # Dry-run message has not been written to output.
+    assert b"" == out.stderr_bytes
 
 
 def test_generate_hashes_with_editable(runner):


### PR DESCRIPTION
<!--- Describe the changes here. --->
Changed the log level for the message *"Dry-run, so nothing updated."* from `warning` to `info`.

Closes issue #845 

**Changelog-friendly one-liner**: Prevent --dry-run log message from being printed with --quiet option.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
