### PR TITLE
Add retry wrapper to codecov command in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -99,5 +99,5 @@ after_test:
   - IF NOT "x%TOXENV:-coverage=%"=="x%TOXENV%" (
       pip install codecov &&
       coverage xml &&
-      codecov --required -X gcov pycov search -f coverage.xml -n %TOXENV%-windows
+      appveyor-retry codecov --required -X gcov pycov search -f coverage.xml -n %TOXENV%-windows
     )

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
 
 after_success:
   - travis_retry pip install codecov coveralls
-  - codecov -n "py${TRAVIS_PYTHON_VERSION}-pip${PIP}-${TRAVIS_OS_NAME}"
+  - travis_retry codecov --required -n "py${TRAVIS_PYTHON_VERSION}-pip${PIP}-${TRAVIS_OS_NAME}"
   - "COVERALLS_PARALLEL=true coveralls"
 
 notifications:


### PR DESCRIPTION
To prevent fail job if sending report to codecov is failed for some reason (usually timeout). It's happening too frequently on AppVeyor CI.