### PR TITLE
Update install_command in tox to force install up-to-date dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,8 +13,8 @@ environment:
           PIP: 10.0.1
         - TOXENV: py27-pip18.0
           PIP: 18.0
-        - TOXENV: py27-pip19.0
-          PIP: 19.0
+        - TOXENV: py27-pip19.0.3
+          PIP: 19.0.3
         - TOXENV: py27-pip19.1
           PIP: 19.1
         - TOXENV: py27-pipmaster
@@ -32,8 +32,8 @@ environment:
           PIP: 10.0.1
         - TOXENV: py35-pip18.0-coverage
           PIP: 18.0
-        - TOXENV: py35-pip19.0
-          PIP: 19.0
+        - TOXENV: py35-pip19.0.3
+          PIP: 19.0.3
         - TOXENV: py35-pip19.1
           PIP: 19.1
         - TOXENV: py35-pipmaster
@@ -51,8 +51,8 @@ environment:
           PIP: 10.0.1
         - TOXENV: py36-pip18.0
           PIP: 18.0
-        - TOXENV: py36-pip19.0-coverage
-          PIP: 19.0
+        - TOXENV: py36-pip19.0.3-coverage
+          PIP: 19.0.3
         - TOXENV: py36-pip19.1
           PIP: 19.1
         - TOXENV: py36-pipmaster
@@ -70,8 +70,8 @@ environment:
           PIP: 10.0.1
         - TOXENV: py37-pip18.0
           PIP: 18.0
-        - TOXENV: py37-pip19.0
-          PIP: 19.0
+        - TOXENV: py37-pip19.0.3
+          PIP: 19.0.3
         - TOXENV: py37-pip19.1-coverage
           PIP: 19.1
         - TOXENV: py37-pipmaster-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - PIP=9.0.3
   - PIP=10.0.1
   - PIP=18.0
-  - PIP=19.0
+  - PIP=19.0.3
   - PIP=19.1
   - PIP=latest
   - PIP=master

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .travis.yml for tox-travis.
-    py{27,35,36,37,38,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,19.0,19.1,latest,master}-coverage
+    py{27,35,36,37,38,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,19.0.3,19.1,latest,master}-coverage
     checkqa
     readme
 skip_missing_interpreters = True
@@ -15,7 +15,7 @@ deps =
     pip9.0.3: pip==9.0.3
     pip10.0.1: pip==10.0.1
     pip18.0: pip==18.0
-    pip19.0: pip==19.0
+    pip19.0.3: pip==19.0.3
     pip19.1: pip==19.1
     mock
     pytest
@@ -28,7 +28,7 @@ setenv =
     pip9.0.3: PIP=9.0.3
     pip10.0.1: PIP=10.0.1
     pip18.0: PIP=18.0
-    pip19.0: PIP==19.0
+    pip19.0.3: PIP==19.0.3
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
@@ -54,7 +54,7 @@ PIP =
     9.0.3: pip9.0.3
     10.0.1: pip10.0.1
     18.0: pip18.0
-    19.0: pip19.0
+    19.0.3: pip19.0.3
     19.1: pip19.1
     latest: piplatest
     master: pipmaster

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,10 @@ setenv =
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
-install_command= python -m pip install {opts} {packages}
-commands = pytest {posargs}
+install_command = python -m pip install --no-cache-dir {opts} {packages}
+commands =
+    pip --version
+    pytest {posargs}
 
 [testenv:checkqa]
 basepython = python3


### PR DESCRIPTION
Force pip by `--no-cache-dir` to pull in up-to-date versions of all dependencies. See https://github.com/jazzband/pip-tools/issues/858#issuecomment-515244332.

Print explicitly pip version for debugging to know which exactly version
of pip was installed with PIP=latest.

Also had to upgrade 19.0 to 19.0.3, since pip crashes with --no-cache-dir in 19.0. See https://github.com/pypa/pip/issues/6158.

P.S.
Previously i've been considered to add `-U` flag, but it doesn't work with `pip==8.1.1` on windows py36. See https://github.com/jazzband/pip-tools/pull/859#issuecomment-515373865.