### PR TITLE
ci: Travis: do not use (pip) cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   - PIP=latest
   - PIP=master
 
-cache: pip
+cache: false
 install:
   - travis_retry pip install tox-travis
 script:


### PR DESCRIPTION
This is usually handled already by HTTP caching, and does not gain much
since the cache has to be downloaded also (and might be even much bigger
then).

Ref: https://github.com/jazzband/pip-tools/pull/866