### PR TITLE
Install dependencies in tox with --upgrade option

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,8 +41,10 @@ environment:
         - TOXENV: py35-piplatest
           PIP: latest
 
-        - TOXENV: py36-pip8.1.1
-          PIP: 8.1.1
+        # Note, pip install -U pip doesn't work on py36 windows
+        # See https://github.com/pypa/pip/issues/3964
+        # - TOXENV: py36-pip8.1.1
+        #   PIP: 8.1.1
         - TOXENV: py36-pip9.0.1
           PIP: 9.0.1
         - TOXENV: py36-pip9.0.3

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,8 +62,10 @@ environment:
         - TOXENV: py36-piplatest
           PIP: latest
 
-        - TOXENV: py37-pip8.1.1
-          PIP: 8.1.1
+        # Note, pip install -U pip doesn't work on py37 windows
+        # See https://github.com/pypa/pip/issues/3964
+        # - TOXENV: py37-pip8.1.1
+        #   PIP: 8.1.1
         - TOXENV: py37-pip9.0.1
           PIP: 9.0.1
         - TOXENV: py37-pip9.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ setenv =
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
-install_command = python -m pip install --no-cache-dir {opts} {packages}
+install_command = python -m pip install -U {opts} {packages}
 commands =
     pip --version
     pytest {posargs}


### PR DESCRIPTION
The workaround with `--cache-dir` didn't work (#866).  See the output of `pip --version` in CI jobs:
 - [Travis-CI](https://travis-ci.org/jazzband/pip-tools/jobs/567417975#L213-L214)
 - [AppVeyor](https://ci.appveyor.com/project/jazzband/pip-tools/builds/26447187/job/14xbg8r1e3a4psyh#L42)

Had to comment off py36-pip8.1.1 and py37-pip8.1.1 dimension in AppVeyor matrix due to `python -m pip install -U pip` doesn't work because of a bug. See https://github.com/pypa/pip/issues/3964 for details.

