### PR TITLE
Fix piplatest env

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,10 +41,8 @@ environment:
         - TOXENV: py35-piplatest
           PIP: latest
 
-        # Note, pip install -U pip doesn't work on py36 windows
-        # See https://github.com/pypa/pip/issues/3964
-        # - TOXENV: py36-pip8.1.1
-        #   PIP: 8.1.1
+        - TOXENV: py36-pip8.1.1
+          PIP: 8.1.1
         - TOXENV: py36-pip9.0.1
           PIP: 9.0.1
         - TOXENV: py36-pip9.0.3
@@ -62,10 +60,8 @@ environment:
         - TOXENV: py36-piplatest
           PIP: latest
 
-        # Note, pip install -U pip doesn't work on py37 windows
-        # See https://github.com/pypa/pip/issues/3964
-        # - TOXENV: py37-pip8.1.1
-        #   PIP: 8.1.1
+        - TOXENV: py37-pip8.1.1
+          PIP: 8.1.1
         - TOXENV: py37-pip9.0.1
           PIP: 9.0.1
         - TOXENV: py37-pip9.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -32,10 +32,11 @@ setenv =
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
-install_command = python -m pip install -U {opts} {packages}
-commands =
+install_command = python -m pip install {opts} {packages}
+commands_pre =
+    piplatest: pip install -U pip
     pip --version
-    pytest {posargs}
+commands = pytest {posargs}
 
 [testenv:checkqa]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 install_command = python -m pip install {opts} {packages}
 commands_pre =
-    piplatest: pip install -U pip
+    piplatest: python -m pip install -U pip
     pip --version
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ setenv =
     pip19.1: PIP==19.1
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
-install_command = python -m pip install {opts} {packages}
 commands_pre =
     piplatest: python -m pip install -U pip
     pip --version


### PR DESCRIPTION
Upgrades pip to the latest version with `commands_pre` setting.
Reverts f747932.


Ref: see discussion starting from https://github.com/jazzband/pip-tools/pull/868#issuecomment-518020602