### PR TITLE
Filter deprecation warnings from pip._vendor module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,9 @@ license_file = LICENSE
 [tool:pytest]
 norecursedirs = .* build dist venv test_data piptools/_compat/* piptools/_vendored/*
 testpaths = tests piptools
-filterwarnings = ignore::PendingDeprecationWarning:pip[.*]
+filterwarnings =
+    ignore::PendingDeprecationWarning:pip\._vendor.+
+    ignore::DeprecationWarning:pip\._vendor.+
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Ignore `DeprecationWarning` and `PendingDeprecationWarning` from module
`pip._vendor.*` that pip-tools has no control over.


Ref: #844 