### PR TITLE
Add --no-emit-find-links option (fixes #848)

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -163,6 +163,12 @@ pip_defaults = InstallCommand().parser.get_default_values()
     "Build dependencies specified by PEP 518 must be already installed "
     "if build isolation is disabled.",
 )
+@click.option(
+    "--emit-find-links/--no-emit-find-links",
+    is_flag=True,
+    default=True,
+    help="Add the find-links option to generated file",
+)
 def cli(
     ctx,
     verbose,
@@ -188,6 +194,7 @@ def cli(
     src_files,
     max_rounds,
     build_isolation,
+    emit_find_links,
 ):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbosity = verbose - quiet
@@ -400,6 +407,7 @@ def cli(
         format_control=repository.finder.format_control,
         allow_unsafe=allow_unsafe,
         find_links=repository.finder.find_links,
+        emit_find_links=emit_find_links,
     )
     writer.write(
         results=results,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -54,6 +54,7 @@ class OutputWriter(object):
         format_control,
         allow_unsafe,
         find_links,
+        emit_find_links,
     ):
         self.src_files = src_files
         self.dst_file = dst_file
@@ -70,6 +71,7 @@ class OutputWriter(object):
         self.format_control = format_control
         self.allow_unsafe = allow_unsafe
         self.find_links = find_links
+        self.emit_find_links = emit_find_links
 
     def _sort_key(self, ireq):
         return (not ireq.editable, str(ireq.req).lower())
@@ -106,8 +108,9 @@ class OutputWriter(object):
             yield "--only-binary {}".format(ob)
 
     def write_find_links(self):
-        for find_link in dedup(self.find_links):
-            yield "--find-links {}".format(find_link)
+        if self.emit_find_links:
+            for find_link in dedup(self.find_links):
+                yield "--find-links {}".format(find_link)
 
     def write_flags(self):
         emitted = False

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -183,6 +183,15 @@ def test_trusted_host_no_emit(pip_conf, runner):
     assert "--trusted-host example.com" not in out.stderr
 
 
+def test_find_links_no_emit(pip_conf, runner):
+    with open("requirements.in", "w"):
+        pass
+    out = runner.invoke(
+        cli, ["-v", "--no-emit-find-links"]
+    )
+    assert "--find-links" not in out.stderr
+
+
 def test_realistic_complex_sub_dependencies(runner):
     wheels_dir = "wheels"
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -186,9 +186,7 @@ def test_trusted_host_no_emit(pip_conf, runner):
 def test_find_links_no_emit(pip_conf, runner):
     with open("requirements.in", "w"):
         pass
-    out = runner.invoke(
-        cli, ["-v", "--no-emit-find-links"]
-    )
+    out = runner.invoke(cli, ["-v", "--no-emit-find-links"])
     assert "--find-links" not in out.stderr
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -41,6 +41,7 @@ def writer(tmpdir_cwd):
             format_control=FormatControl(set(), set()),
             allow_unsafe=False,
             find_links=[],
+            emit_find_links=True,
         )
         yield writer
 


### PR DESCRIPTION
**Changelog-friendly one-liner**: Add new --no-emit-find-links option (fixes #848)

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
