### PR TITLE
[WIP] Parse extras_require when compile setup.py

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -303,6 +303,18 @@ def cli(
 
                 dist = run_setup(src_file)
                 tmpfile.write("\n".join(dist.install_requires))
+
+                # Parse extras_require of the form
+                # "extra:{marker}": ["package"] to
+                # "package ; {marker}" if extra is empty.
+                for extra_and_marker, packages in dist.extras_require.items():
+                    extra, marker = extra_and_marker.split(":")
+                    # TODO: non-empty extras will be ignored, perhaps we need
+                    #  an option like --with-extra to specify one. See GH-625.
+                    if extra:
+                        continue
+                    for package in packages:
+                        tmpfile.write("{} ; {}\n".format(package, marker))
             else:
                 tmpfile.write(sys.stdin.read())
             tmpfile.flush()

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     pip18.0: pip==18.0
     pip19.0.3: pip==19.0.3
     pip19.1: pip==19.1
+    setuptools>=36.2.1  # Needed for environment markers (PEP496) support.
     mock
     pytest
     coverage: pytest-cov


### PR DESCRIPTION
Closes #625.

**Changelog-friendly one-liner**: Parse `extras_require` when compile `setup.py` file.

TODO

- [x] handle `extras_require={'dev': "small-fake-a==0.1"}`
- [ ] research how pip handles `extras_require` via `pip install -e .[dev]`

##### Contributor checklist

- [X] Provided the tests for the changes.
- [ ] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
