### PR TITLE
Resolver.constraints: Keep our_constraints before their_constraints

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -56,7 +56,6 @@ def combine_install_requirements(ireqs):
     source_ireqs = []
     for ireq in ireqs:
         source_ireqs.extend(getattr(ireq, "_source_ireqs", [ireq]))
-    source_ireqs.sort(key=str)
 
     # deepcopy the accumulator so as to not modify the inputs
     combined_ireq = copy.deepcopy(source_ireqs[0])
@@ -120,7 +119,12 @@ class Resolver(object):
     @property
     def constraints(self):
         return set(
-            self._group_constraints(chain(self.our_constraints, self.their_constraints))
+            self._group_constraints(
+                chain(
+                    sorted(self.our_constraints, key=str),
+                    sorted(self.their_constraints, key=str),
+                )
+            )
         )
 
     def resolve_hashes(self, ireqs):
@@ -258,7 +262,7 @@ class Resolver(object):
         for best_match in best_matches:
             their_constraints.extend(self._iter_dependencies(best_match))
         # Grouping constraints to make clean diff between rounds
-        theirs = set(self._group_constraints(their_constraints))
+        theirs = set(self._group_constraints(sorted(their_constraints, key=str)))
 
         # NOTE: We need to compare RequirementSummary objects, since
         # InstallRequirement does not define equality

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,12 @@ from piptools.exceptions import NoCandidateFound
 from piptools.repositories import PyPIRepository
 from piptools.repositories.base import BaseRepository
 from piptools.resolver import Resolver
-from piptools.utils import as_tuple, key_from_req, make_install_requirement
+from piptools.utils import (
+    as_tuple,
+    is_url_requirement,
+    key_from_req,
+    make_install_requirement,
+)
 
 
 class FakeRepository(BaseRepository):
@@ -59,7 +64,7 @@ class FakeRepository(BaseRepository):
         )
 
     def get_dependencies(self, ireq):
-        if ireq.editable:
+        if ireq.editable or is_url_requirement(ireq):
             return self.editables[str(ireq.link)]
 
         name, version, extras = as_tuple(ireq)

--- a/tests/test_data/fake-editables.json
+++ b/tests/test_data/fake-editables.json
@@ -1,3 +1,4 @@
 {
-  "git+git://example.org/django.git#egg=django": []
+  "git+git://example.org/django.git#egg=django": [],
+  "git+https://github.com/celery/billiard#egg=billiard==3.5.9999": []
 }

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -155,6 +155,23 @@ from piptools.resolver import combine_install_requirements
                     ),
                 },
             ),
+            # Git URL requirement
+            # See: GH-851
+            (
+                [
+                    "git+https://github.com/celery/billiard#egg=billiard==3.5.9999",
+                    "celery==4.0.2",
+                ],
+                [
+                    "amqp==2.1.4 (from kombu==4.0.2->celery==4.0.2)",
+                    "kombu==4.0.2 (from celery==4.0.2)",
+                    "billiard<3.6.0,==3.5.9999,>=3.5.0.2 from "
+                    "git+https://github.com/celery/billiard#egg=billiard==3.5.9999",
+                    "vine==1.1.3 (from amqp==2.1.4->kombu==4.0.2->celery==4.0.2)",
+                    "celery==4.0.2",
+                    "pytz==2016.4 (from celery==4.0.2)",
+                ],
+            ),
         ]
     ),
 )
@@ -264,8 +281,8 @@ def test_compile_failure_shows_provenance(resolver, from_line):
     with pytest.raises(NoCandidateFound) as err:
         resolver(requirements).resolve()
     lines = str(err.value).splitlines()
+    assert lines[-2].strip() == "celery>3.2"
     assert (
-        lines[-2].strip()
+        lines[-1].strip()
         == "celery==3.1.18 (from fake-piptools-test-with-pinned-deps==0.1)"
     )
-    assert lines[-1].strip() == "celery>3.2"


### PR DESCRIPTION
Not sure if this is the right solution, but this seems to fix #851, which was introduced when the `source_ireqs.sort(key=str)` operation was added in #837.

Cc: @jakevdp

**Changelog-friendly one-liner**: Try to fix resolution of requirements from Git URLs without -e.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
