### PR TITLE
Use skipif instead of xfail in test_filter_pip_markers

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -18,8 +18,6 @@ from piptools.utils import PIP_VERSION
 TEST_DATA_PATH = os.path.join(os.path.split(__file__)[0], "test_data")
 MINIMAL_WHEELS_PATH = os.path.join(TEST_DATA_PATH, "minimal_wheels")
 
-fail_below_pip9 = pytest.mark.xfail(PIP_VERSION < (9,), reason="needs pip 9 or greater")
-
 
 @pytest.fixture
 def pip_conf(tmpdir, monkeypatch):
@@ -533,7 +531,7 @@ def test_generate_hashes_verbose(runner):
     assert expected_verbose_text in out.stderr
 
 
-@fail_below_pip9
+@pytest.mark.skipif(PIP_VERSION < (9,), reason="needs pip 9 or greater")
 def test_filter_pip_markers(runner):
     """
     Check that pip-compile works with pip environment markers (PEP496)


### PR DESCRIPTION
Since the `test_filter_pip_markers` is not gonna be passed anymore
with pip<9, so better to skip it than expect to fail.

The proper support of environment markers has been added in pip 9.0.0.