### PR TITLE
Install pip master in tox via commands_pre directive

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ skip_missing_interpreters = True
 [testenv]
 deps =
     piplatest: pip
-    pipmaster: -e git+https://github.com/pypa/pip.git@master#egg=pip
     pip8.1.1: pip==8.1.1
     pip9.0.1: pip==9.0.1
     pip9.0.3: pip==9.0.3
@@ -34,6 +33,7 @@ setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 commands_pre =
     piplatest: python -m pip install -U pip
+    pipmaster: python -m pip install -e 'git+https://github.com/pypa/pip.git@master#egg=pip'
     pip --version
 commands = pytest {posargs}
 


### PR DESCRIPTION
Directive `deps=-e git+https://github.com/pypa/pip.git@master#egg=pip` in tox would install pip only once during the setup environment. The problem is that for new commits in master `tox -e py37-pipmaster` won't reinstall pip.

The workaround is the same as for `piplatest`. See https://github.com/jazzband/pip-tools/issues/858#issuecomment-515244332 for the reference.