### PR TITLE
Remove redundant deps=piplatest declaration from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
-    piplatest: pip
     pipmaster: -e git+https://github.com/pypa/pip.git@master#egg=pip
     pip8.1.1: pip==8.1.1
     pip9.0.1: pip==9.0.1


### PR DESCRIPTION
Because tox already installs piplatest in the `commands_pre` directive.

