### PR TITLE
Add compatibility with pip==19.3 for removed Link.is_artifact property

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -254,7 +254,7 @@ class PyPIRepository(BaseRepository):
                 # If a download_dir is passed, pip will  unnecessarely
                 # archive the entire source directory
                 download_dir = None
-            elif ireq.link and not ireq.link.is_artifact:
+            elif ireq.link and is_vcs_url(ireq.link):
                 # No download_dir for VCS sources.  This also works around pip
                 # using git-checkout-index, which gets rid of the .git dir.
                 download_dir = None


### PR DESCRIPTION
Remove Link.is_artifact usage in favour of `is_vcs_url`.

See https://github.com/pypa/pip/pull/7059

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Add compatibility with `pip==19.3`.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [x] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
