### PR TITLE
Allow failing PIP=19.3 until pip being released

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,6 +91,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - PIP: master
+    - PIP: 19.3  # TODO remove after pip==19.3 being released
 
 install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ jobs:
           repo: jazzband/pip-tools
   allow_failures:
     - env: PIP=master
+    - env: PIP=19.3  # TODO remove after pip==19.3 being released
     - python: 3.8-dev
 
 after_success:


### PR DESCRIPTION
@codingjoe looks like I've forgotten it in #864. Master is broken and new PRs are CI-red now.
