### PR TITLE
Include already-installed matching requirements in the to_install set, so that pip-sync reliably installs dependencies

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -150,7 +150,6 @@ def diff(
     """
     requirements_lut = {diff_key_from_ireq(r): r for r in compiled_requirements}
 
-    satisfied = set()  # holds keys
     to_install = set()  # holds InstallRequirement objects
     to_uninstall = set()  # holds keys
 
@@ -159,11 +158,9 @@ def diff(
         key = key_from_req(dist)
         if key not in requirements_lut or not requirements_lut[key].match_markers():
             to_uninstall.add(key)
-        elif requirements_lut[key].specifier.contains(dist.version):
-            satisfied.add(key)
 
     for key, requirement in requirements_lut.items():
-        if key not in satisfied and requirement.match_markers():
+        if requirement.match_markers():
             to_install.add(requirement)
 
     # Make sure to not uninstall any packages that should be ignored

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -118,7 +118,7 @@ def test_diff_should_do_nothing():
     reqs = []  # no requirements
 
     to_install, to_uninstall = diff(reqs, installed)
-    assert to_install == set()
+    assert to_install == set(reqs)
     assert to_uninstall == set()
 
 
@@ -136,7 +136,7 @@ def test_diff_should_uninstall(fake_dist):
     reqs = []
 
     to_install, to_uninstall = diff(reqs, installed)
-    assert to_install == set()
+    assert to_install == set(reqs)
     assert to_uninstall == {"django"}  # no version spec when uninstalling
 
 
@@ -200,7 +200,7 @@ def test_diff_leave_packaging_packages_alone(fake_dist, from_line):
     reqs = [from_line("django==1.7")]
 
     to_install, to_uninstall = diff(reqs, installed)
-    assert to_install == set()
+    assert to_install == set(reqs)
     assert to_uninstall == {"first"}
 
 
@@ -221,7 +221,7 @@ def test_diff_leave_piptools_alone(fake_dist, from_line):
     reqs = [from_line("django==1.7")]
 
     to_install, to_uninstall = diff(reqs, installed)
-    assert to_install == set()
+    assert to_install == set(reqs)
     assert to_uninstall == {"foobar"}
 
 
@@ -242,12 +242,12 @@ def test_diff_with_editable(fake_dist, from_editable):
 
 
 def test_diff_with_matching_url_versions(fake_dist, from_line):
-    # if URL version is explicitly provided, use it to avoid reinstalling
+    # if URL version is explicitly provided, pip itself will avoid reinstalling
     installed = [fake_dist("example==1.0")]
     reqs = [from_line("file:///example.zip#egg=example==1.0")]
 
     to_install, to_uninstall = diff(reqs, installed)
-    assert to_install == set()
+    assert to_install == set(reqs)
     assert to_uninstall == set()
 
 


### PR DESCRIPTION
Have `diff` include already-installed matching requirements in its `to_install` set.

This means that during sync, dependencies of desired packages will be (re)installed after potentially being uninstalled, regardless of environment state at time of sync, for a more consistent, predictable, and practical resulting state. Fixes #896.

If this is not desired, `--no-deps` can be provided via the new `--pip-args` option, whereby it will be passed through to `pip install`, and un-locked deps will be either removed or not installed, to match the lockfile exactly.

The following existing tests check the `to_install` set, and are herein adjusted to expect the inclusion of explicit requirements (all in `test_sync.py`):

- `test_diff_should_do_nothing`
- `test_diff_should_uninstall`
- `test_diff_should_uninstall_with_markers`
- `test_diff_leave_packaging_packages_alone`
- `test_diff_leave_piptools_alone`
- `test_diff_with_matching_url_versions`

Note: `test_diff_with_matching_url_versions`, before this change, expects pip-tools to prevent reinstallation of versioned URL requirements, but this is unnecessary as `pip` itself will do that, reporting "Requirement already satisfied . . .", and the test's comment is updated to reflect that. If this is incorrect under some circumstance, please correct me!

**Changelog-friendly one-liner**: `pip-sync` now ensures installation of dependencies of a locked requirement, even if those deps are not locked and the locked requirement is already installed; this can be disabled with `pip-sync --pip-args=--no-deps`.

##### Contributor checklist

- [X] Provided the tests for the changes. (Well, modified existing tests)
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

If this were to be accepted, would the appropriate merge point be the next major version, as the behavior may not be what is currently expected? I view it as a bug fix, and do not know when or why the current behavior would be desired instead, but I am only me.

@atugushev Please have a look for discussion and review. Thanks!