### PR TITLE
Ensure pip-compile --no-header <blank requirements.in> creates/overwrites requirements.txt

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -801,3 +801,29 @@ def test_dry_run_doesnt_touch_output_file(
     # The output file must not be touched
     after_compile_mtime = os.stat("requirements.txt").st_mtime
     assert after_compile_mtime == before_compile_mtime
+
+
+@pytest.mark.parametrize(
+    "empty_input_pkg, prior_output_pkg",
+    [
+        ("", ""),
+        ("", "small-fake-a==0.1\n"),
+        ("# Nothing to see here", ""),
+        ("# Nothing to see here", "small-fake-a==0.1\n"),
+    ],
+)
+def test_empty_input_file_no_header(runner, empty_input_pkg, prior_output_pkg):
+    """
+    Tests pip-compile creates an empty requirements.txt file,
+    given --no-header and empty requirements.in
+    """
+    with open("requirements.in", "w") as req_in:
+        req_in.write(empty_input_pkg)  # empty input file
+
+    with open("requirements.txt", "w") as req_txt:
+        req_txt.write(prior_output_pkg)
+
+    runner.invoke(cli, ["--no-header", "requirements.in"])
+
+    with open("requirements.txt", "r") as req_txt:
+        assert req_txt.read().strip() == ""


### PR DESCRIPTION
Before, in the case where the writer should generate a blank output document (e.g. `requirements.txt`), no new file would be created, and any existing file with that name would be left unchanged. With this change, a blank document will created and overwritten if it exists.

This is implemented by having the writer keep track of whether it yields any lines, and if not, yielding an empty string (where before it would yield nothing).

A simpler solution would be to always yield an extra empty string at the end of `_iter_lines`, but that would result in a bit of awkward space at the bottom of all the `txt`s, and if that were fixed it would involve leaking the composition logic outside of `_iter_lines`.

**Changelog-friendly one-liner**: `pip-compile --no-header <blank requirements.in>` now creates/overwrites `requirements.txt`.

Fixes #900.

@atugushev I hereby request a review. If this does not satisfy the "Requested a review from another contributor" requirement, please tell me what does. Thanks!

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).