### PR TITLE
Fix create_command() import

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -377,6 +377,6 @@ def create_install_command():
     if PIP_VERSION < (19, 3):
         return InstallCommand()
 
-    from pip._internal import create_command
+    from pip._internal.commands import create_command
 
     return create_command("install")


### PR DESCRIPTION
It should be imported directly from `pip._internal.commands`.
See PR https://github.com/pypa/pip/pull/7061 which [breaks](https://travis-ci.org/jazzband/pip-tools/jobs/590063914) pip-tools.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Add compatibility with `pip==19.3`.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [ ] Requested a review from another contributor.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).