### PR TITLE
Add --ask option to pip-sync

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -16,6 +16,12 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 @click.command()
 @click.version_option()
 @click.option(
+    "-a",
+    "--ask",
+    is_flag=True,
+    help="Show what would happen, then ask whether to continue",
+)
+@click.option(
     "-n",
     "--dry-run",
     is_flag=True,
@@ -63,6 +69,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 )
 @click.argument("src_files", required=False, type=click.Path(exists=True), nargs=-1)
 def cli(
+    ask,
     dry_run,
     force,
     find_links,
@@ -137,5 +144,6 @@ def cli(
             verbose=(not quiet),
             dry_run=dry_run,
             install_flags=install_flags,
+            ask=ask,
         )
     )

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -147,3 +147,30 @@ def test_pip_install_flags(check_call, cli_flags, expected_install_flags, runner
     assert [args[6:] for args in call_args if args[3] == "install"] == [
         expected_install_flags
     ]
+
+
+@mock.patch("piptools.sync.check_call")
+def test_sync_ask_declined(check_call, runner):
+    """
+    Make sure nothing is installed if the confirmation is declined
+    """
+    with open("requirements.txt", "w") as req_in:
+        req_in.write("small-fake-a==1.10.0")
+
+    runner.invoke(cli, ["--ask"], input="n\n")
+
+    check_call.assert_not_called()
+
+
+@mock.patch("piptools.sync.check_call")
+def test_sync_ask_accepted(check_call, runner):
+    """
+    Make sure pip is called when the confirmation is accepted (even if
+    --dry-run is given)
+    """
+    with open("requirements.txt", "w") as req_in:
+        req_in.write("small-fake-a==1.10.0")
+
+    runner.invoke(cli, ["--ask", "--dry-run"], input="y\n")
+
+    assert check_call.call_count == 2


### PR DESCRIPTION
This adds an `--ask` option to pip-sync which will first show the user what would change, like `--dry-run`, and then ask to confirm before continuing with the changes. This is supposed to address issue #671 without breaking existing workflows (in particular CI pipelines) and in a way that is well-established by existing tools like nmcli (network manager) and portage (Gentoo package manager).

This change requires a minor version bump.

**Changelog-friendly one-liner**: Add `--ask` option to `pip-sync`.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
