### PR TITLE
Add cron job for pipmaster env to GitHub actions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,30 @@
+name: cron
+
+on:
+  schedule:
+  # Run every day at 00:00 UTC
+  - cron: 0 0 * * *
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7]
+        env:
+        - TOXENV: pipmaster
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install tox
+      - name: Test with tox ${{ matrix.env.TOXENV }}
+        run: |
+          tox
+        env: ${{ matrix.env }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -22,9 +22,7 @@ jobs:
         with:
           version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          pip install tox
+        run: pip install tox
       - name: Test with tox ${{ matrix.env.TOXENV }}
-        run: |
-          tox
+        run: tox
         env: ${{ matrix.env }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install tox
         run: pip install tox
       - name: Test with tox ${{ matrix.env.TOXENV }}
         run: tox


### PR DESCRIPTION
Test pip-tools against pip master every day on the latest Ubuntu and Windows using GitHub Actions.
See an example of actions on my fork: https://github.com/atugushev/pip-tools/actions

Resolves #853.