### PR TITLE
Add network mark for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ testpaths = tests piptools
 filterwarnings =
     ignore::PendingDeprecationWarning:pip\._vendor.+
     ignore::DeprecationWarning:pip\._vendor.+
+markers =
+    network: mark tests that require internet access
 
 [flake8]
 max-line-length = 88

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -189,6 +189,7 @@ def test_find_links_no_emit(pip_conf, runner):
     assert "--find-links" not in out.stderr
 
 
+@pytest.mark.network
 def test_realistic_complex_sub_dependencies(runner):
     wheels_dir = "wheels"
 
@@ -224,6 +225,7 @@ def test_run_as_module_compile():
     assert status == 0
 
 
+@pytest.mark.network
 def test_editable_package(runner):
     """ piptools can compile an editable """
     fake_package_dir = os.path.join(TEST_DATA_PATH, "small_fake_package")
@@ -238,6 +240,7 @@ def test_editable_package(runner):
     assert "six==1.10.0" in out.stderr
 
 
+@pytest.mark.network
 def test_editable_package_vcs(runner):
     vcs_package = (
         "git+git://github.com/jazzband/pip-tools@"
@@ -252,6 +255,7 @@ def test_editable_package_vcs(runner):
     assert "click" in out.stderr  # dependency of pip-tools
 
 
+@pytest.mark.network
 def test_locally_available_editable_package_is_not_archived_in_cache_dir(
     tmpdir, runner
 ):
@@ -336,6 +340,7 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
     ],
 )
 @mark.parametrize(("generate_hashes",), [(True,), (False,)])
+@pytest.mark.network
 def test_url_package(runner, line, dependency, rewritten_line, generate_hashes):
     if rewritten_line is None:
         rewritten_line = line
@@ -349,6 +354,7 @@ def test_url_package(runner, line, dependency, rewritten_line, generate_hashes):
     assert dependency in out.stderr
 
 
+@pytest.mark.network
 def test_input_file_without_extension(runner):
     """
     piptools can compile a file without an extension,
@@ -481,6 +487,7 @@ def test_dry_run_quiet_option(runner):
     assert not out.stderr_bytes
 
 
+@pytest.mark.network
 def test_generate_hashes_with_editable(runner):
     small_fake_package_dir = os.path.join(TEST_DATA_PATH, "small_fake_package")
     small_fake_package_url = path_to_url(small_fake_package_dir)
@@ -502,6 +509,7 @@ def test_generate_hashes_with_editable(runner):
     assert expected in out.stderr
 
 
+@pytest.mark.network
 def test_generate_hashes_with_url(runner):
     with open("requirements.in", "w") as fp:
         fp.write(
@@ -519,6 +527,7 @@ def test_generate_hashes_with_url(runner):
     assert expected in out.stderr
 
 
+@pytest.mark.network
 def test_generate_hashes_verbose(runner):
     """
     The hashes generation process should show a progress.
@@ -533,6 +542,7 @@ def test_generate_hashes_verbose(runner):
 
 
 @fail_below_pip9
+@pytest.mark.network
 def test_filter_pip_markers(runner):
     """
     Check that pip-compile works with pip environment markers (PEP496)
@@ -547,6 +557,7 @@ def test_filter_pip_markers(runner):
     assert "unknown_package" not in out.stderr
 
 
+@pytest.mark.network
 def test_no_candidates(runner):
     with open("requirements", "w") as req_in:
         req_in.write("six>1.0b0,<1.0b0")
@@ -557,6 +568,7 @@ def test_no_candidates(runner):
     assert "Skipped pre-versions:" in out.stderr
 
 
+@pytest.mark.network
 def test_no_candidates_pre(runner):
     with open("requirements", "w") as req_in:
         req_in.write("six>1.0b0,<1.0b0")
@@ -604,6 +616,7 @@ def test_not_specified_input_file(runner):
     assert out.exit_code == 2
 
 
+@pytest.mark.network
 def test_stdin(runner):
     """
     Test compile requirements from STDIN.
@@ -640,6 +653,7 @@ def test_multiple_input_files_without_output_file(runner):
         ("--no-annotate", "six==1.10.0\n"),
     ],
 )
+@pytest.mark.network
 def test_annotate_option(pip_conf, runner, option, expected):
     """
     The output lines has have annotations if option is turned on.
@@ -657,6 +671,7 @@ def test_annotate_option(pip_conf, runner, option, expected):
     "option, expected",
     [("--allow-unsafe", "\nsetuptools=="), (None, "\n# setuptools==")],
 )
+@pytest.mark.network
 def test_allow_unsafe_option(runner, option, expected):
     """
     Unsafe packages are printed as expected with and without --allow-unsafe.
@@ -721,6 +736,7 @@ def test_build_isolation_option(
         (True, True, "small-fake-a==0.3b1"),
     ],
 )
+@pytest.mark.network
 def test_pre_option(pip_conf, runner, cli_option, infile_option, expected_package):
     """
     Tests pip-compile respects --pre option.

--- a/tests/test_repository_local.py
+++ b/tests/test_repository_local.py
@@ -1,3 +1,5 @@
+import pytest
+
 from piptools.repositories.local import LocalRequirementsRepository
 from piptools.utils import name_from_req
 
@@ -46,6 +48,7 @@ EXPECTED = {
 }
 
 
+@pytest.mark.network
 def test_get_hashes_local_repository_cache_miss(from_line, pypi_repository):
     existing_pins = {}
     local_repository = LocalRequirementsRepository(existing_pins, pypi_repository)

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -5,6 +5,7 @@ from piptools._compat.pip_compat import Link, Session, path_to_url
 from piptools.repositories.pypi import open_local_or_remote_file
 
 
+@pytest.mark.network
 def test_generate_hashes_all_platforms(from_line, pypi_repository):
     expected = {
         "sha256:04b133ef629ae2bc05f83d0b079a964494a9cd17914943e690c57209b44aae20",
@@ -55,6 +56,7 @@ def test_generate_hashes_all_platforms(from_line, pypi_repository):
         assert pypi_repository.get_hashes(ireq) == expected
 
 
+@pytest.mark.network
 def test_generate_hashes_without_interfering_with_each_other(
     from_line, pypi_repository
 ):

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -36,6 +36,7 @@ def mocked_repository():
         ]
     ),
 )
+@pytest.mark.network
 def test_editable_top_level_deps_preserved(
     base_resolver, mocked_repository, from_editable, input, expected
 ):


### PR DESCRIPTION
Add network marker for tests that require internet access

<!--- Describe the changes here. --->
Based on [#895 ](https://github.com/jazzband/pip-tools/issues/895) isssue I added `@pytest.mark.network` marker to some test wich require internet access.

Closes #895.

**Changelog-friendly one-liner**: Add `@pytest.mark.network` to tests which require the internet.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [x] Requested a review from another contributor.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).