### PR TITLE
Unify development requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 ## Project Contribution Guidelines
 
 Here are a few additional or emphasized guidelines to follow when contributing to pip-tools:
+- Install pip-tools in development mode and its test dependencies with `pip install -e .[testing]`.
 - Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
 - Always provide tests for your changes.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,0 @@
--e .
-mock
-pytest!=5.1.2
-pytest-rerunfailures
-wheel

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     setup_requires=["setuptools_scm"],
     install_requires=["click>=7", "six", "pip>=20.0"],
+    extras_require={
+        "testing": ["mock", "pytest", "pytest-rerunfailures"],
+        "coverage": ["pytest-cov"],
+    },
     zip_safe=False,
     entry_points={
         "console_scripts": [

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,12 @@ envlist =
 skip_missing_interpreters = True
 
 [testenv]
+extras =
+    testing
+    coverage: coverage
 deps =
     pipmaster: -e git+https://github.com/pypa/pip.git@master#egg=pip
     pip20.0: pip==20.0.*
-    mock
-    pytest!=5.1.2
-    pytest-rerunfailures
-    coverage: pytest-cov
 setenv =
     piplatest: PIP=latest
     pipmaster: PIP=master


### PR DESCRIPTION
- removes dev-requirements.txt in favor of extras_require in setup.py
- adds testing and coverage extras
- adds instruction to install pip-tools in development mode with test dependencies in CONTRIBUTING.md
- updates tox.ini to use extras
- unpins pytest dependency, since the fix has already [released](https://github.com/pytest-dev/pytest/releases/tag/5.1.3)