### PR TITLE
Add flaky mark to network tests in CI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -e .
 mock
 pytest!=5.1.2
+pytest-rerunfailures
 wheel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import json
 from contextlib import contextmanager
 from functools import partial
@@ -5,6 +6,7 @@ from functools import partial
 from click.testing import CliRunner
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
+import pytest
 from pytest import fixture
 
 from piptools._compat import (
@@ -102,6 +104,13 @@ class FakeInstalledDistribution(object):
 
     def as_requirement(self):
         return self.req
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        # Mark network tests as flaky
+        if item.get_closest_marker("network") and "CI" in os.environ:
+            item.add_marker(pytest.mark.flaky(reruns=3, reruns_delay=2))
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
-import os
 import json
+import os
 from contextlib import contextmanager
 from functools import partial
 
+import pytest
 from click.testing import CliRunner
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
-import pytest
 from pytest import fixture
 
 from piptools._compat import (

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     pip19.3: -e git+https://github.com/pypa/pip.git@master#egg=pip
     mock
     pytest!=5.1.2
+    pytest-rerunfailures
     coverage: pytest-cov
 setenv =
     piplatest: PIP=latest

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ commands_pre =
     piplatest: python -m pip install -U pip
     pip --version
 commands = pytest {posargs}
+passenv = CI
 
 [testenv:checkqa]
 basepython = python3


### PR DESCRIPTION
Add a `flaky` mark to tests with `network` mark to rerun if fails

Closes #918 

**Changelog-friendly one-liner**: Add a flaky mark to network tests in CI

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
