### PR TITLE
Exclude requirements with non-matching markers from pip-sync's merge stage

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -82,18 +82,19 @@ def merge(requirements, ignore_conflicts):
         # Limitation: URL requirements are merged by precise string match, so
         # "file:///example.zip#egg=example", "file:///example.zip", and
         # "example==1.0" will not merge with each other
-        key = key_from_ireq(ireq)
+        if ireq.match_markers():
+            key = key_from_ireq(ireq)
 
-        if not ignore_conflicts:
-            existing_ireq = by_key.get(key)
-            if existing_ireq:
-                # NOTE: We check equality here since we can assume that the
-                # requirements are all pinned
-                if ireq.specifier != existing_ireq.specifier:
-                    raise IncompatibleRequirements(ireq, existing_ireq)
+            if not ignore_conflicts:
+                existing_ireq = by_key.get(key)
+                if existing_ireq:
+                    # NOTE: We check equality here since we can assume that the
+                    # requirements are all pinned
+                    if ireq.specifier != existing_ireq.specifier:
+                        raise IncompatibleRequirements(ireq, existing_ireq)
 
-        # TODO: Always pick the largest specifier in case of a conflict
-        by_key[key] = ireq
+            # TODO: Always pick the largest specifier in case of a conflict
+            by_key[key] = ireq
     return by_key.values()
 
 


### PR DESCRIPTION
Fixes #925.

During sync's `merge` stage, any requirements with markers which don't match the current environment will be ignored. This allows successful syncing when the requirements.txt contains irrelevant (but properly marked) entries. The merge test has been updated to expect successful syncing in these cases.

**Changelog-friendly one-liner**: Exclude requirements with non-matching markers from sync operations.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).