### PR TITLE
Use python-version instead of version in GitHub Actions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: pip install tox
       - name: Test with tox ${{ matrix.env.TOXENV }}


### PR DESCRIPTION
It's deprecated since https://github.com/actions/setup-python/commit/6f6fcee33085a7661a7333ea58b4e32714b0f91f.

Demonstration: https://github.com/atugushev/pip-tools/commit/812a4c8d439a42ae4f3f72b5a82e39471d41e85b/checks

_I've cancelled travis and appveyor CIs manually to not waste a time._
