### PR TITLE
Skip commands_pre for checkqa and readme env in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,10 +45,12 @@ passenv = CI
 basepython = python3
 skip_install = True
 deps = pre-commit
+commands_pre =
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:readme]
 deps = twine
+commands_pre =
 commands = twine check {distdir}/*
 
 [travis:env]


### PR DESCRIPTION
Prevents [running](https://travis-ci.org/jazzband/pip-tools/jobs/597097879#L221) `commands_pre` on `tox -e checkqa` and `tox -e readme`.

P.S.
An alternative solution is to move everything from`commands_pre` to `commands`, but intuitively I've chosen the current one.