### PR TITLE
Remove useless excludes from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,4 @@ repos:
     hooks:
     - id: bandit
       language_version: python3.7
-      exclude: ^(tests|\.tox|\.eggs|\.venv|\.git)
+      exclude: ^tests/


### PR DESCRIPTION
"pre-commit won't check files that aren't checked in"
(c) @asottile

Thanks, Anthony!