### PR TITLE
Add setup_requires packages to tox.ini deps to be able to run tox without the network

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     mock
     pytest!=5.1.2
     pytest-rerunfailures
+    setuptools_scm
     coverage: pytest-cov
 setenv =
     piplatest: PIP=latest


### PR DESCRIPTION
This change allows running `tox` without the internet if virtual environment already created.

Every time you run tox, it tries to download packages from setup_requires and caches nothing. Hence you can't run tox without the internet, see:

```bash

$ tox -e checkqa
GLOB sdist-make: /Users/albert/Projects/pip-tools/setup.py
checkqa inst-nodeps: /Users/albert/Projects/pip-tools/.tox/.tmp/package/1/pip-tools-0.0.0.zip
ERROR: invocation failed (exit code 1), logfile: /Users/albert/Projects/pip-tools/.tox/checkqa/log/checkqa-13.log
================================== log start ==================================
Processing ./.tox/.tmp/package/1/pip-tools-0.0.0.zip
    ERROR: Command errored out with exit status 1:
     command: /Users/albert/Projects/pip-tools/.tox/checkqa/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/4x/rz_w89dx1z3bydfd6qpdjn_h0000gn/T/pip-req-build-ciz_e27o/setup.py'"'"'; __file__='"'"'/private/var/folders/4x/rz_w89dx1z3bydfd6qpdjn_h0000gn/T/pip-req-build-ciz_e27o/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /private/var/folders/4x/rz_w89dx1z3bydfd6qpdjn_h0000gn/T/pip-req-build-ciz_e27o/
    Complete output (25 lines):
    Download error on https://pypi.org/simple/setuptools-scm/: [Errno 8] nodename nor servname provided, or not known -- Some packages may not be found!
    Couldn't find index page for 'setuptools-scm' (maybe misspelled?)
    Download error on https://pypi.org/simple/: [Errno 8] nodename nor servname provided, or not known -- Some packages may not be found!
    No local packages or working download links found for setuptools-scm
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/4x/rz_w89dx1z3bydfd6qpdjn_h0000gn/T/pip-req-build-ciz_e27o/setup.py", line 53, in <module>
        "Topic :: System :: Systems Administration",
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/setuptools/__init__.py", line 144, in setup
        _install_setup_requires(attrs)
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/setuptools/__init__.py", line 139, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/setuptools/dist.py", line 719, in fetch_build_eggs
        replace_conflicting=True,
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/pkg_resources/__init__.py", line 782, in resolve
        replace_conflicting=replace_conflicting
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1065, in best_match
        return self.obtain(req, installer)
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1077, in obtain
        return installer(requirement)
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/setuptools/dist.py", line 786, in fetch_build_egg
        return cmd.easy_install(req)
      File "/Users/albert/Projects/pip-tools/.tox/checkqa/lib/python3.6/site-packages/setuptools/command/easy_install.py", line 673, in easy_install
        raise DistutilsError(msg)
    distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('setuptools-scm')
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
================================== log end ==================================
```


Adding setuptools_scpm to deps resolves the problem because easy_install will not trigger if the dependencies are already satisfied.

Thanks @gaborbernat for the hint!