### PR TITLE
Address TODO related to pip==19.3 release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,7 +91,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - PIP: master
-    - PIP: 19.3  # TODO remove after pip==19.3 being released
 
 install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,8 @@ environment:
           PIP: 19.0.3
         - TOXENV: py27-pip19.1
           PIP: 19.1
+        - TOXENV: py27-pip19.2.3
+          PIP: 19.2.3
         - TOXENV: py27-pip19.3
           PIP: 19.3
         - TOXENV: py27-pipmaster
@@ -38,6 +40,8 @@ environment:
           PIP: 19.0.3
         - TOXENV: py35-pip19.1
           PIP: 19.1
+        - TOXENV: py35-pip19.2.3
+          PIP: 19.2.3
         - TOXENV: py35-pip19.3
           PIP: 19.3
         - TOXENV: py35-pipmaster
@@ -59,6 +63,8 @@ environment:
           PIP: 19.0.3
         - TOXENV: py36-pip19.1
           PIP: 19.1
+        - TOXENV: py36-pip19.2.3
+          PIP: 19.2.3
         - TOXENV: py36-pip19.3
           PIP: 19.3
         - TOXENV: py36-pipmaster
@@ -80,6 +86,8 @@ environment:
           PIP: 19.0.3
         - TOXENV: py37-pip19.1-coverage
           PIP: 19.1
+        - TOXENV: py37-pip19.2.3
+          PIP: 19.2.3
         - TOXENV: py37-pip19.3
           PIP: 19.3
         - TOXENV: py37-pipmaster-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,6 @@ jobs:
           repo: jazzband/pip-tools
   allow_failures:
     - env: PIP=master
-    - env: PIP=19.3  # TODO remove after pip==19.3 being released
     - python: 3.8-dev
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - PIP=18.0
   - PIP=19.0.3
   - PIP=19.1
+  - PIP=19.2.3
   - PIP=19.3
   - PIP=latest
   - PIP=master

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .travis.yml for tox-travis.
-    py{27,35,36,37,38,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,19.0.3,19.1,19.3,latest,master}-coverage
+    py{27,35,36,37,38,py,py3}-pip{8.1.1,9.0.1,9.0.3,10.0.1,18.0,19.0.3,19.1,19.2.3,19.3,latest,master}-coverage
     checkqa
     readme
 skip_missing_interpreters = True
@@ -16,6 +16,7 @@ deps =
     pip18.0: pip==18.0
     pip19.0.3: pip==19.0.3
     pip19.1: pip==19.1
+    pip19.2.3: pip==19.2.3
     pip19.3: pip==19.3
     mock
     pytest!=5.1.2
@@ -31,6 +32,7 @@ setenv =
     pip18.0: PIP=18.0
     pip19.0.3: PIP==19.0.3
     pip19.1: PIP==19.1
+    pip19.2.3: PIP==19.2.3
     pip19.3: PIP==19.3
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
@@ -59,6 +61,7 @@ PIP =
     18.0: pip18.0
     19.0.3: pip19.0.3
     19.1: pip19.1
+    19.2.3: pip19.2.3
     19.3: pip19.3
     latest: piplatest
     master: pipmaster

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,7 @@ deps =
     pip18.0: pip==18.0
     pip19.0.3: pip==19.0.3
     pip19.1: pip==19.1
-    # TODO change it to pip==19.3 after pip being released
-    pip19.3: -e git+https://github.com/pypa/pip.git@master#egg=pip
+    pip19.3: pip==19.3
     mock
     pytest!=5.1.2
     pytest-rerunfailures


### PR DESCRIPTION
`pip==19.3` is released, see https://pypi.org/project/pip/19.3/.

Adds `pip==19.2.3` to the CI matrix (fixes coverage downgrade).