### PR TITLE
Fix python version from 3.7 to just 3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,20 +3,20 @@ repos:
     rev: 19.3b0
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.16
     hooks:
     - id: isort
-      language_version: python3.7
+      language_version: python3
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.7
     hooks:
     - id: flake8
-      language_version: python3.7
+      language_version: python3
   - repo: https://github.com/PyCQA/bandit
     rev: 1.6.0
     hooks:
     - id: bandit
-      language_version: python3.7
+      language_version: python3
       exclude: ^tests/


### PR DESCRIPTION
Fixes #954.

**Fix python version in pre-commit config from 3.7 to use just 3**

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).