### PR TITLE
Add python 3.8 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,10 +95,34 @@ environment:
         - TOXENV: py37-piplatest-coverage
           PIP: latest
 
+        - TOXENV: py38-pip9.0.1
+          PIP: 9.0.1
+        - TOXENV: py38-pip9.0.3
+          PIP: 9.0.3
+        - TOXENV: py38-pip10.0.1
+          PIP: 10.0.1
+        - TOXENV: py38-pip18.0
+          PIP: 18.0
+        - TOXENV: py38-pip19.0.3
+          PIP: 19.0.3
+        - TOXENV: py38-pip19.1
+          PIP: 19.1
+        - TOXENV: py38-pip19.2.3-coverage
+          PIP: 19.2.3
+        - TOXENV: py38-pip19.3-coverage
+          PIP: 19.3
+        - TOXENV: py38-pipmaster-coverage
+          PIP: master
+        - TOXENV: py38-piplatest-coverage
+          PIP: latest
+
 matrix:
   fast_finish: true
   allow_failures:
     - PIP: master
+  exclude:
+    # platform.linux_distribution() is removed in Python 3.8 (bpo-28167).
+    - TOXENV: py38-pip8.1.1
 
 install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         env:
         - TOXENV: pipmaster
         os: [ubuntu-latest, windows-latest]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 env:
   # NOTE: keep this in sync with envlist in tox.ini for tox-travis.
@@ -37,8 +38,13 @@ jobs:
   exclude:
     - python: "pypy3.5-6.0"
       env: PIP=8.1.1
+    # platform.linux_distribution() is removed in Python 3.8 (bpo-28167).
+    - python: "3.8"
+      env: PIP=8.1.1
 
     # Baseline jobs (included there/below).
+    - env: PIP=latest
+      python: "3.8"
     - env: PIP=latest
       python: "3.7"
     - env: PIP=latest
@@ -48,6 +54,8 @@ jobs:
     # Baseline stage to abort early.
     - stage: baseline
       env: PIP=latest
+      python: "3.8"
+    - env: PIP=latest
       python: "3.7"
     - env: PIP=latest
       python: "2.7"
@@ -62,11 +70,6 @@ jobs:
     - env: TOXENV=readme
       python: 2.7
       after_success: skip  # No need coverage
-
-    # Default stage (used with matrix).
-    - stage: test
-      python: 3.8-dev
-      env: PIP=latest
 
     # Only test pypy/pypy3 with latest pip.
     - env: PIP=latest
@@ -92,7 +95,6 @@ jobs:
           repo: jazzband/pip-tools
   allow_failures:
     - env: PIP=master
-    - python: 3.8-dev
 
 after_success:
   - travis_retry pip install codecov coveralls

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Systems Administration",


### PR DESCRIPTION
<!--- Describe the changes here. --->

Closes #948.

**Changelog-friendly one-liner**: Added python 3.8 support.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).