### PR TITLE
Add warn about requirements.txt file to "requirements without setup.py" section of readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,10 @@ Run it with ``pip-compile`` or  ``python -m piptools compile``. If you use
 multiple Python versions, you can run ``pip-compile`` as ``py -X.Y -m piptools
 compile`` on Windows and ``pythonX.Y -m piptools compile`` on other systems.
 
+**Note**: ensure you don't have ``requirements.txt`` if you compile
+``setup.py`` or ``requirements.in`` from scratch, otherwise, it might
+interfere.
+
 Requirements from ``setup.py``
 ------------------------------
 


### PR DESCRIPTION
<!--- Describe the changes here. --->

Resolves #744.

**Changelog-friendly one-liner**: Add warn about requirements.txt file to "requirements without setup.py" section of readme.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
