### PR TITLE
Add test for FakeRepository.get_hashes()

### DIFF
--- a/tests/test_fake_index.py
+++ b/tests/test_fake_index.py
@@ -78,3 +78,12 @@ def test_get_dependencies_rejects_non_pinned_requirements(from_line, repository)
     not_a_pinned_req = from_line("django>1.6")
     with raises(TypeError):
         repository.get_dependencies(not_a_pinned_req)
+
+
+def test_get_hashes(from_line, repository):
+    ireq = from_line("django==1.8")
+    expected = {
+        "test:123",
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    }
+    assert repository.get_hashes(ireq) == expected


### PR DESCRIPTION
<!--- Describe the changes here. --->
Closes #960 

**Changelog-friendly one-liner**: Add test for FakeRepository.get_hashes()
##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
