### PR TITLE
Cleanup ephemeral wheel cache properly

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -274,10 +274,10 @@ class PyPIRepository(BaseRepository):
                         os.environ["PIP_REQ_TRACKER"] = prev_tracker
                     else:
                         del os.environ["PIP_REQ_TRACKER"]
-                try:
-                    self.wheel_cache.cleanup()
-                except AttributeError:
-                    pass
+
+                # WheelCache.cleanup() introduced in pip==10.0.0
+                if PIP_VERSION >= (10,):
+                    wheel_cache.cleanup()
         return self._dependencies_cache[ireq]
 
     def get_hashes(self, ireq):

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -174,3 +174,19 @@ def test_pypirepo_calls_reqset_with_str_paths(pypi_repository, from_line):
         assert isinstance(called_with_finder, PackageFinder)
         assert called_with_ireq == ireq
         assert not pf_call_kwargs
+
+
+@pytest.mark.skipif(
+    PIP_VERSION < (10,), reason="WheelCache.cleanup() introduced in pip==10.0.0"
+)
+@mock.patch("piptools.repositories.pypi.PyPIRepository.resolve_reqs")  # to run offline
+@mock.patch("piptools.repositories.pypi.WheelCache")
+def test_wheel_cache_cleanup_called(
+    WheelCache, resolve_reqs, pypi_repository, from_line
+):
+    """
+    Test WheelCache.cleanup() called once after dependency resolution.
+    """
+    ireq = from_line("six==1.10.0")
+    pypi_repository.get_dependencies(ireq)
+    WheelCache.return_value.cleanup.assert_called_once_with()


### PR DESCRIPTION
<!--- Describe the changes here. --->

Attribute `self.wheel_cache` has been removed in f6de247b3f7a9e776325057a1e6cf6e48d34e7e7, thus `self.wheel_cache.cleanup()` will allways throw:

```pythin
AttributeError("'PyPIRepository' object has no attribute 'wheel_cache'")
```

and `wheel_cache.cleanup()` will never be called as supposed to be.

WheelCache.cleanup() has been introduced in `pip==10.0.0`. Try-except block has been refactored, for it's better to check the pip version explicitly (LBYL) rather than ask for forgiveness (EAFP).


**Changelog-friendly one-liner**: Fix dependency resolver to clean up the ephemeral wheel cache.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).