### PR TITLE
Unpin commented out unsafe packages

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -189,17 +189,18 @@ class OutputWriter(object):
                 yield MESSAGE_UNSAFE_PACKAGES
 
             for ireq in unsafe_requirements:
-                req = self._format_requirement(
-                    ireq,
-                    reverse_dependencies,
-                    primary_packages,
-                    marker=markers.get(key_from_ireq(ireq)),
-                    hashes=hashes,
-                )
+                ireq_key = key_from_ireq(ireq)
                 if not self.allow_unsafe:
-                    yield comment("# {}".format(req))
+                    yield comment("# {}".format(ireq_key))
                 else:
-                    yield req
+                    line = self._format_requirement(
+                        ireq,
+                        reverse_dependencies,
+                        primary_packages,
+                        marker=markers.get(ireq_key),
+                        hashes=hashes,
+                    )
+                    yield line
 
         # Yield even when there's no real content, so that blank files are written
         if not yielded:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -691,8 +691,7 @@ def test_annotate_option(pip_conf, runner, option, expected):
 
 
 @pytest.mark.parametrize(
-    "option, expected",
-    [("--allow-unsafe", "\nsetuptools=="), (None, "\n# setuptools==")],
+    "option, expected", [("--allow-unsafe", "\nsetuptools=="), (None, "\n# setuptools")]
 )
 @pytest.mark.network
 def test_allow_unsafe_option(runner, option, expected):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -129,7 +129,7 @@ def test_iter_lines__unsafe_dependencies(writer, from_line, allow_unsafe):
         "test==1.2",
         "",
         MESSAGE_UNSAFE_PACKAGES,
-        "setuptools==1.10.0" if allow_unsafe else comment("# setuptools==1.10.0"),
+        "setuptools==1.10.0" if allow_unsafe else comment("# setuptools"),
     )
     assert tuple(lines) == expected_lines
 
@@ -147,7 +147,7 @@ def test_iter_lines__unsafe_with_hashes(writer, from_line):
         "test==1.2 \\\n    --hash=FAKEHASH",
         "",
         MESSAGE_UNSAFE_PACKAGES_UNPINNED,
-        comment("# setuptools==1.10.0"),
+        comment("# setuptools"),
     )
     assert tuple(lines) == expected_lines
 


### PR DESCRIPTION
Resolves #973. See the proposal in https://github.com/jazzband/pip-tools/issues/973#issuecomment-547010219.

**Changelog-friendly one-liner**: Unpin commented out unsafe packages in `requirements.txt`.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).