### PR TITLE
Add short name version option (-V) to the CLI scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ venv/
 requirements.in
 requirements.txt
 .eggs/
+
+# Dynamic version file written by setuptools_scm
+/piptools/__version__.py

--- a/piptools/__init__.py
+++ b/piptools/__init__.py
@@ -1,6 +1,9 @@
 import locale
 
-from piptools.click import secho
+from .__version__ import __version__
+from .click import secho
+
+__all__ = ("__version__",)
 
 # Needed for locale.getpreferredencoding(False) to work
 # in pip._internal.utils.encoding.auto_decode

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -7,7 +7,7 @@ import tempfile
 
 from click.utils import safecall
 
-from .. import click
+from .. import __version__ as piptools_version, click
 from .._compat import install_req_from_line, parse_requirements
 from ..exceptions import PipToolsError
 from ..logging import log
@@ -33,7 +33,7 @@ pip_defaults = install_command.parser.get_default_values()
 
 
 @click.command(name="pip-compile")
-@click.version_option(None, "-V", "--version")
+@click.version_option(piptools_version, "-V", "--version")
 @click.pass_context
 @click.option("-v", "--verbose", count=True, help="Show more output")
 @click.option("-q", "--quiet", count=True, help="Give less output")

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -32,8 +32,8 @@ install_command = create_install_command()
 pip_defaults = install_command.parser.get_default_values()
 
 
-@click.command()
-@click.version_option()
+@click.command(name="pip-compile")
+@click.version_option(None, "-V", "--version")
 @click.pass_context
 @click.option("-v", "--verbose", count=True, help="Show more output")
 @click.option("-q", "--quiet", count=True, help="Give less output")

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -13,8 +13,8 @@ from ..utils import flat_map
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
 
-@click.command()
-@click.version_option()
+@click.command(name="pip-sync")
+@click.version_option(None, "-V", "--version")
 @click.option(
     "-a",
     "--ask",

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import sys
 
-from .. import click, sync
+from .. import __version__ as piptools_version, click, sync
 from .._compat import get_installed_distributions, parse_requirements
 from ..exceptions import PipToolsError
 from ..logging import log
@@ -14,7 +14,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
 
 @click.command(name="pip-sync")
-@click.version_option(None, "-V", "--version")
+@click.version_option(piptools_version, "-V", "--version")
 @click.option(
     "-a",
     "--ask",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ def read_file(filename):
 
 setup(
     name="pip-tools",
-    use_scm_version=True,
+    use_scm_version={
+        "write_to": "piptools/__version__.py",
+        "write_to_template": '__version__ = "{version}"',
+    },
     url="https://github.com/jazzband/pip-tools/",
     license="BSD",
     author="Vincent Driessen",

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -918,3 +918,11 @@ def test_options_in_requirements_file(runner, options):
 
     with open("requirements.txt") as reqs_txt:
         assert options in reqs_txt.read().splitlines()
+
+
+@pytest.mark.parametrize("version_option", ["-V", "--version"])
+def test_version_option(runner, version_option):
+    out = runner.invoke(cli, [version_option])
+
+    assert out.exit_code == 0, out
+    assert out.stdout.startswith("pip-compile, version")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -10,6 +10,7 @@ from pytest import mark
 
 from .utils import invoke
 
+import piptools
 from piptools._compat.pip_compat import PIP_VERSION, path_to_url
 from piptools.repositories import PyPIRepository
 from piptools.scripts.compile import cli
@@ -925,4 +926,4 @@ def test_version_option(runner, version_option):
     out = runner.invoke(cli, [version_option])
 
     assert out.exit_code == 0, out
-    assert out.stdout.startswith("pip-compile, version")
+    assert out.stdout.strip() == "pip-compile, version {}".format(piptools.__version__)

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -5,6 +5,7 @@ import pytest
 
 from .utils import invoke
 
+import piptools
 from piptools.scripts.sync import cli
 
 
@@ -181,4 +182,4 @@ def test_version_option(runner, version_option):
     out = runner.invoke(cli, [version_option])
 
     assert out.exit_code == 0, out
-    assert out.stdout.startswith("pip-sync, version")
+    assert out.stdout.strip() == "pip-sync, version {}".format(piptools.__version__)

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -174,3 +174,11 @@ def test_sync_ask_accepted(check_call, runner):
     runner.invoke(cli, ["--ask", "--dry-run"], input="y\n")
 
     assert check_call.call_count == 2
+
+
+@pytest.mark.parametrize("version_option", ["-V", "--version"])
+def test_version_option(runner, version_option):
+    out = runner.invoke(cli, [version_option])
+
+    assert out.exit_code == 0, out
+    assert out.stdout.startswith("pip-sync, version")


### PR DESCRIPTION
<!--- Describe the changes here. --->

Prints version on `pip-compile -V` and `pip-sync -V` commands (like `python -V` or `pip -V`), under the hood I had to do the following changes:
* Set a name to the cli commands, so that the tests can get the correct name (not just a `cli`)
* Use `setuptools-scm` at a build time and writes explicit version to `piptools/__version__.py`
* Add `piptools.__version__` variable

**Changelog-friendly one-liner**: Add short name version option `-V` to the CLI scripts.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).