### PR TITLE
Fix compatibility with pip master (pip>=19.4)

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -202,6 +202,10 @@ class PyPIRepository(BaseRepository):
                 )
                 resolver_kwargs["make_install_req"] = make_install_req
 
+            if PIP_VERSION >= (19, 4):
+                preparer_kwargs["session"] = self.session
+                del resolver_kwargs["session"]
+
             resolver = None
             preparer = None
             with RequirementTracker() as req_tracker:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -223,8 +223,7 @@ class PyPIRepository(BaseRepository):
                 if PIP_VERSION < (19, 4):
                     resolver.require_hashes = require_hashes
                     results = resolver._resolve_one(reqset, ireq)
-                else:  # pragma: no cover
-                    # TODO remove pragma after pip==19.4 being released
+                else:
                     results = resolver._resolve_one(reqset, ireq, require_hashes)
 
                 reqset.cleanup_files()


### PR DESCRIPTION
Moved `RequirementPreparer.session` to `Resolver.session`. See https://github.com/pypa/pip/pull/7290


Failed job: https://github.com/jazzband/pip-tools/commit/4dee581f2603e21271e9c7b38830507ed749357b/checks?check_suite_id=294004753


<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Add compatibility with `pip>=19.4`.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).