### PR TITLE
Add finder to RequirementPreparer() kwargs

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -203,6 +203,7 @@ class PyPIRepository(BaseRepository):
                 resolver_kwargs["make_install_req"] = make_install_req
 
             if PIP_VERSION >= (19, 4):
+                preparer_kwargs["finder"] = self.finder
                 preparer_kwargs["session"] = self.session
                 del resolver_kwargs["session"]
 


### PR DESCRIPTION
See https://github.com/pypa/pip/pull/7301

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Add compatibility with `pip>=19.4`.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
