### PR TITLE
Add --no-deps flag to pip-sync, which is simply passed through to pip install

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -28,6 +28,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     help="Only show what would happen, don't change anything",
 )
 @click.option("--force", is_flag=True, help="Proceed even if conflicts are found")
+@click.option("--no-deps", is_flag=True, help="Don't install package dependencies")
 @click.option(
     "-f",
     "--find-links",
@@ -72,6 +73,7 @@ def cli(
     ask,
     dry_run,
     force,
+    no_deps,
     find_links,
     index_url,
     extra_index_url,
@@ -120,6 +122,8 @@ def cli(
     install_flags = []
     for link in find_links or []:
         install_flags.extend(["-f", link])
+    if no_deps:
+        install_flags.append("--no-deps")
     if no_index:
         install_flags.append("--no-index")
     if index_url:

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -115,6 +115,7 @@ def test_merge_error(runner):
     [
         (["--find-links", "./libs"], ["-f", "./libs"]),
         (["--no-index"], ["--no-index"]),
+        (["--no-deps"], ["--no-deps"]),
         (["--index-url", "https://example.com"], ["-i", "https://example.com"]),
         (
             ["--extra-index-url", "https://foo", "--extra-index-url", "https://bar"],


### PR DESCRIPTION
`--no-deps` can now be provided to `pip-sync`, whereby `--no-deps` will be passed through to `pip install`, and un-locked deps of locked requirements will be either removed or not installed in the first place, in order to match the lockfile exactly, despite breaking package dependencies.

**Changelog-friendly one-liner**: `pip-sync` now accepts `--no-deps`, to match locked `txt`s exactly, ignoring any unlocked dependencies

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
