### PR TITLE
Moved global test constants to tests.constants module (issues_991).

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,5 @@
+import os
+
+TEST_DATA_PATH = os.path.join(os.path.split(__file__)[0], "test_data")
+MINIMAL_WHEELS_PATH = os.path.join(TEST_DATA_PATH, "minimal_wheels")
+PACKAGES_PATH = os.path.join(TEST_DATA_PATH, "packages")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -8,15 +8,12 @@ import pytest
 from click.testing import CliRunner
 from pytest import mark
 
+from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 from .utils import invoke
 
 from piptools._compat.pip_compat import PIP_VERSION, path_to_url
 from piptools.repositories import PyPIRepository
 from piptools.scripts.compile import cli
-
-TEST_DATA_PATH = os.path.join(os.path.split(__file__)[0], "test_data")
-MINIMAL_WHEELS_PATH = os.path.join(TEST_DATA_PATH, "minimal_wheels")
-PACKAGES_PATH = os.path.join(TEST_DATA_PATH, "packages")
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #991.

**Changelog-friendly one-liner**: Moved global test constants to tests.constants module.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
