### PR TITLE
Clean up piptools/_vendored

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,6 @@ branch = True
 source = .
 omit =
     piptools/_compat/*
-    piptools/_vendored/*
 
 [report]
 include = piptools/*, tests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ universal = 1
 license_file = LICENSE
 
 [tool:pytest]
-norecursedirs = .* build dist venv test_data piptools/_compat/* piptools/_vendored/*
 testpaths = tests piptools
 filterwarnings =
     ignore::PendingDeprecationWarning:pip\._vendor.+

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ universal = 1
 license_file = LICENSE
 
 [tool:pytest]
+norecursedirs = .* build dist venv test_data piptools/_compat/*
 testpaths = tests piptools
 filterwarnings =
     ignore::PendingDeprecationWarning:pip\._vendor.+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-# Trigger an import of piptools, effectively injecting piptools/_vendored in sys.path
-import piptools  # noqa


### PR DESCRIPTION
<!--- Describe the changes here. --->

Closes #993.

- Remove `piptools/_vendored/*` from `.coveragerc`
- Remove `norecursedirs` from `setup.cfg`
- Remove `import piptools` from `tests/__init__.py`

**Changelog-friendly one-liner**: Clean up piptools/_vendored

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).