### PR TITLE
Use `PACKAGES_PATH` constants in tests.test_sync.test_diff_with_editable.

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,6 +6,8 @@ from collections import Counter
 import mock
 import pytest
 
+from .constants import PACKAGES_PATH
+
 from piptools._compat import path_to_url
 from piptools.exceptions import IncompatibleRequirements
 from piptools.sync import dependency_tree, diff, merge, sync
@@ -228,9 +230,7 @@ def test_diff_leave_piptools_alone(fake_dist, from_line):
 
 def test_diff_with_editable(fake_dist, from_editable):
     installed = [fake_dist("small-fake-with-deps==0.0.1"), fake_dist("six==1.10.0")]
-    path_to_package = os.path.join(
-        os.path.dirname(__file__), "test_data", "packages", "small_fake_with_deps"
-    )
+    path_to_package = os.path.join(PACKAGES_PATH, "small_fake_with_deps")
     reqs = [from_editable(path_to_package)]
     to_install, to_uninstall = diff(reqs, installed)
 


### PR DESCRIPTION
Based on @atugushev [comment](https://github.com/jazzband/pip-tools/pull/1009#discussion_r350727207).
Do we have any other?

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Use `PACKAGES_PATH` constants in tests.test_sync.test_diff_with_editable.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
