### PR TITLE
Fix `test_locally_available_editable_package_is_not_archived_in_cache_dir` test fails when pytest ran with -k "not network".

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -239,7 +239,7 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
         with open("requirements.in", "w") as req_in:
             req_in.write("-e " + fake_package_dir)  # require editable fake package
 
-        out = runner.invoke(cli, ["-n"])
+        out = runner.invoke(cli, ["-n", "--rebuild"])
 
         assert out.exit_code == 0
         assert fake_package_dir in out.stderr


### PR DESCRIPTION
Fixes #1014.
**Changelog-friendly one-liner**: Fix `test_locally_available_editable_package_is_not_archived_in_cache_dir` test fails when pytest ran with -k "not network".

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
