### PR TITLE
Add --cache-dir option to pip-compile

### DIFF
--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -8,7 +8,6 @@ import sys
 from pip._vendor.packaging.requirements import Requirement
 
 from .exceptions import PipToolsError
-from .locations import CACHE_DIR
 from .utils import as_tuple, key_from_req, lookup_table
 
 
@@ -49,9 +48,7 @@ class DependencyCache(object):
     Where X.Y indicates the Python version.
     """
 
-    def __init__(self, cache_dir=None):
-        if cache_dir is None:
-            cache_dir = CACHE_DIR
+    def __init__(self, cache_dir):
         if not os.path.isdir(cache_dir):
             os.makedirs(cache_dir)
         py_version = ".".join(str(digit) for digit in sys.version_info[:2])

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -26,9 +26,9 @@ from .._compat import (
     path_to_url,
     url_to_path,
 )
-from ..cache import CACHE_DIR
 from ..click import progressbar
 from ..exceptions import NoCandidateFound
+from ..locations import CACHE_DIR
 from ..logging import log
 from ..utils import (
     create_install_command,

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -28,7 +28,6 @@ from .._compat import (
 )
 from ..click import progressbar
 from ..exceptions import NoCandidateFound
-from ..locations import CACHE_DIR
 from ..logging import log
 from ..utils import (
     create_install_command,
@@ -54,7 +53,7 @@ class PyPIRepository(BaseRepository):
     changed/configured on the Finder.
     """
 
-    def __init__(self, pip_args, build_isolation=False):
+    def __init__(self, pip_args, cache_dir, build_isolation=False):
         self.build_isolation = build_isolation
 
         # Use pip's parser for pip.conf management and defaults.
@@ -81,8 +80,9 @@ class PyPIRepository(BaseRepository):
 
         # Setup file paths
         self.freshen_build_caches()
-        self._download_dir = fs_str(os.path.join(CACHE_DIR, "pkgs"))
-        self._wheel_download_dir = fs_str(os.path.join(CACHE_DIR, "wheels"))
+        self._cache_dir = cache_dir
+        self._download_dir = fs_str(os.path.join(self._cache_dir, "pkgs"))
+        self._wheel_download_dir = fs_str(os.path.join(self._cache_dir, "wheels"))
 
     def freshen_build_caches(self):
         """
@@ -262,7 +262,7 @@ class PyPIRepository(BaseRepository):
             if not os.path.isdir(self._wheel_download_dir):
                 os.makedirs(self._wheel_download_dir)
 
-            wheel_cache = WheelCache(CACHE_DIR, self.options.format_control)
+            wheel_cache = WheelCache(self._cache_dir, self.options.format_control)
             prev_tracker = os.environ.get("PIP_REQ_TRACKER")
             try:
                 self._dependencies_cache[ireq] = self.resolve_reqs(

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -8,7 +8,6 @@ from itertools import chain, count
 
 from . import click
 from ._compat import install_req_from_line
-from .cache import DependencyCache
 from .logging import log
 from .utils import (
     UNSAFE_PACKAGES,
@@ -95,7 +94,7 @@ class Resolver(object):
         self,
         constraints,
         repository,
-        cache=None,
+        cache,
         prereleases=False,
         clear_caches=False,
         allow_unsafe=False,
@@ -108,8 +107,6 @@ class Resolver(object):
         self.our_constraints = set(constraints)
         self.their_constraints = set()
         self.repository = repository
-        if cache is None:
-            cache = DependencyCache()  # pragma: no cover
         self.dependency_cache = cache
         self.prereleases = prereleases
         self.clear_caches = clear_caches

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -176,10 +176,10 @@ pip_defaults = install_command.parser.get_default_values()
 )
 @click.option(
     "--cache-dir",
-    help="Specify a directory to cache dependency information (defaults to {})".format(
-        CACHE_DIR
-    ),
+    help="Store the cache data in DIRECTORY.",
+    default=CACHE_DIR,
     envvar="PIP_TOOLS_CACHE_DIR",
+    show_default=True,
     show_envvar=True,
     type=click.Path(file_okay=False, writable=True),
 )
@@ -359,9 +359,6 @@ def cli(
         log.debug("Configuration:")
         for find_link in dedup(repository.finder.find_links):
             log.debug("  -f {}".format(find_link))
-
-    if cache_dir is None:
-        cache_dir = CACHE_DIR
 
     try:
         resolver = Resolver(

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -272,7 +272,9 @@ def cli(
         for host in trusted_host:
             pip_args.extend(["--trusted-host", host])
 
-    repository = PyPIRepository(pip_args, build_isolation=build_isolation)
+    repository = PyPIRepository(
+        pip_args, build_isolation=build_isolation, cache_dir=cache_dir
+    )
 
     # Parse all constraints coming from --upgrade-package/-P
     upgrade_reqs_gen = (install_req_from_line(pkg) for pkg in upgrade_packages)

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -20,6 +20,7 @@ COMPILE_EXCLUDE_OPTIONS = {
     "--upgrade",
     "--upgrade-package",
     "--verbose",
+    "--cache-dir",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,8 +124,11 @@ def repository():
 
 
 @fixture
-def pypi_repository():
-    return PyPIRepository(["--index-url", PyPIRepository.DEFAULT_INDEX_URL])
+def pypi_repository(tmpdir):
+    return PyPIRepository(
+        ["--index-url", PyPIRepository.DEFAULT_INDEX_URL],
+        cache_dir=str(tmpdir / "pypi-repo"),
+    )
 
 
 @fixture

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -15,6 +15,11 @@ from piptools._compat.pip_compat import PIP_VERSION, path_to_url
 from piptools.scripts.compile import cli
 
 
+@pytest.fixture(autouse=True)
+def temp_dep_cache(tmpdir, monkeypatch):
+    monkeypatch.setenv("PIP_TOOLS_CACHE_DIR", str(tmpdir / "cache"))
+
+
 def test_default_pip_conf_read(pip_with_index_conf, runner):
     # preconditions
     with open("requirements.in", "w"):
@@ -519,7 +524,7 @@ def test_generate_hashes_verbose(pip_conf, runner):
 
 
 @pytest.mark.skipif(PIP_VERSION < (9,), reason="needs pip 9 or greater")
-def test_filter_pip_markers(runner):
+def test_filter_pip_markers(pip_conf, runner):
     """
     Check that pip-compile works with pip environment markers (PEP496)
     """
@@ -592,7 +597,7 @@ def test_not_specified_input_file(runner):
     assert out.exit_code == 2
 
 
-def test_stdin(runner):
+def test_stdin(pip_conf, runner):
     """
     Test compile requirements from STDIN.
     """

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -238,15 +238,14 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
     fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_with_deps")
     fake_package_dir = path_to_url(fake_package_dir)
 
-    with mock.patch("piptools.repositories.pypi.CACHE_DIR", new=str(cache_dir)):
-        with open("requirements.in", "w") as req_in:
-            req_in.write("-e " + fake_package_dir)  # require editable fake package
+    with open("requirements.in", "w") as req_in:
+        req_in.write("-e " + fake_package_dir)  # require editable fake package
 
-        out = runner.invoke(cli, ["-n", "--rebuild"])
+    out = runner.invoke(cli, ["-n", "--rebuild", "--cache-dir", str(cache_dir)])
 
-        assert out.exit_code == 0
-        assert fake_package_dir in out.stderr
-        assert "small-fake-a==0.1" in out.stderr
+    assert out.exit_code == 0
+    assert fake_package_dir in out.stderr
+    assert "small-fake-a==0.1" in out.stderr
 
     # we should not find any archived file in {cache_dir}/pkgs
     assert not os.listdir(os.path.join(str(cache_dir), "pkgs"))

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 
 import mock
 import pytest
-from click.testing import CliRunner
 from pytest import mark
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
@@ -74,13 +73,13 @@ def test_command_line_setuptools_read(pip_conf, runner):
         (["setup.py", "--output-file", "output.txt"], "output.txt"),
     ],
 )
-def test_command_line_setuptools_output_file(pip_conf, options, expected_output_file):
+def test_command_line_setuptools_output_file(
+    pip_conf, runner, options, expected_output_file
+):
     """
     Test the output files for setup.py as a requirement file.
     """
-    runner = CliRunner(mix_stderr=False)
-    with runner.isolated_filesystem():
-        package = open("setup.py", "w")
+    with open("setup.py", "w") as package:
         package.write(
             dedent(
                 """\
@@ -89,11 +88,10 @@ def test_command_line_setuptools_output_file(pip_conf, options, expected_output_
                 """
             )
         )
-        package.close()
 
-        out = runner.invoke(cli, options)
-        assert out.exit_code == 0
-        assert os.path.exists(expected_output_file)
+    out = runner.invoke(cli, options)
+    assert out.exit_code == 0
+    assert os.path.exists(expected_output_file)
 
 
 def test_find_links_option(runner):

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -18,8 +18,8 @@ class MockedPyPIRepository(PyPIRepository):
 
 
 @pytest.fixture
-def mocked_repository():
-    return MockedPyPIRepository(["--no-index"])
+def mocked_repository(tmpdir):
+    return MockedPyPIRepository(["--no-index"], cache_dir=str(tmpdir / "pypi-repo"))
 
 
 def test_editable_top_level_deps_preserved(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -348,10 +348,10 @@ def test_create_install_command():
         pytest.param(("example1.com", "example2.com:8080"), id="multiple hosts"),
     ],
 )
-def test_get_trusted_hosts(hosts):
+def test_get_trusted_hosts(hosts, tmpdir):
     """
     Test get_trusted_hosts(finder) returns a list of hosts.
     """
     pip_args = list(itertools.chain(*zip(["--trusted-host"] * len(hosts), hosts)))
-    repository = PyPIRepository(pip_args)
+    repository = PyPIRepository(pip_args, cache_dir=str(tmpdir / "pypi-repo"))
     assert tuple(get_trusted_hosts(repository.finder)) == hosts


### PR DESCRIPTION
Ensure tests pass without dependencies cached from previous tests. 

Running tests individually, I was seeing intermittent failures depending on whether the cache was populated or not, specifically `test_stdin` and `test_filter_pip_markers`. Also I refactored a test to use an existing fixture.

**Changelog-friendly one-liner**: Add `--cache-dir` option to `pip-compile`.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
