### PR TITLE
Use str.format instead of printf-style formatting

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -159,8 +159,8 @@ class Resolver(object):
                 raise RuntimeError(
                     "No stable configuration of concrete packages "
                     "could be found for the given constraints after "
-                    "%d rounds of resolving.\n"
-                    "This is likely a bug." % max_rounds
+                    "{max_rounds} rounds of resolving.\n"
+                    "This is likely a bug.".format(max_rounds=max_rounds)
                 )
 
             log.debug("")


### PR DESCRIPTION
The official Python 3 documentation doesn't recommend printf-style string formatting.
See https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting