### PR TITLE
Do the basic configuration of the builtin logging module

### DIFF
--- a/piptools/logging.py
+++ b/piptools/logging.py
@@ -1,7 +1,13 @@
 # coding: utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+
 from . import click
+
+# Initialise the builtin logging module for other component using it.
+# Ex: pip
+logging.basicConfig()
 
 
 class LogContext(object):


### PR DESCRIPTION
Fixes #292

In a normal use case, `pip` would take care of configuring the logging
module as intended. But due to our intrusive import of pip internals,
that part wasn't properly done.

I think this is a trivial change that we can skip tests for.

**Changelog-friendly one-liner**: Fix the `No handlers could be found for logger "pip.*"` error by configuring the builtin logging module.

##### Contributor checklist

- [ ] Provided the tests for the changes. 
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
