### PR TITLE
Upgrade click version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_data={},
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     setup_requires=["setuptools_scm"],
-    install_requires=["click>=6", "six"],
+    install_requires=["click>=7", "six"],
     zip_safe=False,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Change click version in setup.py.
fix #1038
**Changelog-friendly one-liner**: Upgrade click version in `setup.py`.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
