### PR TITLE
include the implementation in the depcache

### DIFF
--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -3,12 +3,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+import platform
 import sys
 
 from pip._vendor.packaging.requirements import Requirement
 
 from .exceptions import PipToolsError
 from .utils import as_tuple, key_from_req, lookup_table
+
+_PEP425_PY_TAGS = {"cpython": "cp", "pypy": "pp", "ironpython": "ip", "jython": "jy"}
+
+
+def _implementation_name():
+    """similar to PEP 425, however the minor version is separated from the
+    major to differentation "3.10" and "31.0".
+    """
+    implementation_name = platform.python_implementation().lower()
+    implementation = _PEP425_PY_TAGS.get(implementation_name, "??")
+    return "{}{}.{}".format(implementation, *sys.version_info)
 
 
 class CorruptCacheError(PipToolsError):
@@ -45,14 +57,14 @@ class DependencyCache(object):
 
         ~/.cache/pip-tools/depcache-pyX.Y.json
 
+    Where py indicates the Python implementation.
     Where X.Y indicates the Python version.
     """
 
     def __init__(self, cache_dir):
         if not os.path.isdir(cache_dir):
             os.makedirs(cache_dir)
-        py_version = ".".join(str(digit) for digit in sys.version_info[:2])
-        cache_filename = "depcache-py{}.json".format(py_version)
+        cache_filename = "depcache-{}.json".format(_implementation_name())
 
         self._cache_file = os.path.join(cache_dir, cache_filename)
         self._cache = None


### PR DESCRIPTION
Resolves #1049

**Changelog-friendly one-liner**: Ensure that depcache considers the python implementation such that (for example) cpython3.6 does not poison the results of pypy3.6.

##### Contributor checklist

- [ ] Provided the tests for the changes. **(I did not, this doesn't really fit well into the current testsuite)**
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
