### PR TITLE
Replace outdated link with rationale for pinning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ pip-tools = pip-compile + pip-sync
 ==================================
 
 A set of command line tools to help you keep your ``pip``-based packages fresh,
-even when you've pinned them.  `You do pin them, right?`_
+even when you've pinned them.  You do pin them, right? (In building your Python application and its dependencies for production, you want to make sure that your builds are predictable and deterministic.)
 
 .. image:: https://github.com/jazzband/pip-tools/raw/master/img/pip-tools-overview.png
    :alt: pip-tools overview for phase II


### PR DESCRIPTION
Closes #668 
Refs (supersedes) https://github.com/toanant/pip-tools/pull/1

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Replace outdated link in Readme with rationale for pinning

##### Contributor checklist

- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
