### PR TITLE
Make the --build-isolation flag set on by default for pip-compile.

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -46,7 +46,7 @@ class PyPIRepository(BaseRepository):
     changed/configured on the Finder.
     """
 
-    def __init__(self, pip_args, cache_dir, build_isolation=False):
+    def __init__(self, pip_args, cache_dir, build_isolation=True):
         # Use pip's parser for pip.conf management and defaults.
         # General options (find_links, index_url, extra_index_url, trusted_host,
         # and pre) are deferred to pip.

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -157,7 +157,7 @@ pip_defaults = install_command.parser.get_default_values()
 @click.option(
     "--build-isolation/--no-build-isolation",
     is_flag=True,
-    default=False,
+    default=True,
     help="Enable isolation when building a modern source distribution. "
     "Build dependencies specified by PEP 518 must be already installed "
     "if build isolation is disabled.",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -254,7 +254,7 @@ def test_force_text(value, expected_text):
         (["--annotate"], "pip-compile"),
         (["--index"], "pip-compile"),
         (["--max-rounds=10"], "pip-compile"),
-        (["--no-build-isolation"], "pip-compile"),
+        (["--build-isolation"], "pip-compile"),
         # Check options with multiple values
         (
             ["--find-links", "links1", "--find-links", "links2"],


### PR DESCRIPTION
Fixes #1030 

Make the --build-isolation flag set on by default for pip-compile.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
