### PR TITLE
Normalize cache_dir path to be compatible with pip v20

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -28,6 +28,7 @@ from .pip_compat import (
     is_dir_url,
     is_file_url,
     is_vcs_url,
+    normalize_path,
     parse_requirements,
     path_to_url,
     stdlib_pkgs,

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -72,6 +72,7 @@ Link = do_import("models.link", "Link", old_path="index")
 Session = do_import("_vendor.requests.sessions", "Session")
 Resolver = do_import("legacy_resolve", "Resolver", old_path="resolve")
 WheelCache = do_import("cache", "WheelCache", old_path="wheel")
+normalize_path = do_import("utils.misc", "normalize_path", old_path="utils")
 
 # pip 18.1 has refactored InstallRequirement constructors use by pip-tools.
 if PIP_VERSION < (18, 1):

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -24,6 +24,7 @@ from .._compat import (
     is_dir_url,
     is_file_url,
     is_vcs_url,
+    normalize_path,
     path_to_url,
     url_to_path,
 )
@@ -62,6 +63,8 @@ class PyPIRepository(BaseRepository):
         # and pre) are deferred to pip.
         self.command = create_install_command()
         self.options, _ = self.command.parse_args(pip_args)
+        if self.options.cache_dir:
+            self.options.cache_dir = normalize_path(self.options.cache_dir)
 
         self.session = self.command._build_session(self.options)
         self.finder = self.command._build_package_finder(
@@ -81,7 +84,7 @@ class PyPIRepository(BaseRepository):
 
         # Setup file paths
         self.freshen_build_caches()
-        self._cache_dir = cache_dir
+        self._cache_dir = normalize_path(cache_dir)
         self._download_dir = fs_str(os.path.join(self._cache_dir, "pkgs"))
         self._wheel_download_dir = fs_str(os.path.join(self._cache_dir, "wheels"))
 


### PR DESCRIPTION
Fixes #1061

Always use normalized path for cache directory as it is required in newer versions of pip

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
