### PR TITLE
Prevent output of erroneous line continuation

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -247,8 +247,6 @@ class OutputWriter(object):
         if required_by:
             annotation = ", ".join(sorted(required_by))
             line = "{:24}{}{}".format(
-                line,
-                " \\\n    " if ireq_hashes else "  ",
-                comment("# via " + annotation),
+                line, " \n    " if ireq_hashes else "  ", comment("# via " + annotation)
             )
         return line

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -82,7 +82,9 @@ def test_format_requirement_annotation_with_hash(from_line, writer):
     reverse_dependencies = {"test": ["xyz"]}
     hashes = {ireqs[0]: {"FAKEHASH"}}
 
-    lines = writer._iter_lines(ireqs, reverse_dependencies=reverse_dependencies, hashes=hashes)
+    lines = writer._iter_lines(
+        ireqs, reverse_dependencies=reverse_dependencies, hashes=hashes
+    )
 
     expected_lines = (
         "test==1.2 \\\n    --hash=FAKEHASH \n    " + comment("# via xyz"),

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -74,6 +74,23 @@ def test_format_requirement_annotation_lower_case(from_line, writer):
     ) == "test==1.2                 " + comment("# via xyz")
 
 
+def test_format_requirement_annotation_with_hash(from_line, writer):
+    writer.emit_header = False
+    writer.generate_hashes = True
+    writer.annotate = True
+    ireqs = [from_line("test==1.2")]
+    reverse_dependencies = {"test": ["xyz"]}
+    hashes = {ireqs[0]: {"FAKEHASH"}}
+
+    lines = writer._iter_lines(ireqs, reverse_dependencies=reverse_dependencies, hashes=hashes)
+
+    expected_lines = (
+        "test==1.2 \\\n    --hash=FAKEHASH \n    " + comment("# via xyz"),
+    )
+
+    assert tuple(lines) == expected_lines
+
+
 def test_format_requirement_not_for_primary(from_line, writer):
     "Primary packages should not get annotated."
     ireq = from_line("test==1.2")


### PR DESCRIPTION
Fixes #1063

**Changelog-friendly one-liner**: Prevent output of erroneous line continuation preceding an annotation comment

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
