### PR TITLE
Some cleanup

### DIFF
--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from .._compat import FAVORITE_HASH
 from .base import BaseRepository
 
-from piptools.utils import as_tuple, key_from_req, make_install_requirement
+from piptools.utils import as_tuple, key_from_ireq, make_install_requirement
 
 
 def ireq_satisfied_by_existing_pin(ireq, existing_pin):
@@ -56,7 +56,7 @@ class LocalRequirementsRepository(BaseRepository):
         self.repository.freshen_build_caches()
 
     def find_best_match(self, ireq, prereleases=None):
-        key = key_from_req(ireq.req)
+        key = key_from_ireq(ireq)
         existing_pin = self.existing_pins.get(key)
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             project, version, _ = as_tuple(existing_pin)
@@ -70,7 +70,7 @@ class LocalRequirementsRepository(BaseRepository):
         return self.repository.get_dependencies(ireq)
 
     def get_hashes(self, ireq):
-        key = key_from_req(ireq.req)
+        key = key_from_ireq(ireq)
         existing_pin = self.existing_pins.get(key)
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             hashes = existing_pin.options.get("hashes", {})

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -17,7 +17,6 @@ from .utils import (
     is_pinned_requirement,
     is_url_requirement,
     key_from_ireq,
-    key_from_req,
 )
 
 green = partial(click.style, fg="green")
@@ -31,7 +30,7 @@ class RequirementSummary(object):
 
     def __init__(self, ireq):
         self.req = ireq.req
-        self.key = key_from_req(ireq.req)
+        self.key = key_from_ireq(ireq)
         self.extras = str(sorted(ireq.extras))
         self.specifier = str(ireq.specifier)
 
@@ -274,12 +273,10 @@ class Resolver(object):
         if has_changed:
             log.debug("")
             log.debug("New dependencies found in this round:")
-            for new_dependency in sorted(diff, key=lambda req: key_from_req(req.req)):
+            for new_dependency in sorted(diff, key=key_from_ireq):
                 log.debug("  adding {}".format(new_dependency))
             log.debug("Removed dependencies in this round:")
-            for removed_dependency in sorted(
-                removed, key=lambda req: key_from_req(req.req)
-            ):
+            for removed_dependency in sorted(removed, key=key_from_ireq):
                 log.debug("  removing {}".format(removed_dependency))
 
         # Store the last round's results in the their_constraints

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -22,7 +22,6 @@ from ..utils import (
     get_trusted_hosts,
     is_pinned_requirement,
     key_from_ireq,
-    key_from_req,
 )
 from ..writer import OutputWriter
 
@@ -279,7 +278,7 @@ def cli(
     # Parse all constraints coming from --upgrade-package/-P
     upgrade_reqs_gen = (install_req_from_line(pkg) for pkg in upgrade_packages)
     upgrade_install_reqs = {
-        key_from_req(install_req.req): install_req for install_req in upgrade_reqs_gen
+        key_from_ireq(install_req): install_req for install_req in upgrade_reqs_gen
     }
 
     existing_pins_to_upgrade = set()
@@ -303,7 +302,7 @@ def cli(
         # constraints, and separately gather pins to be upgraded
         existing_pins = {}
         for ireq in filter(is_pinned_requirement, ireqs):
-            key = key_from_req(ireq.req)
+            key = key_from_ireq(ireq)
             if key in upgrade_install_reqs:
                 existing_pins_to_upgrade.add(key)
             else:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -186,7 +186,7 @@ def lookup_table(values, key=None, keyval=None, unique=False, use_lists=False):
     ...     'q': ['qux', 'quux']
     ... }
 
-    The values of the resulting lookup table will be values, not sets.
+    The values of the resulting lookup table will be lists, not sets.
 
     For extra power, you can even change the values while building up the LUT.
     To do so, use the `keyval` function instead of the `key` arg:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -137,7 +137,7 @@ def as_tuple(ireq):
     if not is_pinned_requirement(ireq):
         raise TypeError("Expected a pinned InstallRequirement, got {}".format(ireq))
 
-    name = key_from_req(ireq.req)
+    name = key_from_ireq(ireq)
     version = next(iter(ireq.specifier._specs))._spec[1]
     extras = tuple(sorted(ireq.extras))
     return name, version, extras

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from piptools.resolver import Resolver
 from piptools.utils import (
     as_tuple,
     is_url_requirement,
+    key_from_ireq,
     key_from_req,
     make_install_requirement,
 )
@@ -51,21 +52,18 @@ class FakeRepository(BaseRepository):
 
         versions = list(
             ireq.specifier.filter(
-                self.index[key_from_req(ireq.req)], prereleases=prereleases
+                self.index[key_from_ireq(ireq)], prereleases=prereleases
             )
         )
         if not versions:
             tried_versions = [
                 InstallationCandidate(ireq.name, version, "https://fake.url.foo")
-                for version in self.index[key_from_req(ireq.req)]
+                for version in self.index[key_from_ireq(ireq)]
             ]
             raise NoCandidateFound(ireq, tried_versions, ["https://fake.url.foo"])
         best_version = max(versions, key=Version)
         return make_install_requirement(
-            key_from_req(ireq.req),
-            best_version,
-            ireq.extras,
-            constraint=ireq.constraint,
+            key_from_ireq(ireq), best_version, ireq.extras, constraint=ireq.constraint
         )
 
     def get_dependencies(self, ireq):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,9 +17,9 @@ def _read_cache_file_helper(to_write):
     :param str to_write: the content to write to the file
     :yield: the path to the temporary file
     """
+    # Create the file and write to it
+    cache_file = NamedTemporaryFile(mode="w", delete=False)
     try:
-        # Create the file and write to it
-        cache_file = NamedTemporaryFile(mode="w", delete=False)
         cache_file.write(to_write)
         cache_file.close()
 


### PR DESCRIPTION
Some cleanup that was pulled out of a no-longer-useful branch I had been working on:

- Fixed a docstring
- Standardized on `key_from_ireq` for use with `InstallRequirement`s. It had been a mix of `key_from_ireq(ireq)` and `key_from_req(ireq.req)`.
- Ensured that a `finally` block can run even if `NamedTemporaryFile` construction raises

**Changelog-friendly one-liner**: Minor cleanup, including standardizing on key_from_ireq