### PR TITLE
Pass arbitrary args to 'pip' from pip-compile and pip-sync, with '--pip-args'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,16 @@ Or to output to standard output, use ``--output-file=-``:
     $ pip-compile --output-file=- > requirements.txt
     $ pip-compile - --output-file=- < requirements.in > requirements.txt
 
+Forwarding options to ``pip``
+-----------------------------
+
+Any valid ``pip`` flags or arguments may be passed on with ``pip-compile``'s
+``--pip-args`` option, e.g.
+
+.. code-block:: bash
+
+    $ pip-compile requirements.in --pip-args '--retries 10 --timeout 30'
+
 Configuration
 -------------
 
@@ -367,6 +377,13 @@ line arguments, e.g.
     $ pip-sync dev-requirements.txt requirements.txt
 
 Passing in empty arguments would cause it to default to ``requirements.txt``.
+
+Any valid ``pip install`` flags or arguments may be passed with ``pip-sync``'s
+``--pip-args`` option, e.g.
+
+.. code-block:: bash
+
+    $ pip-sync requirements.txt --pip-args '--no-cache-dir --no-deps'
 
 If you use multiple Python versions, you can run ``pip-sync`` as
 ``py -X.Y -m piptools sync ...`` on Windows and

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import shlex
 import sys
 import tempfile
 
@@ -177,6 +178,7 @@ pip_defaults = install_command.parser.get_default_values()
     show_envvar=True,
     type=click.Path(file_okay=False, writable=True),
 )
+@click.option("--pip-args", help="Arguments to pass directly to the pip command.")
 def cli(
     ctx,
     verbose,
@@ -204,6 +206,7 @@ def cli(
     build_isolation,
     emit_find_links,
     cache_dir,
+    pip_args,
 ):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbosity = verbose - quiet
@@ -247,6 +250,7 @@ def cli(
     # Setup
     ###
 
+    right_args = shlex.split(pip_args or "")
     pip_args = []
     if find_links:
         for link in find_links:
@@ -268,6 +272,7 @@ def cli(
 
     if not build_isolation:
         pip_args.append("--no-build-isolation")
+    pip_args.extend(right_args)
 
     repository = PyPIRepository(pip_args, cache_dir=cache_dir)
 

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import itertools
 import os
+import shlex
 import sys
 
 from pip._internal.commands import create_command
@@ -73,6 +74,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     "the private key and the certificate in PEM format.",
 )
 @click.argument("src_files", required=False, type=click.Path(exists=True), nargs=-1)
+@click.option("--pip-args", help="Arguments to pass directly to pip install.")
 def cli(
     ask,
     dry_run,
@@ -87,6 +89,7 @@ def cli(
     cert,
     client_cert,
     src_files,
+    pip_args,
 ):
     """Synchronize virtual environment with requirements.txt."""
     if not src_files:
@@ -139,7 +142,7 @@ def cli(
         user_only=user_only,
         cert=cert,
         client_cert=client_cert,
-    )
+    ) + shlex.split(pip_args or "")
     sys.exit(
         sync.sync(
             to_install,

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -730,7 +730,7 @@ def test_allow_unsafe_option(pip_conf, monkeypatch, runner, option, expected):
 @mock.patch("piptools.scripts.compile.parse_requirements")
 def test_cert_option(parse_requirements, runner, option, attr, expected):
     """
-    The options --cert and --client-crt have to be passed to the PyPIRepository.
+    The options --cert and --client-cert have to be passed to the PyPIRepository.
     """
     with open("requirements.in", "w"):
         pass
@@ -757,6 +757,20 @@ def test_build_isolation_option(parse_requirements, runner, option, expected):
 
     # Ensure the options in parse_requirements has the expected build_isolation option
     assert parse_requirements.call_args.kwargs["options"].build_isolation is expected
+
+
+@mock.patch("piptools.scripts.compile.PyPIRepository")
+def test_forwarded_args(PyPIRepository, runner):
+    """
+    Test the forwarded cli args (--pip-args 'arg...') are passed to the pip command.
+    """
+    with open("requirements.in", "w"):
+        pass
+
+    cli_args = ("--no-annotate", "--generate-hashes")
+    pip_args = ("--no-color", "--isolated", "--disable-pip-version-check")
+    runner.invoke(cli, cli_args + ("--pip-args", " ".join(pip_args)))
+    assert set(pip_args).issubset(set(PyPIRepository.call_args.args[0]))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,6 +265,15 @@ def test_force_text(value, expected_text):
         (["-f", "συνδέσεις"], "pip-compile --find-links='συνδέσεις'"),
         (["-o", "my file.txt"], "pip-compile --output-file='my file.txt'"),
         (["-o", "απαιτήσεις.txt"], "pip-compile --output-file='απαιτήσεις.txt'"),
+        # Check '--pip-args' (forwarded) arguments
+        (
+            ["--pip-args", "--disable-pip-version-check"],
+            "pip-compile --pip-args='--disable-pip-version-check'",
+        ),
+        (
+            ["--pip-args", "--disable-pip-version-check --isolated"],
+            "pip-compile --pip-args='--disable-pip-version-check --isolated'",
+        ),
     ],
 )
 def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):
@@ -273,6 +282,16 @@ def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):
     """
     with compile_cli.make_context("pip-compile", cli_args) as ctx:
         assert get_compile_command(ctx) == expected_command
+
+
+def test_get_compile_command_escaped_filenames(tmpdir_cwd):
+    """
+    Test that get_compile_command output (re-)escapes ' -- '-escaped filenames.
+    """
+    with open("--requirements.in", "w"):
+        pass
+    with compile_cli.make_context("pip-compile", ["--", "--requirements.in"]) as ctx:
+        assert get_compile_command(ctx) == "pip-compile -- --requirements.in"
 
 
 @mark.parametrize(


### PR DESCRIPTION
~Technically, pass all args after the second standalone '--' arg, whether or not they're consecutive.~

Fixes #321

```console
$ pip-sync <pip-sync arg/flag>... --pip-args '<pip install arg/flag>...'
$ pip-sync <pip-sync arg/flag>... --pip-args '<pip install arg/flag>...'
```

**Changelog-friendly one-liners**: 

- ~~Any flags or arguments following two standalone double-dashes (' -- -- ') at the end of pip-compile or pip-sync's argument list are passed on to pip~~
- pip-compile output headers are now more accurate when ' -- ' is used to escape filenames
- pip-compile and pip-sync now pass anything provided to the new --pip-args option on to pip

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
