### PR TITLE
flake8 ignore E203; see https://github.com/psf/black#slices

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ markers =
 [flake8]
 max-line-length = 88
 exclude = build/*, dist/*, pip_tools.egg-info/*, piptools/_compat/*, .tox/*, .venv/*, .git/*, .eggs/*
+extend-ignore = E203  # E203 conflicts with PEP8; see https://github.com/psf/black#slices
 
 [isort]
 combine_as_imports = True

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,7 +7,7 @@ from piptools.resolver import combine_install_requirements
 @pytest.mark.parametrize(
     ("input", "expected", "prereleases", "unsafe_constraints"),
     (
-        (tup + (False, set())[len(tup) - 2 :])  # noqa: E203
+        (tup + (False, set())[len(tup) - 2 :])
         for tup in [
             (["Django"], ["django==1.8"]),
             (


### PR DESCRIPTION
As requested in review for #1080, have flake8 consistently ignore any E203 occurrences. 

**Changelog-friendly one-liner**: Not applicable, I think.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
