### PR TITLE
Unpin tox in AppVeyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -136,12 +136,6 @@ matrix:
 
 install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-
-    # Temporary workaround to prevent tests failing.
-    # See GH-983 for the details.
-    # TODO remove this after tox>3.14.0 being released
-    - pip install "virtualenv>=16.0.0"
-
     - pip install tox
 
 build: false


### PR DESCRIPTION
Resolve TODO comment since `tox==3.14.5` is [released](https://tox.readthedocs.io/en/latest/changelog.html#v3-14-5-2020-02-16).