### PR TITLE
Remove build_isolation param from PyPIRepository constructor

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -46,7 +46,7 @@ class PyPIRepository(BaseRepository):
     changed/configured on the Finder.
     """
 
-    def __init__(self, pip_args, cache_dir, build_isolation=True):
+    def __init__(self, pip_args, cache_dir):
         # Use pip's parser for pip.conf management and defaults.
         # General options (find_links, index_url, extra_index_url, trusted_host,
         # and pre) are deferred to pip.
@@ -55,7 +55,6 @@ class PyPIRepository(BaseRepository):
         if self.options.cache_dir:
             self.options.cache_dir = normalize_path(self.options.cache_dir)
 
-        self.options.build_isolation = build_isolation
         self.options.require_hashes = False
         self.options.ignore_dependencies = False
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -266,9 +266,10 @@ def cli(
         for host in trusted_host:
             pip_args.extend(["--trusted-host", host])
 
-    repository = PyPIRepository(
-        pip_args, build_isolation=build_isolation, cache_dir=cache_dir
-    )
+    if not build_isolation:
+        pip_args.append("--no-build-isolation")
+
+    repository = PyPIRepository(pip_args, cache_dir=cache_dir)
 
     # Parse all constraints coming from --upgrade-package/-P
     upgrade_reqs_gen = (install_req_from_line(pkg) for pkg in upgrade_packages)
@@ -283,9 +284,7 @@ def cli(
     if not upgrade and os.path.exists(output_file.name):
         # Use a temporary repository to ensure outdated(removed) options from
         # existing requirements.txt wouldn't get into the current repository.
-        tmp_repository = PyPIRepository(
-            pip_args, build_isolation=build_isolation, cache_dir=cache_dir
-        )
+        tmp_repository = PyPIRepository(pip_args, cache_dir=cache_dir)
         ireqs = parse_requirements(
             output_file.name,
             finder=tmp_repository.finder,

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -721,22 +721,19 @@ def test_cert_option(parse_requirements, runner, option, attr, expected):
 @pytest.mark.parametrize(
     "option, expected", [("--build-isolation", True), ("--no-build-isolation", False)]
 )
-@mock.patch("piptools.scripts.compile.PyPIRepository")
-@mock.patch("piptools.scripts.compile.parse_requirements")  # prevent to parse
-def test_build_isolation_option(
-    parse_requirements, PyPIRepository, runner, option, expected
-):
+@mock.patch("piptools.scripts.compile.parse_requirements")
+def test_build_isolation_option(parse_requirements, runner, option, expected):
     """
     A value of the --build-isolation/--no-build-isolation flag
-    must be passed to the PyPIRepository.
+    must be passed to parse_requirements().
     """
     with open("requirements.in", "w"):
         pass
 
     runner.invoke(cli, [option])
 
-    # Ensure the build_isolation option in PyPIRepository has the expected value.
-    assert PyPIRepository.call_args.kwargs["build_isolation"] is expected
+    # Ensure the options in parse_requirements has the expected build_isolation option
+    assert parse_requirements.call_args.kwargs["options"].build_isolation is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Pass `--build-isolation/--no-build-isolation` option to the `pip_args` of `PyPIRepository` constructor.

Addresses https://github.com/jazzband/pip-tools/pull/1055#discussion_r377464546.
