### PR TITLE
Compile editables that are both primary reqs and constraints

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -60,7 +60,8 @@ def combine_install_requirements(ireqs):
     combined_ireq = copy.deepcopy(source_ireqs[0])
     for ireq in source_ireqs[1:]:
         # NOTE we may be losing some info on dropped reqs here
-        combined_ireq.req.specifier &= ireq.req.specifier
+        if combined_ireq.req is not None and ireq.req is not None:
+            combined_ireq.req.specifier &= ireq.req.specifier
         combined_ireq.constraint &= ireq.constraint
         # Return a sorted, de-duped tuple of extras
         combined_ireq.extras = tuple(
@@ -220,13 +221,6 @@ class Resolver(object):
 
         """
         for _, ireqs in full_groupby(constraints, key=key_from_ireq):
-            ireqs = list(ireqs)
-            editable_ireq = next((ireq for ireq in ireqs if ireq.editable), None)
-            if editable_ireq:
-                # ignore all the other specs: the editable one is the one that counts
-                yield editable_ireq
-                continue
-
             yield combine_install_requirements(ireqs)
 
     def _resolve_one_round(self):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -219,6 +219,29 @@ def test_editable_package(pip_conf, runner):
     assert "small-fake-a==0.1" in out.stderr
 
 
+@pytest.mark.parametrize(("req_editable",), [(True,), (False,)])
+def test_editable_package_in_constraints(pip_conf, runner, req_editable):
+    """
+    piptools can compile an editable that appears in both primary requirements
+    and constraints
+    """
+    fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_with_deps")
+    fake_package_dir = path_to_url(fake_package_dir)
+
+    with open("constraints.txt", "w") as constraints_in:
+        constraints_in.write("-e " + fake_package_dir)
+
+    with open("requirements.in", "w") as req_in:
+        prefix = "-e " if req_editable else ""
+        req_in.write(prefix + fake_package_dir + "\n-c constraints.txt")
+
+    out = runner.invoke(cli, ["-n"])
+
+    assert out.exit_code == 0
+    assert fake_package_dir in out.stderr
+    assert "small-fake-a==0.1" in out.stderr
+
+
 @pytest.mark.network
 def test_editable_package_vcs(runner):
     vcs_package = (


### PR DESCRIPTION
If an editable package is both a primary requirement and a constraint, it was being considered as solely a constraint, and so it and its dependencies were excluded from pip-compile output.

Instead of combining the editable requirements, we were returning the first one, and the two are sorted the same up to `"... -c constraints.in"` and `"... -r requirements.in"`.

**Changelog-friendly one-liner**: Ensure editables that are both primary reqs and constraints appear in pip-compile output

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
