### PR TITLE
Sort format controls to ensure consistent results

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -233,7 +233,7 @@ def lookup_table(values, key=None, keyval=None, unique=False, use_lists=False):
 
 def dedup(iterable):
     """Deduplicate an iterable object like iter(set(iterable)) but
-    order-reserved.
+    order-preserved.
     """
     return iter(OrderedDict.fromkeys(iterable))
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -114,9 +114,9 @@ class OutputWriter(object):
                 yield "--trusted-host {}".format(trusted_host)
 
     def write_format_controls(self):
-        for nb in dedup(self.format_control.no_binary):
+        for nb in dedup(sorted(self.format_control.no_binary)):
             yield "--no-binary {}".format(nb)
-        for ob in dedup(self.format_control.only_binary):
+        for ob in dedup(sorted(self.format_control.only_binary)):
             yield "--only-binary {}".format(ob)
 
     def write_find_links(self):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -207,16 +207,20 @@ def test_write_format_controls(writer):
     Tests --no-binary/--only-binary options.
     """
 
+    # FormatControl actually expects sets, but we give it lists here to
+    # ensure that we are sorting them when writing.
     writer.format_control = FormatControl(
         no_binary=["psycopg2", "click"], only_binary=["pytz", "django"]
     )
     lines = list(writer.write_format_controls())
 
-    assert "--no-binary psycopg2" in lines
-    assert "--no-binary click" in lines
-
-    assert "--only-binary pytz" in lines
-    assert "--only-binary django" in lines
+    expected_lines = [
+        "--no-binary click",
+        "--no-binary psycopg2",
+        "--only-binary django",
+        "--only-binary pytz",
+    ]
+    assert lines == expected_lines
 
 
 @mark.parametrize(


### PR DESCRIPTION
Sort format controls when writing them to ensure consistent results

Fixes https://github.com/jazzband/pip-tools/issues/1097

**Changelog-friendly one-liner**: Sort format controls to ensure consistent results

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
