### PR TITLE
Fix a bug where pip-compile would downgrade a resolved prerelease version

### DIFF
--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -17,7 +17,9 @@ def ireq_satisfied_by_existing_pin(ireq, existing_pin):
     previously encountered version pin.
     """
     version = next(iter(existing_pin.req.specifier)).version
-    return version in ireq.req.specifier
+    return ireq.req.specifier.contains(
+        version, prereleases=existing_pin.req.specifier.prereleases
+    )
 
 
 class LocalRequirementsRepository(BaseRepository):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1075,3 +1075,16 @@ def test_sub_dependencies_with_constraints(pip_conf, runner):
         "small-fake-with-deps-and-sub-deps==0.1",
         "small-fake-with-unpinned-deps==0.1",
     }.issubset(req_out_lines)
+
+
+def test_preserve_compiled_prerelease_version(pip_conf, runner):
+    with open("requirements.in", "w") as req_in:
+        req_in.write("small-fake-a")
+
+    with open("requirements.txt", "w") as req_txt:
+        req_txt.write("small-fake-a==0.3b1")
+
+    out = runner.invoke(cli, ["--no-annotate", "--no-header"])
+
+    assert out.exit_code == 0, out
+    assert "small-fake-a==0.3b1" in out.stderr.splitlines()


### PR DESCRIPTION
Fixes #1102.

**Changelog-friendly one-liner**: Fix a bug where `pip-compile` would downgrade a resolved pre-release version.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).