### PR TITLE
Add a versions compatibility table to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -424,3 +424,17 @@ Other useful tools
 .. _pipdeptree: https://github.com/naiquevin/pipdeptree
 .. _requirements.txt.vim: https://github.com/raimon49/requirements.txt.vim
 .. _Python extension for VS Code: https://marketplace.visualstudio.com/items?itemName=ms-python.python
+
+Versions and compatibility
+==========================
+
+The table below summarizes the latest ``pip-tools`` versions with the required ``pip``
+versions.
+
++-----------+-----------------+
+| pip-tools | pip             |
++===========+=================+
+| 4.5.x     | 8.1.3 - 20.0.x  |
++-----------+-----------------+
+| 5.0.x     | 20.0.x - 20.1.x |
++-----------+-----------------+


### PR DESCRIPTION
Resolves #1089.

**Changelog-friendly one-liner**: Add a versions compatibility table to `README`.

##### Contributor checklist

- ~~Provided the tests for the changes.~~
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).