### PR TITLE
[WIP] Regression: Fix editable and non-editable requirement duplicate

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -56,6 +56,11 @@ def combine_install_requirements(ireqs):
     for ireq in ireqs:
         source_ireqs.extend(getattr(ireq, "_source_ireqs", [ireq]))
 
+    # TODO Find a way (and logic) to:
+    # - Have the ireq.req be set on editables so they end up grouped with non-editable
+    #   (previously a pip resolver side effect on don-deep-copied editable ireq).
+    # - Properly combine the editable and non-editable requirement for the same package.
+
     # deepcopy the accumulator so as to not modify the inputs
     combined_ireq = copy.deepcopy(source_ireqs[0])
     for ireq in source_ireqs[1:]:
@@ -67,6 +72,7 @@ def combine_install_requirements(ireqs):
         combined_ireq.extras = tuple(
             sorted(set(tuple(combined_ireq.extras) + tuple(ireq.extras)))
         )
+        # TODO propably "merge" editable attibutes here.
 
     # InstallRequirements objects are assumed to come from only one source, and
     # so they support only a single comes_from entry. This function breaks this
@@ -221,6 +227,7 @@ class Resolver(object):
 
         """
         for _, ireqs in full_groupby(constraints, key=key_from_ireq):
+            # TODO full_groupby has to group ediatble and non-editable ireqs somehow.
             yield combine_install_requirements(ireqs)
 
     def _resolve_one_round(self):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -219,6 +219,27 @@ def test_editable_package(pip_conf, runner):
     assert "small-fake-a==0.1" in out.stderr
 
 
+def test_editable_package_without_non_editable_dupplicate(pip_conf, runner):
+    """
+    piptools keeps editable requirement,
+    without also adding a dupplicate "non-editable" requirement variation
+    """
+    fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_a")
+    fake_package_dir = path_to_url(fake_package_dir)
+    with open("requirements.in", "w") as req_in:
+        req_in.write(
+            "-e " + fake_package_dir +  # require editable fake package
+            "\nsmall_fake_with_unpinned_deps"  # This one also requires small_fake_a
+        )
+
+    out = runner.invoke(cli, ["-n"])
+
+    assert out.exit_code == 0
+    assert fake_package_dir in out.stderr
+    # Shouldn't include a non-editable small-fake-a==<version>.
+    assert "small-fake-a==" not in out.stderr
+
+
 @pytest.mark.parametrize(("req_editable",), [(True,), (False,)])
 def test_editable_package_in_constraints(pip_conf, runner, req_editable):
     """

--- a/tests/test_data/packages/small_fake_a/setup.py
+++ b/tests/test_data/packages/small_fake_a/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+
+setup(
+    name="small_fake_a",
+    version=0.1,
+)


### PR DESCRIPTION
WIP, input welcome. The first commit contains a test to reproduce.
This is a regression from 4.5.1

Given a requirement file like:
```
-e /path/to/small_fake_a
small_fake_with_unpinned_deps  # Has dependency on small_fake_a.
```

The output will be:
```
-e file://path/to/small_fake_a
small_fake_a==0.2  # Hey, this is already covered by the editable install above!
small_fake_with_unpinned_deps==0.1
<other dependencies>
```

#1093 introduced the regression, although the effect was hard to spot.

The cause:
- Passing an editable `ireq` to pip resolver (our `_iter_dependency`)has the side effect of setting the `ireq.req` on it, effectively giving it a package name and specifier.
Having `ireq.req` set on it for subsequent cycle (most of the time (always?), editables come from the requirements file, in round 1) cause `_group_constraints` (with `full_groupby`) to group the editable and non-editable requirements for a same package together.
- The change in #1093 made `combine_install_requirements` handle all `ireq`, including editable ones. But `combine_install_requirements` returns a deep-copy of the `ireq`, which means we loose the side effect described above, thus loosing the grouping, thus causing the duplicate in the output.

Removing the deepcopy at https://github.com/jazzband/pip-tools/blob/master/piptools/resolver.py#L60 fixes the issue, but could cause other issues, notably with the diff use to determine if the round is stable, so that's not a solution.

The general solution seems to be:
- Find a way to always have `ireq.req` to have the package name.
  Maybe by resolving links (not their dependencies) as a pre-step before doing anything else.
- Implement a proper logic to combine non-editable and editable requirements together in `combine_install_requirements` rather than returning the first editable as before the #1093.

I'm not yet sure how to do either of those at the moment. Any help/input appreciated.

**Changelog-friendly one-liner**: Fix duplicate editable and non-editable requirement duplicate.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [X] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
