### PR TITLE
Ignore eggs hashes from PyPI JSON API

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -43,6 +43,7 @@ FileStream = collections.namedtuple("FileStream", "stream size")
 
 class PyPIRepository(BaseRepository):
     DEFAULT_INDEX_URL = PyPI.simple_url
+    HASHABLE_PACKAGE_TYPES = {"bdist_wheel", "sdist"}
 
     """
     The PyPIRepository will use the provided Finder instance to lookup
@@ -338,6 +339,7 @@ class PyPIRepository(BaseRepository):
                     algo=FAVORITE_HASH, digest=file_["digests"][FAVORITE_HASH]
                 )
                 for file_ in release_files
+                if file_["packagetype"] in self.HASHABLE_PACKAGE_TYPES
             }
         except KeyError:
             log.debug("Missing digests of release files on PyPI")

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -172,7 +172,16 @@ def test_pip_cache_dir_is_empty(from_line, tmpdir):
     "project_data, expected_hashes",
     (
         pytest.param(
-            {"releases": {"0.1": [{"digests": {"sha256": "fake-hash"}}]}},
+            {
+                "releases": {
+                    "0.1": [
+                        {
+                            "packagetype": "bdist_wheel",
+                            "digests": {"sha256": "fake-hash"},
+                        }
+                    ]
+                }
+            },
             {"sha256:fake-hash"},
             id="return single hash",
         ),
@@ -180,23 +189,59 @@ def test_pip_cache_dir_is_empty(from_line, tmpdir):
             {
                 "releases": {
                     "0.1": [
-                        {"digests": {"sha256": "fake-hash-number1"}},
-                        {"digests": {"sha256": "fake-hash-number2"}},
+                        {
+                            "packagetype": "bdist_wheel",
+                            "digests": {"sha256": "fake-hash-number1"},
+                        },
+                        {
+                            "packagetype": "sdist",
+                            "digests": {"sha256": "fake-hash-number2"},
+                        },
                     ]
                 }
             },
             {"sha256:fake-hash-number1", "sha256:fake-hash-number2"},
             id="return multiple hashes",
         ),
+        pytest.param(
+            {
+                "releases": {
+                    "0.1": [
+                        {
+                            "packagetype": "bdist_wheel",
+                            "digests": {"sha256": "fake-hash-number1"},
+                        },
+                        {
+                            "packagetype": "sdist",
+                            "digests": {"sha256": "fake-hash-number2"},
+                        },
+                        {
+                            "packagetype": "bdist_eggs",
+                            "digests": {"sha256": "fake-hash-number3"},
+                        },
+                    ]
+                }
+            },
+            {"sha256:fake-hash-number1", "sha256:fake-hash-number2"},
+            id="return only bdist_wheel and sdist hashes",
+        ),
         pytest.param(None, None, id="not found project data"),
         pytest.param({}, None, id="not found releases key"),
         pytest.param({"releases": {}}, None, id="not found version"),
         pytest.param({"releases": {"0.1": [{}]}}, None, id="not found digests"),
         pytest.param(
-            {"releases": {"0.1": [{"digests": {}}]}}, None, id="digests are empty"
+            {"releases": {"0.1": [{"packagetype": "bdist_wheel", "digests": {}}]}},
+            None,
+            id="digests are empty",
         ),
         pytest.param(
-            {"releases": {"0.1": [{"digests": {"md5": "fake-hash"}}]}},
+            {
+                "releases": {
+                    "0.1": [
+                        {"packagetype": "bdist_wheel", "digests": {"md5": "fake-hash"}}
+                    ]
+                }
+            },
             None,
             id="not found sha256 algo",
         ),


### PR DESCRIPTION
Fixes #1121.

**Changelog-friendly one-liner**: Ignore hashes for `*.egg` files in `pip-compile`.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).