### PR TITLE
Deprecate --index/--no-index in pip-compile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -442,6 +442,15 @@ Other useful tools
 .. _requirements.txt.vim: https://github.com/raimon49/requirements.txt.vim
 .. _Python extension for VS Code: https://marketplace.visualstudio.com/items?itemName=ms-python.python
 
+
+Deprecations
+============
+
+This section lists ``pip-tools`` features that are currently deprecated.
+
+- ``--index/--no-index`` command-line options, use instead
+  ``--emit-index-url/--no-emit-index-url`` (since 5.2.0).
+
 Versions and compatibility
 ==========================
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import sys
 import tempfile
+import warnings
 
 from click.utils import safecall
 from pip._internal.commands import create_command
@@ -94,8 +95,8 @@ pip_defaults = install_command.parser.get_default_values()
 @click.option(
     "--index/--no-index",
     is_flag=True,
-    default=True,
-    help="Add index URL to generated file",
+    default=None,
+    help="DEPRECATED: Add index URL to generated file",
 )
 @click.option(
     "--emit-trusted-host/--no-emit-trusted-host",
@@ -179,6 +180,12 @@ pip_defaults = install_command.parser.get_default_values()
     type=click.Path(file_okay=False, writable=True),
 )
 @click.option("--pip-args", help="Arguments to pass directly to the pip command.")
+@click.option(
+    "--emit-index-url/--no-emit-index-url",
+    is_flag=True,
+    default=True,
+    help="Add index URL to generated file",
+)
 def cli(
     ctx,
     verbose,
@@ -207,6 +214,7 @@ def cli(
     emit_find_links,
     cache_dir,
     pip_args,
+    emit_index_url,
 ):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbosity = verbose - quiet
@@ -245,6 +253,14 @@ def cli(
 
         # Close the file at the end of the context execution
         ctx.call_on_close(safecall(output_file.close_intelligently))
+
+    if index is not None:
+        warnings.warn(
+            "--index and --no-index are deprecated and will be removed "
+            "in future versions. Use --emit-index-url/--no-emit-index-url instead.",
+            category=FutureWarning,
+        )
+        emit_index_url = index
 
     ###
     # Setup
@@ -410,7 +426,7 @@ def cli(
         click_ctx=ctx,
         dry_run=dry_run,
         emit_header=header,
-        emit_index=index,
+        emit_index_url=emit_index_url,
         emit_trusted_host=emit_trusted_host,
         annotate=annotate,
         generate_hashes=generate_hashes,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -31,22 +31,19 @@ install_command = create_command("install")
 pip_defaults = install_command.parser.get_default_values()
 
 
-class CompileCommand(Command):
-    def __init__(self, *awrgs, **kwargs):
-        super(CompileCommand, self).__init__(*awrgs, **kwargs)
-        self._os_args = None
+class BaseCommand(Command):
+    _os_args = None
 
     def parse_args(self, ctx, args):
         """
-        Override `parse_args` to store args since click doesn't provide
-        this information in the context.
+        Override base `parse_args` to store the argument part of `sys.argv`.
         """
         self._os_args = set(args)
-        return super(CompileCommand, self).parse_args(ctx, args)
+        return super(BaseCommand, self).parse_args(ctx, args)
 
     def has_arg(self, arg_name):
         """
-        Detect whether given arg name is present in the argument part of `sys.argv`.
+        Detect whether a given arg name is present in the argument part of `sys.argv`.
         """
         command_options = {option.name: option for option in self.params}
         option = command_options[arg_name]
@@ -54,7 +51,7 @@ class CompileCommand(Command):
         return bool(self._os_args & args)
 
 
-@click.command(cls=CompileCommand)
+@click.command(cls=BaseCommand)
 @click.version_option()
 @click.pass_context
 @click.option("-v", "--verbose", count=True, help="Show more output")

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -183,7 +183,7 @@ pip_defaults = install_command.parser.get_default_values()
 @click.option(
     "--emit-index-url/--no-emit-index-url",
     is_flag=True,
-    default=True,
+    default=None,
     help="Add index URL to generated file",
 )
 def cli(
@@ -254,13 +254,20 @@ def cli(
         # Close the file at the end of the context execution
         ctx.call_on_close(safecall(output_file.close_intelligently))
 
-    if index is not None:
+    if index is not None and emit_index_url is not None:
+        raise click.BadParameter(
+            "--index/--no-index and --emit-index-url/--no-emit-index-url "
+            "are mutual exclusive."
+        )
+    elif index is not None:
         warnings.warn(
             "--index and --no-index are deprecated and will be removed "
             "in future versions. Use --emit-index-url/--no-emit-index-url instead.",
             category=FutureWarning,
         )
         emit_index_url = index
+    elif emit_index_url is None:
+        emit_index_url = True
 
     ###
     # Setup

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -43,7 +43,8 @@ class BaseCommand(Command):
 
     def has_arg(self, arg_name):
         """
-        Detect whether a given arg name is present in the argument part of `sys.argv`.
+        Detect whether a given arg name (including negative counterparts
+        to the arg, e.g. --no-arg) is present in the argument part of `sys.argv`.
         """
         command_options = {option.name: option for option in self.params}
         option = command_options[arg_name]
@@ -278,7 +279,7 @@ def cli(
     if cli.has_arg("index") and cli.has_arg("emit_index_url"):
         raise click.BadParameter(
             "--index/--no-index and --emit-index-url/--no-emit-index-url "
-            "are mutual exclusive."
+            "are mutually exclusive."
         )
     elif cli.has_arg("index"):
         warnings.warn(

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -56,7 +56,7 @@ class OutputWriter(object):
         click_ctx,
         dry_run,
         emit_header,
-        emit_index,
+        emit_index_url,
         emit_trusted_host,
         annotate,
         generate_hashes,
@@ -73,7 +73,7 @@ class OutputWriter(object):
         self.click_ctx = click_ctx
         self.dry_run = dry_run
         self.emit_header = emit_header
-        self.emit_index = emit_index
+        self.emit_index_url = emit_index_url
         self.emit_trusted_host = emit_trusted_host
         self.annotate = annotate
         self.generate_hashes = generate_hashes
@@ -101,7 +101,7 @@ class OutputWriter(object):
             yield comment("#")
 
     def write_index_options(self):
-        if self.emit_index:
+        if self.emit_index_url:
             for index, index_url in enumerate(dedup(self.index_urls)):
                 if index_url.rstrip("/") == self.default_index_url:
                     continue

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -209,7 +209,7 @@ def test_mutual_exclusive_index_options(runner, options):
     assert out.exit_code == 2
     assert (
         "--index/--no-index and --emit-index-url/--no-emit-index-url "
-        "are mutual exclusive"
+        "are mutually exclusive"
     ) in out.stderr
 
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -152,20 +152,45 @@ def test_trusted_host(pip_conf, runner):
     assert "--trusted-host example.com\n" "--trusted-host example2.com\n" in out.stderr
 
 
-def test_trusted_host_no_emit(pip_conf, runner):
+@pytest.mark.parametrize(
+    "options",
+    (
+        pytest.param(
+            ["--trusted-host", "example.com", "--no-emit-trusted-host"],
+            id="trusted host",
+        ),
+        pytest.param(
+            ["--find-links", "wheels", "--no-emit-find-links"], id="find links"
+        ),
+        pytest.param(
+            ["--index-url", "https://index-url", "--no-emit-index-url"], id="index url"
+        ),
+    ),
+)
+def test_all_no_emit_options(runner, options):
     with open("requirements.in", "w"):
         pass
-    out = runner.invoke(
-        cli, ["-v", "--trusted-host", "example.com", "--no-emit-trusted-host"]
-    )
-    assert "--trusted-host example.com" not in out.stderr
+    out = runner.invoke(cli, ["--no-header"] + options)
+    assert out.stderr.strip().splitlines() == []
 
 
-def test_find_links_no_emit(pip_conf, runner):
+@pytest.mark.parametrize(
+    ("option", "expected_output"),
+    (
+        pytest.param("--index", ["--index-url https://index-url"], id="index url"),
+        pytest.param("--no-index", [], id="no index"),
+    ),
+)
+def test_index_option(runner, option, expected_output):
     with open("requirements.in", "w"):
         pass
-    out = runner.invoke(cli, ["-v", "--no-emit-find-links"])
-    assert "--find-links" not in out.stderr
+
+    with pytest.warns(FutureWarning, match="--index and --no-index are deprecated"):
+        out = runner.invoke(
+            cli, ["--no-header", "--index-url", "https://index-url", option]
+        )
+
+    assert out.stderr.strip().splitlines() == expected_output
 
 
 @pytest.mark.network

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import subprocess
 import sys
@@ -191,6 +192,25 @@ def test_index_option(runner, option, expected_output):
         )
 
     assert out.stderr.strip().splitlines() == expected_output
+
+
+@pytest.mark.parametrize(
+    "options",
+    itertools.product(
+        ("--index", "--no-index"), ("--emit-index-url", "--no-emit-index-url")
+    ),
+)
+def test_mutual_exclusive_index_options(runner, options):
+    with open("requirements.in", "w"):
+        pass
+
+    out = runner.invoke(cli, options)
+
+    assert out.exit_code == 2
+    assert (
+        "--index/--no-index and --emit-index-url/--no-emit-index-url "
+        "are mutual exclusive"
+    ) in out.stderr
 
 
 @pytest.mark.network

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,12 +246,14 @@ def test_force_text(value, expected_text):
         (["--pre"], "pip-compile --pre"),
         (["--allow-unsafe"], "pip-compile --allow-unsafe"),
         # Check negative flags
+        (["--no-index"], "pip-compile --no-index"),
         (["--no-emit-index-url"], "pip-compile --no-emit-index-url"),
         (["--no-emit-trusted-host"], "pip-compile --no-emit-trusted-host"),
         (["--no-annotate"], "pip-compile --no-annotate"),
         # Check that default values will be removed from the command
         (["--emit-trusted-host"], "pip-compile"),
         (["--annotate"], "pip-compile"),
+        (["--index"], "pip-compile"),
         (["--emit-index-url"], "pip-compile"),
         (["--max-rounds=10"], "pip-compile"),
         (["--build-isolation"], "pip-compile"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,13 +246,13 @@ def test_force_text(value, expected_text):
         (["--pre"], "pip-compile --pre"),
         (["--allow-unsafe"], "pip-compile --allow-unsafe"),
         # Check negative flags
-        (["--no-index"], "pip-compile --no-index"),
+        (["--no-emit-index-url"], "pip-compile --no-emit-index-url"),
         (["--no-emit-trusted-host"], "pip-compile --no-emit-trusted-host"),
         (["--no-annotate"], "pip-compile --no-annotate"),
         # Check that default values will be removed from the command
         (["--emit-trusted-host"], "pip-compile"),
         (["--annotate"], "pip-compile"),
-        (["--index"], "pip-compile"),
+        (["--emit-index-url"], "pip-compile"),
         (["--max-rounds=10"], "pip-compile"),
         (["--build-isolation"], "pip-compile"),
         # Check options with multiple values
@@ -327,7 +327,7 @@ def test_get_compile_command_sort_args(tmpdir_cwd):
         pass
 
     args = [
-        "--no-index",
+        "--no-emit-index-url",
         "--no-emit-trusted-host",
         "--no-annotate",
         "setup.py",
@@ -340,6 +340,6 @@ def test_get_compile_command_sort_args(tmpdir_cwd):
     with compile_cli.make_context("pip-compile", args) as ctx:
         assert get_compile_command(ctx) == (
             "pip-compile --find-links=bar --find-links=foo "
-            "--no-annotate --no-emit-trusted-host --no-index "
+            "--no-annotate --no-emit-index-url --no-emit-trusted-host "
             "requirements.in setup.py"
         )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -31,7 +31,7 @@ def writer(tmpdir_cwd):
             click_ctx=ctx,
             dry_run=True,
             emit_header=True,
-            emit_index=True,
+            emit_index_url=True,
             emit_trusted_host=True,
             annotate=True,
             generate_hashes=False,
@@ -318,9 +318,10 @@ def test_write_index_options(writer, index_urls, expected_lines):
 
 def test_write_index_options_no_emit_index(writer):
     """
-    There should not be --index-url/--extra-index-url options if emit_index is False.
+    There should not be --index-url/--extra-index-url options
+    if emit_index_url is False.
     """
-    writer.emit_index = False
+    writer.emit_index_url = False
     with pytest.raises(StopIteration):
         next(writer.write_index_options())
 


### PR DESCRIPTION
To avoid ambiguity of `pip-sync --no-index`.

Resolves #373.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Deprecate `--index/--no-index` in favor of `--emit-index-url/--no-emit-index-url` options in `pip-compile`.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).