### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [bdist_wheel]
 universal = 1
 
-[metadata]
-license_file = LICENSE
-
 [tool:pytest]
 norecursedirs = .* build dist venv test_data piptools/_compat/*
 testpaths = tests piptools


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license_file" option is
deprecated.

https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include LICENSE, it is now included
automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

<!--- Describe the changes here. --->

Remove deprecated license_file from setup.cfg.

##### Contributor checklist

- [ ] Provided the tests for the changes. (N/A)
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
