### PR TITLE
Adopt flake8-pytest-style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
     hooks:
     - id: flake8
       language_version: python3
+      additional_dependencies:
+      - flake8-pytest-style
   - repo: https://github.com/PyCQA/bandit
     rev: 1.6.0
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,15 @@ max-line-length = 88
 exclude = build/*, dist/*, pip_tools.egg-info/*, piptools/_compat/*, .tox/*, .venv/*, .git/*, .eggs/*
 extend-ignore = E203  # E203 conflicts with PEP8; see https://github.com/psf/black#slices
 
+# flake8-pytest-style
+# PT001:
+pytest-fixture-no-parentheses = true
+# PT006:
+pytest-parametrize-names-type = tuple
+# PT007:
+pytest-parametrize-values-type = tuple
+pytest-parametrize-values-row-type = tuple
+
 [isort]
 combine_as_imports = True
 forced_separate = piptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from pip._internal.req.constructors import (
 )
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
-from pytest import fixture
 
 from .constants import MINIMAL_WHEELS_PATH
 
@@ -111,17 +110,17 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.flaky(reruns=3, reruns_delay=2))
 
 
-@fixture
+@pytest.fixture
 def fake_dist():
     return FakeInstalledDistribution
 
 
-@fixture
+@pytest.fixture
 def repository():
     return FakeRepository()
 
 
-@fixture
+@pytest.fixture
 def pypi_repository(tmpdir):
     return PyPIRepository(
         ["--index-url", PyPIRepository.DEFAULT_INDEX_URL],
@@ -129,12 +128,12 @@ def pypi_repository(tmpdir):
     )
 
 
-@fixture
+@pytest.fixture
 def depcache(tmpdir):
     return DependencyCache(str(tmpdir / "dep-cache"))
 
 
-@fixture
+@pytest.fixture
 def resolver(depcache, repository):
     # TODO: It'd be nicer if Resolver instance could be set up and then
     #       use .resolve(...) on the specset, instead of passing it to
@@ -142,29 +141,29 @@ def resolver(depcache, repository):
     return partial(Resolver, repository=repository, cache=depcache)
 
 
-@fixture
+@pytest.fixture
 def base_resolver(depcache):
     return partial(Resolver, cache=depcache)
 
 
-@fixture
+@pytest.fixture
 def from_line():
     return install_req_from_line
 
 
-@fixture
+@pytest.fixture
 def from_editable():
     return install_req_from_editable
 
 
-@fixture
+@pytest.fixture
 def runner():
     cli_runner = CliRunner(mix_stderr=False)
     with cli_runner.isolated_filesystem():
         yield cli_runner
 
 
-@fixture
+@pytest.fixture
 def tmpdir_cwd(tmpdir):
     with tmpdir.as_cwd():
         yield tmpdir

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,7 +3,7 @@ from os import remove
 from shutil import rmtree
 from tempfile import NamedTemporaryFile
 
-from pytest import raises
+import pytest
 
 from piptools.cache import CorruptCacheError, DependencyCache, read_cache_file
 
@@ -36,7 +36,7 @@ def test_read_cache_file_not_json():
     A cache file that's not JSON should throw a corrupt cache error.
     """
     with _read_cache_file_helper("not json") as cache_file_name:
-        with raises(
+        with pytest.raises(
             CorruptCacheError,
             match="The dependency cache seems to have been corrupted.",
         ):
@@ -48,7 +48,7 @@ def test_read_cache_file_wrong_format():
     A cache file with a wrong "__format__" value should throw an assertion error.
     """
     with _read_cache_file_helper('{"__format__": 2}') as cache_file_name:
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             read_cache_file(cache_file_name)
 
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -6,7 +6,6 @@ from textwrap import dedent
 import mock
 import pytest
 from pip._internal.utils.urls import path_to_url
-from pytest import mark
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 from .utils import invoke
@@ -15,7 +14,7 @@ from piptools.scripts.compile import cli
 
 
 @pytest.fixture(autouse=True)
-def temp_dep_cache(tmpdir, monkeypatch):
+def _temp_dep_cache(tmpdir, monkeypatch):
     monkeypatch.setenv("PIP_TOOLS_CACHE_DIR", str(tmpdir / "cache"))
 
 
@@ -66,8 +65,8 @@ def test_command_line_setuptools_read(pip_conf, runner):
 
 
 @pytest.mark.parametrize(
-    "options, expected_output_file",
-    [
+    ("options", "expected_output_file"),
+    (
         # For the `pip-compile` output file should be "requirements.txt"
         ([], "requirements.txt"),
         # For the `pip-compile --output-file=output.txt`
@@ -78,7 +77,7 @@ def test_command_line_setuptools_read(pip_conf, runner):
         # For the `pip-compile setup.py --output-file=output.txt`
         # output file should be "output.txt"
         (["setup.py", "--output-file", "output.txt"], "output.txt"),
-    ],
+    ),
 )
 def test_command_line_setuptools_output_file(
     pip_conf, runner, options, expected_output_file
@@ -266,7 +265,7 @@ def test_editable_package_constraint_without_non_editable_duplicate(pip_conf, ru
     assert "small-fake-a==" not in out.stderr
 
 
-@pytest.mark.parametrize(("req_editable",), [(True,), (False,)])
+@pytest.mark.parametrize("req_editable", ((True,), (False,)))
 def test_editable_package_in_constraints(pip_conf, runner, req_editable):
     """
     piptools can compile an editable that appears in both primary requirements
@@ -328,9 +327,9 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
     assert not os.listdir(os.path.join(str(cache_dir), "pkgs"))
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("line", "dependency"),
-    [
+    (
         # zip URL
         # use pip-tools version prior to its use of setuptools_scm,
         # which is incompatible with https: install
@@ -352,9 +351,9 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
             "899c16bb8bac419/pip_tools-3.6.1-py2.py3-none-any.whl",
             "\nclick==",
         ),
-    ],
+    ),
 )
-@mark.parametrize(("generate_hashes",), [(True,), (False,)])
+@pytest.mark.parametrize("generate_hashes", ((True,), (False,)))
 @pytest.mark.network
 def test_url_package(runner, line, dependency, generate_hashes):
     with open("requirements.in", "w") as req_in:
@@ -366,9 +365,9 @@ def test_url_package(runner, line, dependency, generate_hashes):
     assert dependency in out.stderr
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("line", "dependency", "rewritten_line"),
-    [
+    (
         # file:// wheel URL
         (
             path_to_url(
@@ -398,9 +397,9 @@ def test_url_package(runner, line, dependency, generate_hashes):
                 )
             ),
         ),
-    ],
+    ),
 )
-@mark.parametrize(("generate_hashes",), [(True,), (False,)])
+@pytest.mark.parametrize("generate_hashes", ((True,), (False,)))
 def test_local_url_package(
     pip_conf, runner, line, dependency, rewritten_line, generate_hashes
 ):
@@ -479,7 +478,7 @@ def test_upgrade_packages_option_no_existing_file(pip_conf, runner):
 
 
 @pytest.mark.parametrize(
-    "current_package, upgraded_package",
+    ("current_package", "upgraded_package"),
     (
         pytest.param("small-fake-b==0.1", "small-fake-b==0.3", id="upgrade"),
         pytest.param("small-fake-b==0.3", "small-fake-b==0.1", id="downgrade"),
@@ -726,15 +725,15 @@ def test_multiple_input_files_without_output_file(runner):
 
 
 @pytest.mark.parametrize(
-    "option, expected",
-    [
+    ("option", "expected"),
+    (
         (
             "--annotate",
             "small-fake-a==0.1         "
             "# via -c constraints.txt, small-fake-with-deps\n",
         ),
         ("--no-annotate", "small-fake-a==0.1\n"),
-    ],
+    ),
 )
 def test_annotate_option(pip_conf, runner, option, expected):
     """
@@ -753,8 +752,8 @@ def test_annotate_option(pip_conf, runner, option, expected):
 
 
 @pytest.mark.parametrize(
-    "option, expected",
-    [("--allow-unsafe", "small-fake-a==0.1"), (None, "# small-fake-a")],
+    ("option", "expected"),
+    (("--allow-unsafe", "small-fake-a==0.1"), (None, "# small-fake-a")),
 )
 def test_allow_unsafe_option(pip_conf, monkeypatch, runner, option, expected):
     """
@@ -771,8 +770,8 @@ def test_allow_unsafe_option(pip_conf, monkeypatch, runner, option, expected):
 
 
 @pytest.mark.parametrize(
-    "option, attr, expected",
-    [("--cert", "cert", "foo.crt"), ("--client-cert", "client_cert", "bar.pem")],
+    ("option", "attr", "expected"),
+    (("--cert", "cert", "foo.crt"), ("--client-cert", "client_cert", "bar.pem")),
 )
 @mock.patch("piptools.scripts.compile.parse_requirements")
 def test_cert_option(parse_requirements, runner, option, attr, expected):
@@ -789,7 +788,8 @@ def test_cert_option(parse_requirements, runner, option, attr, expected):
 
 
 @pytest.mark.parametrize(
-    "option, expected", [("--build-isolation", True), ("--no-build-isolation", False)]
+    ("option", "expected"),
+    (("--build-isolation", True), ("--no-build-isolation", False)),
 )
 @mock.patch("piptools.scripts.compile.parse_requirements")
 def test_build_isolation_option(parse_requirements, runner, option, expected):
@@ -821,15 +821,15 @@ def test_forwarded_args(PyPIRepository, runner):
 
 
 @pytest.mark.parametrize(
-    "cli_option, infile_option, expected_package",
-    [
+    ("cli_option", "infile_option", "expected_package"),
+    (
         # no --pre pip-compile should resolve to the last stable version
         (False, False, "small-fake-a==0.2"),
         # pip-compile --pre should resolve to the last pre-released version
         (True, False, "small-fake-a==0.3b1"),
         (False, True, "small-fake-a==0.3b1"),
         (True, True, "small-fake-a==0.3b1"),
-    ],
+    ),
 )
 def test_pre_option(pip_conf, runner, cli_option, infile_option, expected_package):
     """
@@ -848,14 +848,14 @@ def test_pre_option(pip_conf, runner, cli_option, infile_option, expected_packag
 
 @pytest.mark.parametrize(
     "add_options",
-    [
+    (
         [],
         ["--output-file", "requirements.txt"],
         ["--upgrade"],
         ["--upgrade", "--output-file", "requirements.txt"],
         ["--upgrade-package", "small-fake-a"],
         ["--upgrade-package", "small-fake-a", "--output-file", "requirements.txt"],
-    ],
+    ),
 )
 def test_dry_run_option(pip_conf, runner, add_options):
     """
@@ -872,8 +872,8 @@ def test_dry_run_option(pip_conf, runner, add_options):
 
 
 @pytest.mark.parametrize(
-    "add_options, expected_cli_output_package",
-    [
+    ("add_options", "expected_cli_output_package"),
+    (
         ([], "small-fake-a==0.1"),
         (["--output-file", "requirements.txt"], "small-fake-a==0.1"),
         (["--upgrade"], "small-fake-a==0.2"),
@@ -883,7 +883,7 @@ def test_dry_run_option(pip_conf, runner, add_options):
             ["--upgrade-package", "small-fake-a", "--output-file", "requirements.txt"],
             "small-fake-a==0.2",
         ),
-    ],
+    ),
 )
 def test_dry_run_doesnt_touch_output_file(
     pip_conf, runner, add_options, expected_cli_output_package
@@ -914,13 +914,13 @@ def test_dry_run_doesnt_touch_output_file(
 
 
 @pytest.mark.parametrize(
-    "empty_input_pkg, prior_output_pkg",
-    [
+    ("empty_input_pkg", "prior_output_pkg"),
+    (
         ("", ""),
         ("", "small-fake-a==0.1\n"),
         ("# Nothing to see here", ""),
         ("# Nothing to see here", "small-fake-a==0.1\n"),
-    ],
+    ),
 )
 def test_empty_input_file_no_header(runner, empty_input_pkg, prior_output_pkg):
     """
@@ -966,7 +966,7 @@ def test_upgrade_package_doesnt_remove_annotation(pip_conf, runner):
 
 @pytest.mark.parametrize(
     "options",
-    [
+    (
         # TODO add --no-index support in OutputWriter
         # "--no-index",
         "--index-url https://example.com",
@@ -975,7 +975,7 @@ def test_upgrade_package_doesnt_remove_annotation(pip_conf, runner):
         "--trusted-host example.com",
         "--no-binary :all:",
         "--only-binary :all:",
-    ],
+    ),
 )
 def test_options_in_requirements_file(runner, options):
     """
@@ -992,7 +992,7 @@ def test_options_in_requirements_file(runner, options):
 
 
 @pytest.mark.parametrize(
-    "cli_options, expected_message",
+    ("cli_options", "expected_message"),
     (
         pytest.param(
             ["--index-url", "file:foo"],
@@ -1023,7 +1023,7 @@ def test_unreachable_index_urls(runner, cli_options, expected_message):
 
 
 @pytest.mark.parametrize(
-    "current_package, upgraded_package",
+    ("current_package", "upgraded_package"),
     (
         pytest.param("small-fake-b==0.1", "small-fake-b==0.2", id="upgrade"),
         pytest.param("small-fake-b==0.2", "small-fake-b==0.1", id="downgrade"),
@@ -1056,7 +1056,7 @@ def test_upgrade_packages_option_subdependency(
 
 
 @pytest.mark.parametrize(
-    "input_opts, output_opts",
+    ("input_opts", "output_opts"),
     (
         # Test that input options overwrite output options
         pytest.param(

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -95,13 +95,13 @@ def test_force_files_with_dot_in_extension(runner):
 
 @pytest.mark.parametrize(
     ("req_lines", "should_raise"),
-    [
+    (
         (["six>1.10.0", "six<1.10.0"], True),
         (
             ["six>1.10.0 ; python_version>='3.0'", "six<1.10.0 ; python_version<'3.0'"],
             False,
         ),
-    ],
+    ),
 )
 def test_merge_error(req_lines, should_raise, runner):
     """
@@ -125,7 +125,7 @@ def test_merge_error(req_lines, should_raise, runner):
 
 @pytest.mark.parametrize(
     ("cli_flags", "expected_install_flags"),
-    [
+    (
         (
             ["--find-links", "./libs1", "--find-links", "./libs2"],
             ["--find-links", "./libs1", "--find-links", "./libs2"],
@@ -155,7 +155,7 @@ def test_merge_error(req_lines, should_raise, runner):
             ["--pip-args=\"--cache-dir='/tmp/cache dir with spaces/'\""],
             ["--cache-dir='/tmp/cache dir with spaces/'"],
         ),
-    ],
+    ),
 )
 @mock.patch("piptools.sync.check_call")
 def test_pip_install_flags(check_call, cli_flags, expected_install_flags, runner):
@@ -176,7 +176,7 @@ def test_pip_install_flags(check_call, cli_flags, expected_install_flags, runner
 
 @pytest.mark.parametrize(
     "install_flags",
-    [
+    (
         ["--no-index"],
         ["--index-url", "https://example.com"],
         ["--extra-index-url", "https://example.com"],
@@ -184,7 +184,7 @@ def test_pip_install_flags(check_call, cli_flags, expected_install_flags, runner
         ["--trusted-host", "example.com"],
         ["--no-binary", ":all:"],
         ["--only-binary", ":all:"],
-    ],
+    ),
 )
 @mock.patch("piptools.sync.check_call")
 def test_pip_install_flags_in_requirements_file(check_call, runner, install_flags):

--- a/tests/test_fake_index.py
+++ b/tests/test_fake_index.py
@@ -1,4 +1,4 @@
-from pytest import raises
+import pytest
 
 
 def test_find_best_match(from_line, repository):
@@ -76,7 +76,7 @@ def test_get_dependencies_for_editable(from_editable, repository):
 
 def test_get_dependencies_rejects_non_pinned_requirements(from_line, repository):
     not_a_pinned_req = from_line("django>1.6")
-    with raises(TypeError):
+    with pytest.raises(TypeError):
         repository.get_dependencies(not_a_pinned_req)
 
 

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -61,7 +61,7 @@ def test_get_hashes_editable_empty_set(from_editable, pypi_repository):
     assert pypi_repository.get_hashes(ireq) == set()
 
 
-@pytest.mark.parametrize("content, content_length", [(b"foo", 3), (b"foobar", 6)])
+@pytest.mark.parametrize(("content", "content_length"), ((b"foo", 3), (b"foobar", 6)))
 def test_open_local_or_remote_file__local_file(tmp_path, content, content_length):
     """
     Test the `open_local_or_remote_file` returns a context manager to a FileStream
@@ -86,14 +86,15 @@ def test_open_local_or_remote_file__directory(tmpdir):
     link = Link(path_to_url(tmpdir.strpath))
     session = Session()
 
-    with pytest.raises(ValueError, match="Cannot open directory for read"):
-        with open_local_or_remote_file(link, session):
-            pass  # pragma: no cover
+    with pytest.raises(
+        ValueError, match="Cannot open directory for read"
+    ), open_local_or_remote_file(link, session):
+        pass  # pragma: no cover
 
 
 @pytest.mark.parametrize(
-    "content, content_length, expected_content_length",
-    [(b"foo", 3, 3), (b"bar", None, None), (b"kek", "invalid-content-length", None)],
+    ("content", "content_length", "expected_content_length"),
+    ((b"foo", 3, 3), (b"bar", None, None), (b"kek", "invalid-content-length", None)),
 )
 def test_open_local_or_remote_file__remote_file(
     tmp_path, content, content_length, expected_content_length
@@ -169,7 +170,7 @@ def test_pip_cache_dir_is_empty(from_line, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "project_data, expected_hashes",
+    ("project_data", "expected_hashes"),
     (
         pytest.param(
             {

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -28,7 +28,7 @@ def mocked_tmp_req_file(mocked_tmp_file):
 
 @pytest.mark.parametrize(
     ("installed", "root", "expected"),
-    [
+    (
         ([], "pip-tools", []),
         ([("pip-tools==1", [])], "pip-tools", ["pip-tools"]),
         ([("pip-tools==1", []), ("django==1.7", [])], "pip-tools", ["pip-tools"]),
@@ -61,7 +61,7 @@ def mocked_tmp_req_file(mocked_tmp_file):
             "root",
             ["root", "child"],
         ),
-    ],
+    ),
 )
 def test_dependency_tree(fake_dist, installed, root, expected):
     installed = {
@@ -399,10 +399,10 @@ def test_sync_verbose(check_call, from_line):
 
 @pytest.mark.parametrize(
     ("to_install", "to_uninstall", "expected_message"),
-    [
+    (
         ({"django==1.8", "click==4.0"}, set(), "Would install:"),
         (set(), {"django==1.8", "click==4.0"}, "Would uninstall:"),
-    ],
+    ),
 )
 def test_sync_dry_run(runner, from_line, to_install, to_uninstall, expected_message):
     """
@@ -422,10 +422,10 @@ def test_sync_dry_run(runner, from_line, to_install, to_uninstall, expected_mess
 
 @pytest.mark.parametrize(
     ("to_install", "to_uninstall", "expected_message"),
-    [
+    (
         ({"django==1.8", "click==4.0"}, set(), "Would install:"),
         (set(), {"django==1.8", "click==4.0"}, "Would uninstall:"),
-    ],
+    ),
 )
 @mock.patch("piptools.sync.check_call")
 @mock.patch("piptools.sync.click.confirm", return_value=False)
@@ -450,7 +450,7 @@ def test_sync_ask_declined(
     check_call.assert_not_called()
 
 
-@pytest.mark.parametrize("dry_run", [True, False])
+@pytest.mark.parametrize("dry_run", (True, False))
 @mock.patch("piptools.sync.click.confirm")
 @mock.patch("piptools.sync.check_call")
 def test_sync_ask_accepted(check_call, confirm, from_line, dry_run):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 import os
 
+import pytest
 import six
-from pytest import mark, raises
 from six.moves import shlex_quote
 
 from piptools.scripts.compile import cli as compile_cli
@@ -116,7 +116,7 @@ def test_as_tuple(from_line):
     should_be_rejected = ["foo==1.*", "foo~=1.1,<1.5,>1.2", "foo"]
     for spec in should_be_rejected:
         ireq = from_line(spec)
-        with raises(TypeError):
+        with pytest.raises(TypeError):
             as_tuple(ireq)
 
 
@@ -147,9 +147,9 @@ def test_get_hashes_from_ireq(from_line):
     assert get_hashes_from_ireq(ireq) == expected
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("line", "expected"),
-    [
+    (
         ("django==1.8", True),
         ("django===1.8", True),
         ("django>1.8", False),
@@ -157,7 +157,7 @@ def test_get_hashes_from_ireq(from_line):
         ("django==1.*", False),
         ("file:///example.zip", False),
         ("https://example.com/example.zip", False),
-    ],
+    ),
 )
 def test_is_pinned_requirement(from_line, line, expected):
     ireq = from_line(line)
@@ -169,9 +169,9 @@ def test_is_pinned_requirement_editable(from_editable):
     assert not is_pinned_requirement(ireq)
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("line", "expected"),
-    [
+    (
         ("django==1.8", False),
         ("django", False),
         ("file:///example.zip", True),
@@ -180,7 +180,7 @@ def test_is_pinned_requirement_editable(from_editable):
         ("git+git://github.com/jazzband/pip-tools@master", True),
         ("../example.zip", True),
         ("/example.zip", True),
-    ],
+    ),
 )
 def test_is_url_requirement(from_line, line, expected):
     ireq = from_line(line)
@@ -203,22 +203,22 @@ def test_fs_str():
     assert isinstance(fs_str("whatever"), str)
 
 
-@mark.skipif(six.PY2, reason="Not supported in py2")
+@pytest.mark.skipif(six.PY2, reason="Not supported in py2")
 def test_fs_str_with_bytes():
-    with raises(AssertionError):
+    with pytest.raises(AssertionError):
         fs_str(b"whatever")
 
 
-@mark.parametrize(
-    "value, expected_text", [(None, ""), (42, "42"), ("foo", "foo"), ("bãr", "bãr")]
+@pytest.mark.parametrize(
+    ("value", "expected_text"), ((None, ""), (42, "42"), ("foo", "foo"), ("bãr", "bãr"))
 )
 def test_force_text(value, expected_text):
     assert force_text(value) == expected_text
 
 
-@mark.parametrize(
-    "cli_args, expected_command",
-    [
+@pytest.mark.parametrize(
+    ("cli_args", "expected_command"),
+    (
         # Check empty args
         ([], "pip-compile"),
         # Check all options which will be excluded from command
@@ -274,7 +274,7 @@ def test_force_text(value, expected_text):
             ["--pip-args", "--disable-pip-version-check --isolated"],
             "pip-compile --pip-args='--disable-pip-version-check --isolated'",
         ),
-    ],
+    ),
 )
 def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):
     """
@@ -294,8 +294,8 @@ def test_get_compile_command_escaped_filenames(tmpdir_cwd):
         assert get_compile_command(ctx) == "pip-compile -- --requirements.in"
 
 
-@mark.parametrize(
-    "filename", ["requirements.in", "my requirements.in", "απαιτήσεις.txt"]
+@pytest.mark.parametrize(
+    "filename", ("requirements.in", "my requirements.in", "απαιτήσεις.txt")
 )
 def test_get_compile_command_with_files(tmpdir_cwd, filename):
     """

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,5 +1,5 @@
+import pytest
 from pip._internal.models.format_control import FormatControl
-from pytest import fixture, mark, raises
 
 from piptools.scripts.compile import cli
 from piptools.utils import comment
@@ -11,7 +11,7 @@ from piptools.writer import (
 )
 
 
-@fixture
+@pytest.fixture
 def writer(tmpdir_cwd):
     with open("src_file", "w"), open("src_file2", "w"):
         pass
@@ -107,7 +107,7 @@ def test_format_requirement_environment_marker(from_line, writer):
     )
 
 
-@mark.parametrize(("allow_unsafe",), [(True,), (False,)])
+@pytest.mark.parametrize("allow_unsafe", ((True,), (False,)))
 def test_iter_lines__unsafe_dependencies(writer, from_line, allow_unsafe):
     writer.allow_unsafe = allow_unsafe
     writer.emit_header = False
@@ -220,7 +220,7 @@ def test_write_header_no_emit_header(writer):
     """
     writer.emit_header = False
 
-    with raises(StopIteration):
+    with pytest.raises(StopIteration):
         next(writer.write_header())
 
 
@@ -245,15 +245,15 @@ def test_write_format_controls(writer):
     assert lines == expected_lines
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("index_urls", "expected_lines"),
     (
         # No urls - no options
-        [[], []],
+        ([], []),
         # Single URL should be index-url
-        [["https://index-url.com"], ["--index-url https://index-url.com"]],
+        (["https://index-url.com"], ["--index-url https://index-url.com"]),
         # First URL should be index-url, the others should be extra-index-url
-        [
+        (
             [
                 "https://index-url1.com",
                 "https://index-url2.com",
@@ -264,10 +264,10 @@ def test_write_format_controls(writer):
                 "--extra-index-url https://index-url2.com",
                 "--extra-index-url https://index-url3.com",
             ],
-        ],
+        ),
         # If a first URL equals to the default URL, the the index url must not be set
         # and the others should be extra-index-url
-        [
+        (
             [
                 "https://default-index-url.com",
                 "https://index-url1.com",
@@ -277,10 +277,10 @@ def test_write_format_controls(writer):
                 "--extra-index-url https://index-url1.com",
                 "--extra-index-url https://index-url2.com",
             ],
-        ],
+        ),
         # Ignore URLs equal to the default index-url
         # (note: the previous case is exception)
-        [
+        (
             [
                 "https://index-url1.com",
                 "https://default-index-url.com",
@@ -290,11 +290,11 @@ def test_write_format_controls(writer):
                 "--index-url https://index-url1.com",
                 "--extra-index-url https://index-url2.com",
             ],
-        ],
+        ),
         # Ignore URLs equal to the default index-url
-        [["https://default-index-url.com", "https://default-index-url.com"], []],
+        (["https://default-index-url.com", "https://default-index-url.com"], []),
         # All URLs must be deduplicated
-        [
+        (
             [
                 "https://index-url1.com",
                 "https://index-url1.com",
@@ -304,7 +304,7 @@ def test_write_format_controls(writer):
                 "--index-url https://index-url1.com",
                 "--extra-index-url https://index-url2.com",
             ],
-        ],
+        ),
     ),
 )
 def test_write_index_options(writer, index_urls, expected_lines):
@@ -321,16 +321,16 @@ def test_write_index_options_no_emit_index(writer):
     There should not be --index-url/--extra-index-url options if emit_index is False.
     """
     writer.emit_index = False
-    with raises(StopIteration):
+    with pytest.raises(StopIteration):
         next(writer.write_index_options())
 
 
-@mark.parametrize(
-    "find_links, expected_lines",
+@pytest.mark.parametrize(
+    ("find_links", "expected_lines"),
     (
-        [[], []],
-        [["./foo"], ["--find-links ./foo"]],
-        [["./foo", "./bar"], ["--find-links ./foo", "--find-links ./bar"]],
+        ([], []),
+        (["./foo"], ["--find-links ./foo"]),
+        (["./foo", "./bar"], ["--find-links ./foo", "--find-links ./bar"]),
     ),
 )
 def test_write_find_links(writer, find_links, expected_lines):


### PR DESCRIPTION
Resolves #1133.

**Changelog-friendly one-liner**: Adopt `flake8-pytest-style`.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).