### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
     - id: black
       language_version: python3
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.16
+    rev: v4.3.21
     hooks:
     - id: isort
       language_version: python3
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.8.1
     hooks:
     - id: flake8
       language_version: python3
       additional_dependencies:
       - flake8-pytest-style
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.0
+    rev: 1.6.2
     hooks:
     - id: bandit
       language_version: python3


### PR DESCRIPTION
Fixes issue on a macOS with `pre-commit`:

```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/Users/albert/.pyenv/versions/3.8.0/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Users/albert/.pyenv/versions/3.8.0/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/checker.py", line 669, in _run_checks
    return checker.run_checks()
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/checker.py", line 608, in run_checks
    self.run_ast_checks()
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/checker.py", line 504, in run_ast_checks
    for (line_number, offset, text, check) in runner:
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8_plugin_utils/plugin.py", line 78, in run
    visitor = self._create_visitor(visitor_cls)
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8_plugin_utils/plugin.py", line 105, in _create_visitor
    if cls.config is None:
AttributeError: type object 'PytestStylePlugin' has no attribute 'config'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/main/cli.py", line 18, in main
    app.run(argv)
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/main/application.py", line 394, in run
    self._run(argv)
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/main/application.py", line 382, in _run
    self.run_checks()
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/main/application.py", line 301, in run_checks
    self.file_checker_manager.run()
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/checker.py", line 328, in run
    self.run_parallel()
  File "/Users/albert/.cache/pre-commit/repo8iv7mhhh/py_env-python3/lib/python3.8/site-packages/flake8/checker.py", line 292, in run_parallel
    for ret in pool_map:
  File "/Users/albert/.pyenv/versions/3.8.0/lib/python3.8/multiprocessing/pool.py", line 448, in <genexpr>
    return (item for chunk in result for item in chunk)
  File "/Users/albert/.pyenv/versions/3.8.0/lib/python3.8/multiprocessing/pool.py", line 865, in next
    raise value
AttributeError: type object 'PytestStylePlugin' has no attribute 'config'
```

"tl;dr python 3.8 multiprocessing switch from fork to spawn on macOS and the plugin configuration approach flake8 uses is not spawn-safe. 3.7.9 has a fix for that." (at)asottile 