### PR TITLE
Fix leaked URLs with credentials in the output

### DIFF
--- a/piptools/exceptions.py
+++ b/piptools/exceptions.py
@@ -1,3 +1,6 @@
+from pip._internal.utils.misc import redact_auth_from_url
+
+
 class PipToolsError(Exception):
     pass
 
@@ -40,11 +43,14 @@ class NoCandidateFound(PipToolsError):
             source_ireqs = getattr(self.ireq, "_source_ireqs", [])
             lines.extend("  {}".format(ireq) for ireq in source_ireqs)
         else:
+            redacted_urls = tuple(
+                redact_auth_from_url(url) for url in self.finder.index_urls
+            )
             lines.append("No versions found")
             lines.append(
                 "{} {} reachable?".format(
-                    "Were" if len(self.finder.index_urls) > 1 else "Was",
-                    " or ".join(self.finder.index_urls),
+                    "Were" if len(redacted_urls) > 1 else "Was",
+                    " or ".join(redacted_urls),
                 )
             )
         return "\n".join(lines)

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -9,6 +9,7 @@ import tempfile
 from click.utils import safecall
 from pip._internal.commands import create_command
 from pip._internal.req.constructors import install_req_from_line
+from pip._internal.utils.misc import redact_auth_from_url
 
 from .. import click
 from .._compat import parse_requirements
@@ -27,6 +28,7 @@ DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 # Get default values of the pip's options (including options from pip.conf).
 install_command = create_command("install")
 pip_defaults = install_command.parser.get_default_values()
+default_index_url = redact_auth_from_url(pip_defaults.index_url)
 
 
 @click.command()
@@ -63,7 +65,7 @@ pip_defaults = install_command.parser.get_default_values()
 @click.option(
     "-i",
     "--index-url",
-    help="Change index URL (defaults to {})".format(pip_defaults.index_url),
+    help="Change index URL (defaults to {})".format(default_index_url),
     envvar="PIP_INDEX_URL",
 )
 @click.option(
@@ -371,14 +373,14 @@ def cli(
     log.debug("Using indexes:")
     with log.indentation():
         for index_url in dedup(repository.finder.index_urls):
-            log.debug(index_url)
+            log.debug(redact_auth_from_url(index_url))
 
     if repository.finder.find_links:
         log.debug("")
-        log.debug("Configuration:")
+        log.debug("Using links:")
         with log.indentation():
             for find_link in dedup(repository.finder.find_links):
-                log.debug("-f {}".format(find_link))
+                log.debug(redact_auth_from_url(find_link))
 
     try:
         resolver = Resolver(

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -25,10 +25,15 @@ from ..writer import OutputWriter
 DEFAULT_REQUIREMENTS_FILE = "requirements.in"
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 
-# Get default values of the pip's options (including options from pip.conf).
-install_command = create_command("install")
-pip_defaults = install_command.parser.get_default_values()
-default_index_url = redact_auth_from_url(pip_defaults.index_url)
+
+def _get_default_option(option_name):
+    """
+    Get default value of the pip's option (including option from pip.conf)
+    by a given option name.
+    """
+    install_command = create_command("install")
+    default_values = install_command.parser.get_default_values()
+    return getattr(default_values, option_name)
 
 
 @click.command()
@@ -65,7 +70,9 @@ default_index_url = redact_auth_from_url(pip_defaults.index_url)
 @click.option(
     "-i",
     "--index-url",
-    help="Change index URL (defaults to {})".format(default_index_url),
+    help="Change index URL (defaults to {index_url})".format(
+        index_url=redact_auth_from_url(_get_default_option("index_url"))
+    ),
     envvar="PIP_INDEX_URL",
 )
 @click.option(

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -8,6 +8,8 @@ from itertools import chain
 import six
 from click.utils import LazyFile
 from pip._internal.req.constructors import install_req_from_line
+from pip._internal.utils.misc import redact_auth_from_url
+from pip._internal.vcs import is_url
 from six.moves import shlex_quote
 
 from ._compat import PIP_VERSION
@@ -365,6 +367,8 @@ def get_compile_command(click_ctx):
                 left_args.append(shlex_quote(arg))
             # Append to args the option with a value
             else:
+                if isinstance(val, six.string_types) and is_url(val):
+                    val = redact_auth_from_url(val)
                 if option.name == "pip_args":
                     # shlex_quote would produce functional but noisily quoted results,
                     # e.g. --pip-args='--cache-dir='"'"'/tmp/with spaces'"'"''

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -274,6 +274,16 @@ def test_force_text(value, expected_text):
             ["--pip-args", "--disable-pip-version-check --isolated"],
             "pip-compile --pip-args='--disable-pip-version-check --isolated'",
         ),
+        pytest.param(
+            ["--extra-index-url", "https://username:password@example.com/"],
+            "pip-compile --extra-index-url='https://username:****@example.com/'",
+            id="redact password in index",
+        ),
+        pytest.param(
+            ["--find-links", "https://username:password@example.com/"],
+            "pip-compile --find-links='https://username:****@example.com/'",
+            id="redact password in link",
+        ),
     ),
 )
 def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):


### PR DESCRIPTION
Fixes #1137.
Reds #811 and #1028.

**Changelog-friendly one-liner**: Fix leaked URLs with credentials in `pip-compile`'s output.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).