### PR TITLE
Avoid URL requirement name collisions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,8 +272,16 @@ def run_setup_file():
     """
 
     def _make_wheel(package_dir_path, *args):
+        old_dir = os.getcwd()
+        # Without changing the dir, manual runs of pytest in the pip-tools
+        # repo will result in sdists with unexpected content
+        os.chdir(package_dir_path)
+
         setup_file = str(package_dir_path / "setup.py")
-        return check_call((sys.executable, setup_file) + args)  # nosec
+        result = check_call((sys.executable, setup_file) + args)  # nosec
+
+        os.chdir(old_dir)
+        return result
 
     return _make_wheel
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,19 +271,13 @@ def run_setup_file():
     Run a setup.py file from a given package dir.
     """
 
-    def _make_wheel(package_dir_path, *args):
-        old_dir = os.getcwd()
-        # Without changing the dir, manual runs of pytest in the pip-tools
-        # repo will result in sdists with unexpected content
-        os.chdir(package_dir_path)
-
+    def _run_setup_file(package_dir_path, *args):
         setup_file = str(package_dir_path / "setup.py")
-        result = check_call((sys.executable, setup_file) + args)  # nosec
+        return check_call(
+            (sys.executable, setup_file) + args, cwd=package_dir_path
+        )  # nosec
 
-        os.chdir(old_dir)
-        return result
-
-    return _make_wheel
+    return _run_setup_file
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,7 +274,7 @@ def run_setup_file():
     def _run_setup_file(package_dir_path, *args):
         setup_file = str(package_dir_path / "setup.py")
         return check_call(
-            (sys.executable, setup_file) + args, cwd=package_dir_path
+            (sys.executable, setup_file) + args, cwd=str(package_dir_path)
         )  # nosec
 
     return _run_setup_file

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -366,8 +366,7 @@ def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tm
     }
 
     for pkg_name, pkg in packages.items():
-        pkg_path = os.path.join(tmpdir, pkg_name)
-        os.mkdir(pkg_path)
+        pkg_path = str(tmpdir / pkg_name)
 
         make_sdist(pkg, pkg_path, "--formats=zip")
 
@@ -376,20 +375,17 @@ def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tm
             os.path.join(pkg_path, "master.zip"),
         )
 
-    name_collision_1 = (
-        "file://"
-        + str(os.path.join(tmpdir, "test_package_1", "master.zip"))
-        + "#egg=test_package_1"
+    name_collision_1 = "file://{dist_path}#egg=test_package_1".format(
+        dist_path=tmpdir / "test_package_1" / "master.zip"
     )
     ireq = from_line(name_collision_1)
-    pypi_repository.get_dependencies(ireq)
+    deps = pypi_repository.get_dependencies(ireq)
+    assert len(deps) == 0
 
-    name_collision_2 = (
-        "file://"
-        + str(os.path.join(tmpdir, "test_package_2", "master.zip"))
-        + "#egg=test_package_2"
+    name_collision_2 = "file://{dist_path}#egg=test_package_2".format(
+        dist_path=tmpdir / "test_package_2" / "master.zip"
     )
     ireq = from_line(name_collision_2)
-    reqs = pypi_repository.get_dependencies(ireq)
-    assert len(reqs) == 1
-    assert reqs.pop().req.name == "test-package-1"
+    deps = pypi_repository.get_dependencies(ireq)
+    assert len(deps) == 1
+    assert deps.pop().name == "test-package-1"


### PR DESCRIPTION
Fixes #1145.

This avoids cache collisions when using URLs which both end with the same filename where a later dependency depends on an earlier one, e.g.
`file:///tmp/mydep1/master.zip`
`file:///tmp/mydep2/master.zip`
(where mydep2 depends on mydep1)

**Changelog-friendly one-liner**: Avoid name collisions with URL based requirements.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
