### PR TITLE
Fix py27 failing jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ matrix:
 
 install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - pip install tox
+    - python -m pip install -U tox virtualenv
 
 build: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install tox
-        run: pip install tox
+      - name: Install test dependencies
+        run: python -m pip install -U tox virtualenv
       - name: Prepare test environment
         run: tox --notest -p auto --parallel-live
       - name: Test pip ${{ matrix.pip-version }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,8 +33,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install tox
-        run: pip install tox
+      - name: Install test dependencies
+        run: python -m pip install -U tox virtualenv
       - name: Prepare test environment
         run: tox --notest -p auto --parallel-live
       - name: Test pip ${{ matrix.pip-version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 cache: false
 install:
-  - travis_retry pip install tox-travis
+  - travis_retry python -m pip install -U tox-travis virtualenv
 script:
   - tox
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,8 @@ classifiers =
 
 [options]
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
-setup_requires = setuptools_scm
+setup_requires =
+    setuptools_scm < 4.0.0
 packages = find:
 zip_safe = false
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,7 @@ classifiers =
 
 [options]
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
-setup_requires =
-    setuptools_scm < 4.0.0
+setup_requires = setuptools_scm
 packages = find:
 zip_safe = false
 install_requires =


### PR DESCRIPTION
Refs https://github.com/pypa/setuptools_scm/issues/442


1. Upgrade `virtualenv` fixed [issue](https://github.com/jazzband/pip-tools/runs/705017713?check_suite_focus=true#step:5:155) with `path.py`

```
File "/tmp/easy_install-KNyzCx/jaraco.windows-5.0.0/temp/easy_install-m7aKTl/path.py-12.4.0/temp/easy_install-LMhEDY/more-itertools-8.3.0/more_itertools/more.py", line 482
    yield from iterable
             ^
SyntaxError: invalid syntax
```

2. Released `setuptools-4.1.0` fixed [issue](https://ci.appveyor.com/project/jazzband/pip-tools/builds/33084292/job/7u6m2qjorh2xkyx3#L85)  with:

```python
File "c:\users\vssadm~1\appdata\local\temp\pip-install-yxxmaf\setuptools-scm\src\setuptools_scm\git.py", line 9, in <module>
    from os.path import samefile
ImportError: cannot import name samefile
```