### PR TITLE
Local repository needs to notify proxied repo of ireq copying

### DIFF
--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -45,6 +45,7 @@ class BaseRepository(object):
         Monkey patches pip.Wheel to allow wheels from all platforms and Python versions.
         """
 
+    @abstractmethod
     def copy_ireq_dependencies(self, source, dest):
         """
         Notifies the repository that `dest` is a copy of `source`, and so it

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -92,3 +92,6 @@ class LocalRequirementsRepository(BaseRepository):
     def allow_all_wheels(self):
         with self.repository.allow_all_wheels():
             yield
+
+    def copy_ireq_dependencies(self, source, dest):
+        self.repository.copy_ireq_dependencies(source, dest)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,10 @@ class FakeRepository(BaseRepository):
         # No need to do an actual pip.Wheel mock here.
         yield
 
+    def copy_ireq_dependencies(self, source, dest):
+        # No state to update.
+        pass
+
 
 class FakeInstalledDistribution(object):
     def __init__(self, line, deps=None):


### PR DESCRIPTION
Otherwise, the proxied repository loses track of what dependencies
the copy has. The local repo is used to prefer versions from an
existing requirements file.

Fixes #1154.
Fixes #1155.

**Changelog-friendly one-liner**: Fixed copying of dependencies when requirements are combined and there is an existing requirements file.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
