### PR TITLE
Add -h alias for --help option

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -61,7 +61,9 @@ class BaseCommand(Command):
         return bool(self._os_args & args)
 
 
-@click.command(cls=BaseCommand, context_settings=CONTEXT_SETTINGS)
+@click.command(
+    cls=BaseCommand, context_settings={"help_option_names": ("-h", "--help")}
+)
 @click.version_option()
 @click.pass_context
 @click.option("-v", "--verbose", count=True, help="Show more output")

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -27,8 +27,6 @@ from ..writer import OutputWriter
 DEFAULT_REQUIREMENTS_FILE = "requirements.in"
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-
 
 def _get_default_option(option_name):
     """

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -27,6 +27,8 @@ from ..writer import OutputWriter
 DEFAULT_REQUIREMENTS_FILE = "requirements.in"
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
 
 def _get_default_option(option_name):
     """
@@ -59,7 +61,7 @@ class BaseCommand(Command):
         return bool(self._os_args & args)
 
 
-@click.command(cls=BaseCommand)
+@click.command(cls=BaseCommand, context_settings=CONTEXT_SETTINGS)
 @click.version_option()
 @click.pass_context
 @click.option("-v", "--verbose", count=True, help="Show more output")

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -20,7 +20,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
 
 
-@click.command(context_settings=CONTEXT_SETTINGS)
+@click.command(context_settings={"help_option_names": ("-h", "--help")})
 @click.version_option()
 @click.option(
     "-a",

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -18,8 +18,10 @@ from ..utils import flat_map
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
-@click.command()
+
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.version_option()
 @click.option(
     "-a",

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -19,7 +19,6 @@ from ..utils import flat_map
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
 
-
 @click.command(context_settings={"help_option_names": ("-h", "--help")})
 @click.version_option()
 @click.option(

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -18,7 +18,6 @@ from ..utils import flat_map
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)


### PR DESCRIPTION
<!--- Describe the changes here. --->
Add shortcut option for help to support `pip-compile|sync -h` 

**Changelog-friendly one-liner**: <!-- One-liner description here -->

Add -h alias for --help option

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
