### PR TITLE
Add pip>=20.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - 3.7
         pip-version:
           - "latest"
+          - "20.2"  # TODO: update to 20.1 after pip-20.2 being released
           - "20.0"
         include:
           - os: Ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ python:
 
 env:
   # NOTE: keep this in sync with envlist in tox.ini for tox-travis.
-  - PIP=20.0
   - PIP=latest
+  - PIP=20.2  # TODO: update to 20.1 after pip-20.2 being released
+  - PIP=20.0
 
 cache: false
 install:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -164,7 +164,10 @@ class PyPIRepository(BaseRepository):
             )
 
             reqset = RequirementSet()
-            ireq.is_direct = True
+            if PIP_VERSION[:2] <= (20, 1):
+                ireq.is_direct = True
+            else:
+                ireq.user_supplied = True
             reqset.add_requirement(ireq)
 
             resolver = self.command.make_resolver(

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .travis.yml for tox-travis.
-    py{27,35,36,37,38,39,py,py3}-pip{20.0,20.1,latest,master}-coverage
+    py{27,35,36,37,38,39,py,py3}-pip{20.0,20.1,20.2,latest,master}-coverage
     checkqa
     readme
 skip_missing_interpreters = True
@@ -12,13 +12,17 @@ extras =
     coverage: coverage
 deps =
     pipmaster: -e git+https://github.com/pypa/pip.git@master#egg=pip
+; TODO: remove all 20.0 mentions after pip-20.2 being released
     pip20.0: pip==20.0.*
-    pip20.1: pip~=20.1b1
+    pip20.1: pip==20.1.*
+; TODO: change to pip==20.2.* after pip-20.2 being released
+    pip20.2: -e git+https://github.com/pypa/pip.git@master#egg=pip
 setenv =
     piplatest: PIP=latest
     pipmaster: PIP=master
     pip20.0: PIP==20.0
     pip20.1: PIP==20.1
+    pip20.2: PIP==20.2
 
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
 commands_pre =
@@ -44,5 +48,6 @@ commands = twine check {distdir}/*
 PIP =
     20.0: pip20.0
     20.1: pip20.1
+    20.2: pip20.2
     latest: piplatest
     master: pipmaster


### PR DESCRIPTION
<!--- Describe the changes here. --->
Addressed breaking changes:
- https://github.com/pypa/pip/pull/8026

`pip-20.2` release tracking issue: https://github.com/pypa/pip/issues/8511

**Changelog-friendly one-liner**: Add `pip>=20.2` support.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).