### PR TITLE
Update sync to return non-zero exit code on dry run

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -183,7 +183,7 @@ def sync(
             for ireq in sorted(to_install, key=key_from_ireq):
                 click.echo("  {}".format(format_requirement(ireq)))
 
-        exit_code = 2
+        exit_code = 1
 
     if ask and click.confirm("Would you like to proceed with these changes?"):
         dry_run = False

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -158,10 +158,12 @@ def sync(
     """
     Install and uninstalls the given sets of modules.
     """
+    exit_code = 0
+
     if not to_uninstall and not to_install:
         if verbose:
             click.echo("Everything up-to-date")
-        return 0
+        return exit_code
 
     pip_flags = []
     if not verbose:
@@ -181,8 +183,11 @@ def sync(
             for ireq in sorted(to_install, key=key_from_ireq):
                 click.echo("  {}".format(format_requirement(ireq)))
 
+        exit_code = 2
+
     if ask and click.confirm("Would you like to proceed with these changes?"):
         dry_run = False
+        exit_code = 0
 
     if not dry_run:
         if to_uninstall:
@@ -215,4 +220,4 @@ def sync(
             finally:
                 os.unlink(tmp_req_file.name)
 
-    return 0
+    return exit_code

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -233,8 +233,7 @@ def test_sync_ask_accepted(check_call, runner):
     assert check_call.call_count == 2
 
 
-@mock.patch("piptools.sync.check_call")
-def test_sync_dry_run_returns_non_zero_exit_code(check_call, runner):
+def test_sync_dry_run_returns_non_zero_exit_code(runner):
     """
     Make sure non-zero exit code is returned when --dry-run is given.
     """

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -120,7 +120,7 @@ def test_merge_error(req_lines, should_raise, runner):
         assert out.exit_code == 2
         assert "Incompatible requirements found" in out.stderr
     else:
-        assert out.exit_code == 2
+        assert out.exit_code == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -242,4 +242,4 @@ def test_sync_dry_run_returns_non_zero_exit_code(runner):
 
     out = runner.invoke(cli, ["--dry-run"])
 
-    assert out.exit_code == 2
+    assert out.exit_code == 1

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -120,7 +120,7 @@ def test_merge_error(req_lines, should_raise, runner):
         assert out.exit_code == 2
         assert "Incompatible requirements found" in out.stderr
     else:
-        assert out.exit_code == 0
+        assert out.exit_code == 2
 
 
 @pytest.mark.parametrize(
@@ -231,3 +231,16 @@ def test_sync_ask_accepted(check_call, runner):
     runner.invoke(cli, ["--ask", "--dry-run"], input="y\n")
 
     assert check_call.call_count == 2
+
+
+@mock.patch("piptools.sync.check_call")
+def test_sync_dry_run_returns_non_zero_exit_code(check_call, runner):
+    """
+    Make sure non-zero exit code is returned when --dry-run is given.
+    """
+    with open("requirements.txt", "w") as req_in:
+        req_in.write("small-fake-a==1.10.0")
+
+    out = runner.invoke(cli, ["--dry-run"])
+
+    assert out.exit_code == 2


### PR DESCRIPTION
Resolves #1166

**Description**
Update sync function and CLI script so that they return non-zero exit codes if they're `dry-run` option is given.

**Changelog-friendly one-liner**: Update sync to return non-zero exit code on dry run

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
