### PR TITLE
Do not search for best_match for -c constraints that are not (yet) requirements

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -323,6 +323,10 @@ class Resolver(object):
             # NOTE: it's much quicker to immediately return instead of
             # hitting the index server
             best_match = ireq
+        elif ireq.constraint:
+            # NOTE: This is not a requirement (yet) and does not need
+            # to be resolved
+            best_match = ireq
         else:
             best_match = self.repository.find_best_match(
                 ireq, prereleases=self.prereleases

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -129,6 +129,18 @@ from piptools.resolver import combine_install_requirements
                     "werkzeug==0.10.4 (from flask==0.10.1)",
                 ],
             ),
+            # We shouldn't fail on invalid irrelevant pip constraints
+            # See: GH-1178
+            (
+                ["Flask", ("missing-dependency<1.0", True), ("itsdangerous", True)],
+                [
+                    "flask==0.10.1",
+                    "itsdangerous==0.24",
+                    "markupsafe==0.23 (from jinja2==2.7.3->flask==0.10.1)",
+                    "jinja2==2.7.3 (from flask==0.10.1)",
+                    "werkzeug==0.10.4 (from flask==0.10.1)",
+                ],
+            ),
             # Unsafe dependencies should be filtered
             (
                 ["setuptools==35.0.0", "anyjson==0.3.3"],


### PR DESCRIPTION
Fixes #1178.

In my organization we use a mono-repository with a huge constraints file for security purposes (via the -c option).
Additionally we have a few internal libs with a lot of versions.

As a result pip-compile is extremely slow as it tries to find a match for all constraints in our constraints file, at each round.
This is not necessary until these constraints become requirements.

The debug line should probably be changed, as an example we have:
```
found candidate urllib3>1.25.7 (constraint was >1.25.7)
```
Maybe I should change it to:
```
unused constraint urllib3>1.25.7
```
or something like that.

**Changelog-friendly one-liner**: Do not find_best_match for constraints (as opposed to requirements)

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
