### PR TITLE
Ignore local hashes with --no-reuse-hashes

### DIFF
--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -33,7 +33,8 @@ class LocalRequirementsRepository(BaseRepository):
     PyPI.  This keeps updates to the requirements.txt down to a minimum.
     """
 
-    def __init__(self, existing_pins, proxied_repository):
+    def __init__(self, existing_pins, proxied_repository, reuse_hashes=True):
+        self._reuse_hashes = reuse_hashes
         self.repository = proxied_repository
         self.existing_pins = existing_pins
 
@@ -74,8 +75,9 @@ class LocalRequirementsRepository(BaseRepository):
         return self.repository.get_dependencies(ireq)
 
     def get_hashes(self, ireq):
-        key = key_from_ireq(ireq)
-        existing_pin = self.existing_pins.get(key)
+        existing_pin = self._reuse_hashes and self.existing_pins.get(
+            key_from_ireq(ireq)
+        )
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             if PIP_VERSION[:2] <= (20, 0):
                 hashes = existing_pin.options.get("hashes", {})

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -184,6 +184,15 @@ class BaseCommand(Command):
     help="Generate pip 8 style hashes in the resulting requirements file.",
 )
 @click.option(
+    "--reuse-hashes/--no-reuse-hashes",
+    is_flag=True,
+    default=True,
+    help=(
+        "Improve the speed of --generate-hashes by reusing the hashes from an "
+        "existing output file."
+    ),
+)
+@click.option(
     "--max-rounds",
     default=10,
     help="Maximum number of rounds before resolving the requirements aborts.",
@@ -241,6 +250,7 @@ def cli(
     output_file,
     allow_unsafe,
     generate_hashes,
+    reuse_hashes,
     src_files,
     max_rounds,
     build_isolation,
@@ -360,7 +370,9 @@ def cli(
                 existing_pins_to_upgrade.add(key)
             else:
                 existing_pins[key] = ireq
-        repository = LocalRequirementsRepository(existing_pins, repository)
+        repository = LocalRequirementsRepository(
+            existing_pins, repository, reuse_hashes=reuse_hashes
+        )
 
     ###
     # Parsing/collecting initial requirements


### PR DESCRIPTION
 Fixes #1176

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Ignore local hashes with `--no-reuse-hashes` in `pip-compile`

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
