### PR TITLE
default to --no-reuse-hashes

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -186,7 +186,7 @@ class BaseCommand(Command):
 @click.option(
     "--reuse-hashes/--no-reuse-hashes",
     is_flag=True,
-    default=True,
+    default=False,
     help=(
         "Improve the speed of --generate-hashes by reusing the hashes from an "
         "existing output file."


### PR DESCRIPTION
A breaking change for v6

**Changelog-friendly one-liner**: default to --no-reuse-hashes

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Now that hashing is way faster than it once was, I think the slight speed improvement from caching no longer outweighs the danger of trusting local/accidental changes to the .txt pins