### PR TITLE
Simplify isort configuration using 'profile = black'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     hooks:
     - id: black
       language_version: python3
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.4.2
     hooks:
     - id: isort
       language_version: python3

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -5,9 +5,9 @@ from contextlib import contextmanager
 
 from pip._internal.utils.hashes import FAVORITE_HASH
 
-from .base import BaseRepository
-
 from piptools.utils import as_tuple, key_from_ireq, make_install_requirement
+
+from .base import BaseRepository
 
 
 def ireq_satisfied_by_existing_pin(ireq, existing_pin):

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,10 +76,4 @@ pytest-parametrize-values-type = tuple
 pytest-parametrize-values-row-type = tuple
 
 [isort]
-combine_as_imports = True
-forced_separate = piptools
-include_trailing_comma = True
-line_length = 88
-multi_line_output = 3
-default_section=THIRDPARTY
-known_first_party = piptools, tests, examples
+profile = black

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,6 @@ from pip._internal.req.constructors import (
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
 
-from .constants import MINIMAL_WHEELS_PATH
-from .utils import looks_like_ci
-
 from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
 from piptools.repositories import PyPIRepository
@@ -31,6 +28,9 @@ from piptools.utils import (
     key_from_req,
     make_install_requirement,
 )
+
+from .constants import MINIMAL_WHEELS_PATH
+from .utils import looks_like_ci
 
 
 class FakeRepository(BaseRepository):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -8,10 +8,10 @@ import mock
 import pytest
 from pip._internal.utils.urls import path_to_url
 
+from piptools.scripts.compile import cli
+
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 from .utils import invoke
-
-from piptools.scripts.compile import cli
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -3,9 +3,9 @@ import sys
 import mock
 import pytest
 
-from .utils import invoke
-
 from piptools.scripts.sync import DEFAULT_REQUIREMENTS_FILE, cli
+
+from .utils import invoke
 
 
 def test_run_as_module_sync():

--- a/tests/test_repository_local.py
+++ b/tests/test_repository_local.py
@@ -2,10 +2,9 @@ import copy
 
 import pytest
 
-from tests.conftest import FakeRepository
-
 from piptools.repositories.local import LocalRequirementsRepository
 from piptools.utils import name_from_req
+from tests.conftest import FakeRepository
 
 EXPECTED = {"sha256:5e6071ee6e4c59e0d0408d366fe9b66781d2cf01be9a6e19a2433bb3c5336330"}
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,10 +7,10 @@ import mock
 import pytest
 from pip._internal.utils.urls import path_to_url
 
-from .constants import PACKAGES_PATH
-
 from piptools.exceptions import IncompatibleRequirements
 from piptools.sync import dependency_tree, diff, merge, sync
+
+from .constants import PACKAGES_PATH
 
 
 @pytest.fixture

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -2,9 +2,9 @@ import os
 
 import pytest
 
-from .constants import PACKAGES_PATH
-
 from piptools.repositories import PyPIRepository
+
+from .constants import PACKAGES_PATH
 
 
 class MockedPyPIRepository(PyPIRepository):


### PR DESCRIPTION
isort now has builtin support for black, use it.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Simplify isort configuration using 'profile = black'

(I'm not sure this needs to be in the changelog, though.)

##### Contributor checklist

- [ ] Provided the tests for the changes. (N/A)
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release). (N/A)
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
