### PR TITLE
Complete testing and documentation of Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,18 @@ jobs:
           - Windows
           - macOS
         python-version:
-          - 3.8
+          - 3.9
           - 2.7
           - 3.5
           - 3.6
           - 3.7
+          - 3.8
         pip-version:
           - "latest"
           - "previous"
         include:
           - os: Ubuntu
-            python-version: 3.9-dev
+            python-version: 3.10-dev
             pip-version: latest
 
     env:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,11 +16,12 @@ jobs:
           - Windows
           - MacOS
         python-version:
-          - 3.8
+          - 3.9
           - 2.7
           - 3.5
           - 3.6
           - 3.7
+          - 3.8
         pip-version:
           - master
     env:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: System :: Systems Administration


### PR DESCRIPTION
<!--- Describe the changes here. --->

Document and add support for Python 3.9.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

---

Testing was added in 7503ad75d849b96c6e29afeefbc2d735681854ae but is now
included in all CI matrices and is documented as trove classifier.

Python 3.9 was released November 15, 2020.
