### PR TITLE
Disable fail-fast in GHA workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os:
           - Ubuntu

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,6 +10,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os:
           - Ubuntu
@@ -44,6 +45,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os:
           - Ubuntu

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -12,6 +12,7 @@ jobs:
     name: ${{ matrix.toxenv }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         toxenv:
           - checkqa


### PR DESCRIPTION
In the event of a CI failure, continue to run the other jobs in the
matrix. This helps contributors to know if the failure is environment
specific or more systemic.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
