### PR TITLE
Enable Python warnings during tests and fix all in the code

### DIFF
--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -12,6 +12,8 @@ class BaseRepository(object):
     def clear_caches(self):
         """Should clear any caches used by the implementation."""
 
+    @abstractmethod
+    @contextmanager
     def freshen_build_caches(self):
         """Should start with fresh build/source caches."""
 

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -56,8 +56,10 @@ class LocalRequirementsRepository(BaseRepository):
     def clear_caches(self):
         self.repository.clear_caches()
 
+    @contextmanager
     def freshen_build_caches(self):
-        self.repository.freshen_build_caches()
+        with self.repository.freshen_build_caches():
+            yield
 
     def find_best_match(self, ireq, prereleases=None):
         key = key_from_ireq(ireq)

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ universal = 1
 norecursedirs = .* build dist venv test_data piptools/_compat/*
 testpaths = tests piptools
 filterwarnings =
+    always
     ignore::PendingDeprecationWarning:pip\._vendor.+
     ignore::DeprecationWarning:pip\._vendor.+
 markers =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,10 @@ class FakeRepository(BaseRepository):
         with open("tests/test_data/fake-editables.json", "r") as f:
             self.editables = json.load(f)
 
+    @contextmanager
+    def freshen_build_caches(self):
+        yield
+
     def get_hashes(self, ireq):
         # Some fake hashes
         return {

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -196,7 +196,7 @@ def test_redacted_urls_in_verbose_output(runner, option):
         cli,
         [
             "--no-header",
-            "--no-index",
+            "--no-emit-index-url",
             "--no-emit-find-links",
             "--verbose",
             option,

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -109,23 +109,30 @@ def test_open_local_or_remote_file__remote_file(
     response_file_path.write_bytes(content)
 
     mock_response = mock.Mock()
-    mock_response.raw = response_file_path.open("rb")
-    mock_response.headers = {"content-length": content_length}
+    with response_file_path.open("rb") as fp:
+        mock_response.raw = fp
+        mock_response.headers = {"content-length": content_length}
 
-    with mock.patch.object(session, "get", return_value=mock_response):
-        with open_local_or_remote_file(link, session) as file_stream:
-            assert file_stream.stream.read() == content
-            assert file_stream.size == expected_content_length
+        with mock.patch.object(session, "get", return_value=mock_response):
+            with open_local_or_remote_file(link, session) as file_stream:
+                assert file_stream.stream.read() == content
+                assert file_stream.size == expected_content_length
 
-    mock_response.close.assert_called_once()
+        mock_response.close.assert_called_once()
 
 
 def test_pypirepo_build_dir_is_str(pypi_repository):
-    assert isinstance(pypi_repository.build_dir, str)
+    assert pypi_repository.build_dir is None
+    with pypi_repository.freshen_build_caches():
+        assert isinstance(pypi_repository.build_dir, str)
+    assert pypi_repository.build_dir is None
 
 
 def test_pypirepo_source_dir_is_str(pypi_repository):
-    assert isinstance(pypi_repository.source_dir, str)
+    assert pypi_repository.source_dir is None
+    with pypi_repository.freshen_build_caches():
+        assert isinstance(pypi_repository.source_dir, str)
+    assert pypi_repository.source_dir is None
 
 
 def test_relative_path_cache_dir_is_normalized(from_line):


### PR DESCRIPTION
When running the test suite with Python warnings enabled, several
warnings are emitted. They look like:

    tests/test_utils.py::test_format_requirement
      /usr/lib64/python3.9/tempfile.py:817: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpezxehep1source'>
        _warnings.warn(warn_message, ResourceWarning)

To solve, make Repository objects a context manager. Upon entering the
with statement, the build an source caches are created and upon exit
they are cleaned up. This ensures they only live for the duration they
are required. This could theoretically be used creating and destroying
any necessary resources. Tests were adjusted.

    tests/test_repository_pypi.py::test_pypirepo_build_dir_is_str
      .../pip/_vendor/requests/adapters.py:59: ResourceWarning: unclosed file <_io.FileIO name='/tmp/pytest-of-jon/pytest-70/test_open_local_or_remote_file5/foo.txt' mode='rb' closefd=True>
        super(BaseAdapter, self).__init__()

To solve, test_open_local_or_remote_file__remote_file() was adjusted to
close its file after use.

    tests/test_cli_compile.py::test_redacted_urls_in_verbose_output[--find-links]
      .../pip-tools/piptools/scripts/compile.py:306: FutureWarning: --index and --no-index are deprecated and will be removed in future versions. Use --emit-index-url/--no-emit-index-url instead.
        warnings.warn(

To solve, use --no-emit-index-url in
test_redacted_urls_in_verbose_output().

There remains one warning left, but this is out of the control of
pip-tools. An upstream PR has been filed:
https://github.com/pypa/pip/pull/9156

Enabling the warnings in test runs will help catch them earlier and make
debugging/fixing easier.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
