### PR TITLE
Remove unnecessary guards around multiple=True CLI options

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -316,23 +316,20 @@ def cli(
 
     right_args = shlex.split(pip_args or "")
     pip_args = []
-    if find_links:
-        for link in find_links:
-            pip_args.extend(["-f", link])
+    for link in find_links:
+        pip_args.extend(["-f", link])
     if index_url:
         pip_args.extend(["-i", index_url])
-    if extra_index_url:
-        for extra_index in extra_index_url:
-            pip_args.extend(["--extra-index-url", extra_index])
+    for extra_index in extra_index_url:
+        pip_args.extend(["--extra-index-url", extra_index])
     if cert:
         pip_args.extend(["--cert", cert])
     if client_cert:
         pip_args.extend(["--client-cert", client_cert])
     if pre:
         pip_args.extend(["--pre"])
-    if trusted_host:
-        for host in trusted_host:
-            pip_args.extend(["--trusted-host", host])
+    for host in trusted_host:
+        pip_args.extend(["--trusted-host", host])
 
     if not build_isolation:
         pip_args.append("--no-build-isolation")

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -185,15 +185,15 @@ def _compose_install_flags(
     else:
         result.append("--no-index")
 
-    for extra_index in extra_index_url or []:
+    for extra_index in extra_index_url:
         result.extend(["--extra-index-url", extra_index])
 
     # Build --trusted-hosts
-    for host in itertools.chain(trusted_host or [], finder.trusted_hosts):
+    for host in itertools.chain(trusted_host, finder.trusted_hosts):
         result.extend(["--trusted-host", host])
 
     # Build --find-links
-    for link in itertools.chain(find_links or [], finder.find_links):
+    for link in itertools.chain(find_links, finder.find_links):
         result.extend(["--find-links", link])
 
     # Build format controls --no-binary/--only-binary


### PR DESCRIPTION
click.option() automatically defaults to an empty list.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
