### PR TITLE
Remove unnecessary flake8 configuration option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ markers =
 
 [flake8]
 max-line-length = 88
-exclude = build/*, dist/*, pip_tools.egg-info/*, piptools/_compat/*, .tox/*, .venv/*, .git/*, .eggs/*
 extend-ignore = E203  # E203 conflicts with PEP8; see https://github.com/psf/black#slices
 
 # flake8-pytest-style


### PR DESCRIPTION
flake8 ignores these directories by default and piptools/_compat/* has
no violations anyway.
