### PR TITLE
Remove unnecessary envvar configuration in click options

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -90,7 +90,6 @@ class BaseCommand(Command):
     "--find-links",
     multiple=True,
     help="Look for archives in this directory or on this HTML page",
-    envvar="PIP_FIND_LINKS",
 )
 @click.option(
     "-i",
@@ -98,13 +97,9 @@ class BaseCommand(Command):
     help="Change index URL (defaults to {index_url})".format(
         index_url=redact_auth_from_url(_get_default_option("index_url"))
     ),
-    envvar="PIP_INDEX_URL",
 )
 @click.option(
-    "--extra-index-url",
-    multiple=True,
-    help="Add additional index URL to search",
-    envvar="PIP_EXTRA_INDEX_URL",
+    "--extra-index-url", multiple=True, help="Add additional index URL to search"
 )
 @click.option("--cert", help="Path to alternate CA bundle.")
 @click.option(
@@ -115,7 +110,6 @@ class BaseCommand(Command):
 @click.option(
     "--trusted-host",
     multiple=True,
-    envvar="PIP_TRUSTED_HOST",
     help="Mark this host as trusted, even though it does not have "
     "valid or any HTTPS.",
 )
@@ -216,9 +210,7 @@ class BaseCommand(Command):
     "--cache-dir",
     help="Store the cache data in DIRECTORY.",
     default=CACHE_DIR,
-    envvar="PIP_TOOLS_CACHE_DIR",
     show_default=True,
-    show_envvar=True,
     type=click.Path(file_okay=False, writable=True),
 )
 @click.option("--pip-args", help="Arguments to pass directly to the pip command.")

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -39,19 +39,10 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     "--find-links",
     multiple=True,
     help="Look for archives in this directory or on this HTML page",
-    envvar="PIP_FIND_LINKS",
 )
+@click.option("-i", "--index-url", help="Change index URL (defaults to PyPI)")
 @click.option(
-    "-i",
-    "--index-url",
-    help="Change index URL (defaults to PyPI)",
-    envvar="PIP_INDEX_URL",
-)
-@click.option(
-    "--extra-index-url",
-    multiple=True,
-    help="Add additional index URL to search",
-    envvar="PIP_EXTRA_INDEX_URL",
+    "--extra-index-url", multiple=True, help="Add additional index URL to search"
 )
 @click.option(
     "--trusted-host",


### PR DESCRIPTION
These are environment variables consumed by pip. As environment
variables are passed through to subprocesses they're already handled. No
special processing in pip-tools is required so simplify the CLI
definition

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
