### PR TITLE
Remove six dependency in favor pip's vendored six

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -2,7 +2,7 @@
 # flake8: noqa
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import six
+from pip._vendor import six
 
 from .pip_compat import PIP_VERSION, parse_requirements
 

--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 
-from six import add_metaclass
+from pip._vendor.six import add_metaclass
 
 
 @add_metaclass(ABCMeta)

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -5,12 +5,12 @@ import sys
 from collections import OrderedDict
 from itertools import chain
 
-import six
 from click.utils import LazyFile
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.vcs import is_url
-from six.moves import shlex_quote
+from pip._vendor import six
+from pip._vendor.six.moves import shlex_quote
 
 from .click import style
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -4,7 +4,7 @@ import os
 import re
 from itertools import chain
 
-import six
+from pip._vendor import six
 
 from .click import unstyle
 from .logging import log

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ packages = find:
 zip_safe = false
 install_requires =
     click >= 7
-    six
     pip >= 20.1
 
 [options.packages.find]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 import os
 
 import pytest
-import six
-from six.moves import shlex_quote
+from pip._vendor import six
+from pip._vendor.six.moves import shlex_quote
 
 from piptools.scripts.compile import cli as compile_cli
 from piptools.utils import (


### PR DESCRIPTION
Allows removing a dependency of pip-tools. The package is already
guaranteed to exist within pip, so might as well use it.

As more and more projects are dropping Python 2 support, they too are
dropping six as a dependency. As more projects drop six, this will
eventually remove the need for projects to pull in six as a transient
dependency.

When pip eventually drops Python 2 support, it will also drop six. When
that day comes, pip-tools can also drop Python 2 support, so the
eventual lack of six should not be an issue.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
