### PR TITLE
Unify sync's logging with compile's logging system

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -54,7 +54,8 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     is_flag=True,
     help="Ignore package index (only looking at --find-links URLs instead)",
 )
-@click.option("-q", "--quiet", default=False, is_flag=True, help="Give less output")
+@click.option("-v", "--verbose", count=True, help="Show more output")
+@click.option("-q", "--quiet", count=True, help="Give less output")
 @click.option(
     "--user", "user_only", is_flag=True, help="Restrict attention to user directory"
 )
@@ -75,6 +76,7 @@ def cli(
     extra_index_url,
     trusted_host,
     no_index,
+    verbose,
     quiet,
     user_only,
     cert,
@@ -83,6 +85,8 @@ def cli(
     pip_args,
 ):
     """Synchronize virtual environment with requirements.txt."""
+    log.verbosity = verbose - quiet
+
     if not src_files:
         if os.path.exists(DEFAULT_REQUIREMENTS_FILE):
             src_files = (DEFAULT_REQUIREMENTS_FILE,)
@@ -138,7 +142,6 @@ def cli(
         sync.sync(
             to_install,
             to_uninstall,
-            verbose=(not quiet),
             dry_run=dry_run,
             install_flags=install_flags,
             ask=ask,

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -9,6 +9,7 @@ from pip._internal.utils.compat import stdlib_pkgs
 
 from . import click
 from .exceptions import IncompatibleRequirements
+from .logging import log
 from .utils import (
     flat_map,
     format_requirement,
@@ -147,26 +148,18 @@ def diff(compiled_requirements, installed_dists):
     return (to_install, to_uninstall)
 
 
-def sync(
-    to_install,
-    to_uninstall,
-    verbose=False,
-    dry_run=False,
-    install_flags=None,
-    ask=False,
-):
+def sync(to_install, to_uninstall, dry_run=False, install_flags=None, ask=False):
     """
     Install and uninstalls the given sets of modules.
     """
     exit_code = 0
 
     if not to_uninstall and not to_install:
-        if verbose:
-            click.echo("Everything up-to-date")
+        log.info("Everything up-to-date", err=False)
         return exit_code
 
     pip_flags = []
-    if not verbose:
+    if log.verbosity < 0:
         pip_flags += ["-q"]
 
     if ask:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -272,15 +272,7 @@ def test_sync_install_temporary_requirement_file(
         to_install = {from_line("django==1.8")}
         sync(to_install, set())
         check_call.assert_called_once_with(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "-r",
-                mocked_tmp_req_file.name,
-                "-q",
-            ]
+            [sys.executable, "-m", "pip", "install", "-r", mocked_tmp_req_file.name]
         )
 
 
@@ -381,7 +373,7 @@ def test_sync_up_to_date(runner):
     Everything up-to-date should be printed.
     """
     with runner.isolation() as (stdout, _):
-        sync(set(), set(), verbose=True)
+        sync(set(), set())
     assert stdout.getvalue().decode().splitlines() == ["Everything up-to-date"]
 
 
@@ -390,7 +382,7 @@ def test_sync_verbose(check_call, from_line):
     """
     The -q option has to be passed to every pip calls.
     """
-    sync({from_line("django==1.8")}, {from_line("click==4.0")}, verbose=True)
+    sync({from_line("django==1.8")}, {from_line("click==4.0")})
     assert check_call.call_count == 2
     for call in check_call.call_args_list:
         check_call_args = call[0][0]
@@ -473,5 +465,5 @@ def test_sync_uninstall_pip_command(check_call):
 
     sync(set(), to_uninstall)
     check_call.assert_called_once_with(
-        [sys.executable, "-m", "pip", "uninstall", "-y", "-q"] + sorted(to_uninstall)
+        [sys.executable, "-m", "pip", "uninstall", "-y"] + sorted(to_uninstall)
     )


### PR DESCRIPTION
sync now uses the same cumulative --verbose/--quiet as compile. sync
output calls go through the LogContext object.

##### Contributor checklist

- [x] Provided the tests for the changes. (already exist)
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
