### PR TITLE
Delay indexing option.opts until its use in get_compile_command()

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -315,9 +315,6 @@ def get_compile_command(click_ctx):
     for option_name, value in click_ctx.params.items():
         option = compile_options[option_name]
 
-        # Get the latest option name (usually it'll be a long name)
-        option_long_name = option.opts[-1]
-
         # Collect variadic args separately, they will be added
         # at the end of the command later
         if option.nargs < 0:
@@ -327,6 +324,9 @@ def get_compile_command(click_ctx):
                 right_args.append("--")
             right_args.extend([shlex_quote(force_text(val)) for val in value])
             continue
+
+        # Get the latest option name (usually it'll be a long name)
+        option_long_name = option.opts[-1]
 
         # Exclude one-off options (--upgrade/--upgrade-package/--rebuild/...)
         # or options that don't change compile behaviour (--verbose/--dry-run/...)


### PR DESCRIPTION
For the src_files argument, the list is indexed and then unused as the
loop exits early.

Brings actual use closer to the variable definition.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
