### PR TITLE
Avoid spurious output during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import json
 import os
+import subprocess
 import sys
 from contextlib import contextmanager
 from functools import partial
-from subprocess import check_call
 from textwrap import dedent
 
 import pytest
@@ -259,6 +259,9 @@ def make_package(tmp_path):
                     setup(
                         name={name!r},
                         version={version!r},
+                        author="pip-tools",
+                        author_email="pip-tools@localhost",
+                        url="https://github.com/jazzband/pip-tools",
                         install_requires={install_requires_str},
                     )
                     """.format(
@@ -268,6 +271,12 @@ def make_package(tmp_path):
                     )
                 )
             )
+
+        # Create a README to avoid setuptools warnings.
+        readme_file = str(package_dir / "README")
+        with open(readme_file, "w"):
+            pass
+
         return package_dir
 
     return _make_package
@@ -281,9 +290,12 @@ def run_setup_file():
 
     def _run_setup_file(package_dir_path, *args):
         setup_file = str(package_dir_path / "setup.py")
-        return check_call(
-            (sys.executable, setup_file) + args, cwd=str(package_dir_path)
-        )  # nosec
+        with open(os.devnull, "w") as fp:
+            return subprocess.check_call(
+                (sys.executable, setup_file) + args,
+                cwd=str(package_dir_path),
+                stdout=fp,
+            )  # nosec
 
     return _run_setup_file
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -311,7 +311,7 @@ def test_realistic_complex_sub_dependencies(runner):
     with open("requirements.in", "w") as req_in:
         req_in.write("fake_with_deps")  # require fake package
 
-    out = runner.invoke(cli, ["-v", "-n", "--rebuild", "-f", wheels_dir])
+    out = runner.invoke(cli, ["-n", "--rebuild", "-f", wheels_dir])
 
     assert out.exit_code == 0
 

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -10,7 +10,7 @@ from piptools.repositories import PyPIRepository
 from piptools.repositories.pypi import open_local_or_remote_file
 
 
-def test_generate_hashes_all_platforms(pip_conf, from_line, pypi_repository):
+def test_generate_hashes_all_platforms(capfd, pip_conf, from_line, pypi_repository):
     expected = {
         "sha256:8d4d131cd05338e09f461ad784297efea3652e542c5fabe04a62358429a6175e",
         "sha256:ad05e1371eb99f257ca00f791b755deb22e752393eb8e75bc01d651715b02ea9",
@@ -20,6 +20,12 @@ def test_generate_hashes_all_platforms(pip_conf, from_line, pypi_repository):
     ireq = from_line("small-fake-multi-arch==0.1")
     with pypi_repository.allow_all_wheels():
         assert pypi_repository.get_hashes(ireq) == expected
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert (
+        captured.err.strip()
+        == "Couldn't get hashes from PyPI, fallback to hashing files"
+    )
 
 
 @pytest.mark.network

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import logging
 import os
 
 import pytest
@@ -178,13 +179,22 @@ def test_is_pinned_requirement_editable(from_editable):
         ("https://example.com/example.zip", True),
         ("https://example.com/example.zip#egg=example", True),
         ("git+git://github.com/jazzband/pip-tools@master", True),
-        ("../example.zip", True),
-        ("/example.zip", True),
     ),
 )
-def test_is_url_requirement(from_line, line, expected):
+def test_is_url_requirement(caplog, from_line, line, expected):
     ireq = from_line(line)
     assert is_url_requirement(ireq) is expected
+
+
+@pytest.mark.parametrize("line", ("../example.zip", "/example.zip"))
+def test_is_url_requirement_filename(caplog, from_line, line):
+    # Ignore warning:
+    #
+    #     Requirement '../example.zip' looks like a filename, but the file does
+    #     not exist
+    caplog.set_level(logging.ERROR, logger="pip")
+    ireq = from_line(line)
+    assert is_url_requirement(ireq) is True
 
 
 def test_name_from_req(from_line):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -5,6 +5,7 @@ from piptools.scripts.compile import cli
 from piptools.utils import comment
 from piptools.writer import (
     MESSAGE_UNHASHED_PACKAGE,
+    MESSAGE_UNINSTALLABLE,
     MESSAGE_UNSAFE_PACKAGES,
     MESSAGE_UNSAFE_PACKAGES_UNPINNED,
     OutputWriter,
@@ -117,7 +118,7 @@ def test_iter_lines__unsafe_dependencies(writer, from_line, allow_unsafe):
     assert tuple(lines) == expected_lines
 
 
-def test_iter_lines__unsafe_with_hashes(writer, from_line):
+def test_iter_lines__unsafe_with_hashes(capfd, writer, from_line):
     writer.allow_unsafe = False
     writer.emit_header = False
     ireqs = [from_line("test==1.2")]
@@ -133,9 +134,12 @@ def test_iter_lines__unsafe_with_hashes(writer, from_line):
         comment("# setuptools"),
     )
     assert tuple(lines) == expected_lines
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == MESSAGE_UNINSTALLABLE
 
 
-def test_iter_lines__hash_missing(writer, from_line):
+def test_iter_lines__hash_missing(capfd, writer, from_line):
     writer.allow_unsafe = False
     writer.emit_header = False
     ireqs = [from_line("test==1.2"), from_line("file:///example/#egg=example")]
@@ -149,6 +153,9 @@ def test_iter_lines__hash_missing(writer, from_line):
         "test==1.2 \\\n    --hash=FAKEHASH",
     )
     assert tuple(lines) == expected_lines
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == MESSAGE_UNINSTALLABLE
 
 
 def test_iter_lines__no_warn_if_only_unhashable_packages(writer, from_line):


### PR DESCRIPTION
It is often convenient to use the pytest option "-s" (shortcut for
--capture=no) to view one's own debugging print() output. When there is
already lots of spurious output, it produces lots of noise and it may be
difficult to view the intended debugging output. By avoiding unnecessary
output, it is easier to find.

Tests that have intentional output now assert that output. For example,
the output of the sync command is now asserted. In addition to the
advantage above, this creates a more robust test suite as the expected
behavior is now more explicit, precise, and better covered.

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
