### PR TITLE
Remove now-unnecessary PIP_REQ_TRACKER cleanup

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -247,17 +247,9 @@ class PyPIRepository(BaseRepository):
 
             with global_tempdir_manager():
                 wheel_cache = WheelCache(self._cache_dir, self.options.format_control)
-                prev_tracker = os.environ.get("PIP_REQ_TRACKER")
-                try:
-                    self._dependencies_cache[ireq] = self.resolve_reqs(
-                        download_dir, ireq, wheel_cache
-                    )
-                finally:
-                    if "PIP_REQ_TRACKER" in os.environ:
-                        if prev_tracker:
-                            os.environ["PIP_REQ_TRACKER"] = prev_tracker
-                        else:
-                            del os.environ["PIP_REQ_TRACKER"]
+                self._dependencies_cache[ireq] = self.resolve_reqs(
+                    download_dir, ireq, wheel_cache
+                )
 
         return self._dependencies_cache[ireq]
 


### PR DESCRIPTION
Since pip 20.0, this is cleaned up automatically by pip. See upstream
commits:

https://github.com/pypa/pip/commit/4a97d91a39ea94c4ef285bc870d5872aa283be8b
get_requirement_tracker() is introduced which uses a context manager to
set and reset the PIP_REQ_TRACKER environment variable.

https://github.com/pypa/pip/commit/b953ef4d18b3a86e19213685c6572732b32a034b
The PIP_REQ_TRACKER is no longer set directly in favor of the context
manage mentioned above.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
