### PR TITLE
Remove unused environment variable PIP from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,13 +20,6 @@ deps =
     # TODO: change to `pip==20.3.*` after pip-20.3 being released
     pip20.3: -e git+https://github.com/pypa/pip.git@master#egg=pip
 setenv =
-    pipprevious: PIP=previous
-    piplatest: PIP=latest
-    pipmaster: PIP=master
-    pip20.1: PIP==20.1
-    pip20.2: PIP==20.2
-    pip20.3: PIP==20.3
-
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
 commands_pre =
     piplatest: python -m pip install -U pip


### PR DESCRIPTION
Unused since b387e5e984f6fc593706e7fc51463924ac43a670.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release). (n/a)
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
