### PR TITLE
Make some long hashes in tests slightly more readable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ markers =
     network: mark tests that require internet access
 
 [flake8]
-max-line-length = 100
+max-line-length = 88
 extend-ignore = E203  # E203 conflicts with PEP8; see https://github.com/psf/black#slices
 
 # flake8-pytest-style

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -414,11 +414,7 @@ def test_editable_package_in_constraints(pip_conf, runner, req_editable):
 
 @pytest.mark.network
 def test_editable_package_vcs(runner):
-    vcs_package = (
-        "git+git://github.com/jazzband/pip-tools@"
-        "f97e62ecb0d9b70965c8eff952c001d8e2722e94"
-        "#egg=pip-tools"
-    )
+    vcs_package = "git+git://github.com/jazzband/pip-tools@f97e62ecb0d9b70965c8eff952c001d8e2722e94#egg=pip-tools"  # noqa: E501
     with open("requirements.in", "w") as req_in:
         req_in.write("-e " + vcs_package)
     out = runner.invoke(cli, ["-n", "--rebuild"])
@@ -706,11 +702,9 @@ def test_generate_hashes_with_editable(pip_conf, runner):
     expected = (
         "-e {}\n"
         "small-fake-a==0.1 \\\n"
-        "    --hash=sha256:5e6071ee6e4c59e0d0408d366f"
-        "e9b66781d2cf01be9a6e19a2433bb3c5336330\n"
+        "    --hash=sha256:5e6071ee6e4c59e0d0408d366fe9b66781d2cf01be9a6e19a2433bb3c5336330\n"  # noqa: E501
         "small-fake-b==0.1 \\\n"
-        "    --hash=sha256:acdba8f8b8a816213c30d5310c"
-        "3fe296c0107b16ed452062f7f994a5672e3b3f\n"
+        "    --hash=sha256:acdba8f8b8a816213c30d5310c3fe296c0107b16ed452062f7f994a5672e3b3f\n"  # noqa: E501
     ).format(small_fake_package_url)
     assert out.exit_code == 0
     assert expected in out.stderr
@@ -720,15 +714,12 @@ def test_generate_hashes_with_editable(pip_conf, runner):
 def test_generate_hashes_with_url(runner):
     with open("requirements.in", "w") as fp:
         fp.write(
-            "https://github.com/jazzband/pip-tools/archive/"
-            "7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip#egg=pip-tools\n"
+            "https://github.com/jazzband/pip-tools/archive/7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip#egg=pip-tools\n"  # noqa: E501
         )
     out = runner.invoke(cli, ["--no-annotate", "--generate-hashes"])
     expected = (
-        "https://github.com/jazzband/pip-tools/archive/"
-        "7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip#egg=pip-tools \\\n"
-        "    --hash=sha256:d24de92e18ad5bf291f25cfcdcf"
-        "0171be6fa70d01d0bef9eeda356b8549715e7\n"
+        "https://github.com/jazzband/pip-tools/archive/7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip#egg=pip-tools \\\n"  # noqa: E501
+        "    --hash=sha256:d24de92e18ad5bf291f25cfcdcf0171be6fa70d01d0bef9eeda356b8549715e7\n"  # noqa: E501
     )
     assert out.exit_code == 0
     assert expected in out.stderr
@@ -764,7 +755,7 @@ def test_generate_hashes_with_annotations(runner):
             --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \\
             --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
             # via -r requirements.in
-        """
+        """  # noqa: E501
     )
 
 
@@ -819,7 +810,7 @@ def test_generate_hashes_with_long_annotations(runner):
             # via
             #   -r requirements.in
             #   django-debug-toolbar
-        """
+        """  # noqa: E501
     )
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -318,8 +318,7 @@ def test_sync_requirement_file_with_hashes(
                 options={
                     "hashes": {
                         "sha256": [
-                            "6a03ce2feafdd193a0ba8a26dbd9773e"
-                            "757d2e5d5e7933a62eac129813bd381a"
+                            "6a03ce2feafdd193a0ba8a26dbd9773e757d2e5d5e7933a62eac129813bd381a",  # noqa: E501
                         ]
                     }
                 },
@@ -329,8 +328,7 @@ def test_sync_requirement_file_with_hashes(
                 options={
                     "hashes": {
                         "sha256": [
-                            "9ab1d313f99b209f8f71a629f3683303"
-                            "0c8d7c72282cf7756834baf567dca662"
+                            "9ab1d313f99b209f8f71a629f36833030c8d7c72282cf7756834baf567dca662",  # noqa: E501
                         ]
                     }
                 },
@@ -340,10 +338,8 @@ def test_sync_requirement_file_with_hashes(
                 options={
                     "hashes": {
                         "sha256": [
-                            "d1d6729c85acea542367138286862712"
-                            "9432fba9a89ecbb248d8d1c7a9f01c67",
-                            "f5c056e8f62d45ba8215e5cb8f50dfcc"
-                            "b198b4b9fbea8500674f3443e4689589",
+                            "d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67",  # noqa: E501
+                            "f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589",  # noqa: E501
                         ]
                     }
                 },
@@ -354,16 +350,12 @@ def test_sync_requirement_file_with_hashes(
 
         expected = (
             "click==4.0 \\\n"
-            "    --hash=sha256:9ab1d313f99b209f8f71a629"
-            "f36833030c8d7c72282cf7756834baf567dca662\n"
+            "    --hash=sha256:9ab1d313f99b209f8f71a629f36833030c8d7c72282cf7756834baf567dca662\n"  # noqa: E501
             "django==1.8 \\\n"
-            "    --hash=sha256:6a03ce2feafdd193a0ba8a26"
-            "dbd9773e757d2e5d5e7933a62eac129813bd381a\n"
+            "    --hash=sha256:6a03ce2feafdd193a0ba8a26dbd9773e757d2e5d5e7933a62eac129813bd381a\n"  # noqa: E501
             "pytz==2017.2 \\\n"
-            "    --hash=sha256:d1d6729c85acea542367138286"
-            "8627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n"
-            "    --hash=sha256:f5c056e8f62d45ba8215e5cb8f"
-            "50dfccb198b4b9fbea8500674f3443e4689589"
+            "    --hash=sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n"  # noqa: E501
+            "    --hash=sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589"  # noqa: E501
         )
         mocked_tmp_req_file.write.assert_called_once_with(expected)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,10 +61,8 @@ def test_format_requirement_ireq_with_hashes(from_line):
 
     expected = (
         "pytz==2017.2 \\\n"
-        "    --hash=sha256:d1d6729c85acea542367138286"
-        "8627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n"
-        "    --hash=sha256:f5c056e8f62d45ba8215e5cb8f5"
-        "0dfccb198b4b9fbea8500674f3443e4689589"
+        "    --hash=sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n"  # noqa: E501
+        "    --hash=sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589"  # noqa: E501
     )
     assert format_requirement(ireq, hashes=ireq_hashes) == expected
 
@@ -79,10 +77,8 @@ def test_format_requirement_ireq_with_hashes_and_markers(from_line):
 
     expected = (
         'pytz==2017.2 ; python_version<"3.0" \\\n'
-        "    --hash=sha256:d1d6729c85acea542367138286"
-        "8627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n"
-        "    --hash=sha256:f5c056e8f62d45ba8215e5cb8f5"
-        "0dfccb198b4b9fbea8500674f3443e4689589"
+        "    --hash=sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67 \\\n"  # noqa: E501
+        "    --hash=sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589"  # noqa: E501
     )
     assert format_requirement(ireq, marker, hashes=ireq_hashes) == expected
 


### PR DESCRIPTION
The expected stdout is easier to read when the lines aren't broken up
mid-line. Expand the allowed line length just enough to make these long
lines look more like the real output.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release). (n/a)
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
