### PR TITLE
Remove bandit lint tool

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,0 @@
-[bandit]
-exclude: tests,.tox,.eggs,.venv,.git
-skips: B101

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,6 @@ repos:
         # Avoid error: Duplicate module named 'setup'
         # https://github.com/python/mypy/issues/4008
         exclude: ^tests/test_data/
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
-    hooks:
-      - id: bandit
-        args: [--ini, .bandit]
-        exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.2.1
     hooks:

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -2,7 +2,7 @@ import collections
 import os
 import sys
 import tempfile
-from subprocess import run  # nosec
+from subprocess import run
 from typing import Deque, Dict, Iterable, List, Optional, Set, Tuple, ValuesView
 
 import click
@@ -202,7 +202,7 @@ def sync(
 
     if not dry_run:
         if to_uninstall:
-            run(  # nosec
+            run(
                 [
                     sys.executable,
                     "-m",
@@ -230,7 +230,7 @@ def sync(
             tmp_req_file.close()
 
             try:
-                run(  # nosec
+                run(
                     [
                         sys.executable,
                         "-m",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,7 +284,7 @@ def run_setup_file():
             cwd=str(package_dir_path),
             stdout=subprocess.DEVNULL,
             check=True,
-        )  # nosec
+        )
 
     return _run_setup_file
 


### PR DESCRIPTION
I'm not convinced this has demonstrated its benefit to the code base.
When introduced, it changed one assert usage to a raise -- that's it --
which doesn't seem all that interesting of a change. Beyond that, this
tool requires many useless "nosec" comments for each suprocess call,
which I find distracting.

The tool itself adds overhead -- even if small -- to all contributor's
test runs and CI. IMO, we're better off without it.

##### Contributor checklist

- [ ] Provided the tests for the changes. (n/a)
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release). (n/a)
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
