### PR TITLE
Use more descriptive exceptions than AssertionError

### DIFF
--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -45,7 +45,7 @@ def read_cache_file(cache_file_path):
 
         # Check version and load the contents
         if doc["__format__"] != 1:
-            raise AssertionError("Unknown cache file format")
+            raise ValueError("Unknown cache file format")
         return doc["dependencies"]
 
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -262,7 +262,7 @@ def fs_str(string):
     if isinstance(string, str):
         return string
     if isinstance(string, bytes):
-        raise AssertionError
+        raise TypeError("fs_str() argument must not be bytes")
     return string.encode(_fs_encoding)
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -48,7 +48,7 @@ def test_read_cache_file_wrong_format():
     A cache file with a wrong "__format__" value should throw an assertion error.
     """
     with _read_cache_file_helper('{"__format__": 2}') as cache_file_name:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match=r"^Unknown cache file format$"):
             read_cache_file(cache_file_name)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -215,7 +215,7 @@ def test_fs_str():
 
 @pytest.mark.skipif(six.PY2, reason="Not supported in py2")
 def test_fs_str_with_bytes():
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError, match=r"^fs_str\(\) argument must not be bytes$"):
         fs_str(b"whatever")
 
 


### PR DESCRIPTION
Better match Python conventions and the stdlib by using TypeError and
ValueError rather than AssertionError.

For example, in CPython:

    $ python -c 'int(object())'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    TypeError: int() argument must be a string, a bytes-like object or a number, not 'object'

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
