### PR TITLE
Add --no-allow-unsafe option to compile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -472,6 +472,11 @@ This section lists ``pip-tools`` features that are currently deprecated.
 - ``--index/--no-index`` command-line options, use instead
   ``--emit-index-url/--no-emit-index-url`` (since 5.2.0).
 
+- In future versions, the ``--allow-unsafe`` behavior will be enabled by
+  default. Use ``--no-allow-unsafe`` to keep the old behavior. It is
+  recommended to pass the ``--allow-unsafe`` now to adapt to the upcoming
+  change.
+
 Versions and compatibility
 ==========================
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -164,11 +164,16 @@ class BaseCommand(Command):
     ),
 )
 @click.option(
-    "--allow-unsafe",
+    "--allow-unsafe/--no-allow-unsafe",
     is_flag=True,
     default=False,
-    help="Pin packages considered unsafe: {}".format(
-        ", ".join(sorted(UNSAFE_PACKAGES))
+    help=(
+        "Pin packages considered unsafe: {}.\n\n"
+        "WARNING: Future versions of pip-tools will enable this behavior by default. "
+        "Use --no-allow-unsafe to keep the old behavior. It is recommended to pass the "
+        "--allow-unsafe now to adapt to the upcoming change.".format(
+            ", ".join(sorted(UNSAFE_PACKAGES))
+        )
     ),
 )
 @click.option(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1010,7 +1010,11 @@ def test_annotate_option(pip_conf, runner, option, expected):
 
 @pytest.mark.parametrize(
     ("option", "expected"),
-    (("--allow-unsafe", "small-fake-a==0.1"), (None, "# small-fake-a")),
+    (
+        ("--allow-unsafe", "small-fake-a==0.1"),
+        ("--no-allow-unsafe", "# small-fake-a"),
+        (None, "# small-fake-a"),
+    ),
 )
 def test_allow_unsafe_option(pip_conf, monkeypatch, runner, option, expected):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,6 +260,7 @@ def test_force_text(value, expected_text):
         (["--no-emit-index-url"], "pip-compile --no-emit-index-url"),
         (["--no-emit-trusted-host"], "pip-compile --no-emit-trusted-host"),
         (["--no-annotate"], "pip-compile --no-annotate"),
+        (["--no-allow-unsafe"], "pip-compile"),
         # Check that default values will be removed from the command
         (["--emit-trusted-host"], "pip-compile"),
         (["--annotate"], "pip-compile"),


### PR DESCRIPTION
In future versions of pip-tools, the --allow-unsafe behavior will used
by default. Adding the --no-allow-unsafe option now allows users to
continue using the old behavior in a backward compatible way.

Refs #989

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
