### PR TITLE
Remove unnecessary system calls via os.path.exists()/os.path.isdir()

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -2,6 +2,9 @@
 # flake8: noqa
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import errno
+import os
+
 from pip._vendor import six
 
 from .pip_compat import PIP_VERSION, parse_requirements
@@ -10,3 +13,14 @@ if six.PY2:
     from .tempfile import TemporaryDirectory
 else:
     from tempfile import TemporaryDirectory
+
+
+def makedirs(name, mode=0o777, exist_ok=False):
+    if six.PY2:
+        try:
+            os.makedirs(name, mode)
+        except OSError as e:
+            if not exist_ok or e.errno != errno.EEXIST:
+                raise
+    else:
+        os.makedirs(name, mode, exist_ok)

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -24,7 +24,7 @@ from pip._internal.utils.temp_dir import TempDirectory, global_tempdir_manager
 from pip._internal.utils.urls import path_to_url, url_to_path
 from pip._vendor.requests import RequestException
 
-from .._compat import PIP_VERSION, TemporaryDirectory, contextlib
+from .._compat import PIP_VERSION, TemporaryDirectory, contextlib, makedirs
 from ..click import progressbar
 from ..exceptions import NoCandidateFound
 from ..logging import log
@@ -238,12 +238,9 @@ class PyPIRepository(BaseRepository):
                 download_dir = None
             else:
                 download_dir = self._get_download_path(ireq)
-                if not os.path.isdir(download_dir):
-                    os.makedirs(download_dir)
-            if PIP_VERSION[:2] <= (20, 2) and not os.path.isdir(
-                self._wheel_download_dir
-            ):
-                os.makedirs(self._wheel_download_dir)
+                makedirs(download_dir, exist_ok=True)
+            if PIP_VERSION[:2] <= (20, 2):
+                makedirs(self._wheel_download_dir, exist_ok=True)
 
             with global_tempdir_manager():
                 wheel_cache = WheelCache(self._cache_dir, self.options.format_control)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+from piptools._compat import makedirs
+
+
+def test_makedirs_exist_ok_true(tmpdir):
+    path = str(tmpdir / "test")
+    makedirs(path, exist_ok=True)
+    assert os.path.isdir(path)
+    makedirs(path, exist_ok=True)
+    assert os.path.isdir(path)
+
+
+def test_makedirs_exist_ok_false(tmpdir):
+    path = str(tmpdir / "test")
+    makedirs(path)
+    assert os.path.isdir(path)
+    with pytest.raises(OSError, match="exists"):
+        makedirs(path)


### PR DESCRIPTION
Rather than checking a file exists, then reading it, simply read it and
handle the potential ENOENT OS error. This reduces the number of system
calls from:

    1. check file exists
    2. read file

To:

    1. read file

Reducing system calls is an optimization.

More importantly, this also avoids race conditions that were previously
not handled. If the file was deleted after the existence check but
before reading it, an unhandled FileNotFound error would be raised.

This approach better follows Python pattern "Easier to ask for
forgiveness than permission" rather than the "Look before you leap"
approach. See: https://docs.python.org/3/glossary.html#term-eafp

The same pattern applies to os.makedirs(). Add a compatibility shim to
allow using the exist_ok parameter on Python 2.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
