### PR TITLE
Remove unnecessary coerce to str

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -345,7 +345,7 @@ class PyPIRepository(BaseRepository):
         if not is_pinned_requirement(ireq):
             raise TypeError("Expected pinned requirement, got {}".format(ireq))
 
-        log.debug("{}".format(ireq.name))
+        log.debug(ireq.name)
 
         with log.indentation():
             hashes = self._get_hashes_from_pypi(ireq)


### PR DESCRIPTION
ireq.name is already a str instance.

##### Contributor checklist

- [ ] Provided the tests for the changes. (n/a)
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release). (n/a)
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
