### PR TITLE
Remove unreachable code in PyPIRepository.get_hashes()

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -339,9 +339,6 @@ class PyPIRepository(BaseRepository):
                     cached_link = link
                 return {self._get_file_hash(cached_link)}
 
-        if not is_pinned_requirement(ireq):
-            raise TypeError("Expected pinned requirement, got {}".format(ireq))
-
         log.debug(ireq.name)
 
         with log.indentation():


### PR DESCRIPTION
get_hashes() is only called after the dependencies have been resolved.
After they have been resolved, requirements are either links or pinned
requirements.

If the requirement is a link, the "if ireq.link" block is executed and
the function returns early. If the requirement is not a link, then it
has been resolved to an exact version. Either way, the exception will
never be raised.

This line is untested and so frequently appears as uncovered during
coverage analysis, erroneously marking the PR with a big red ❌ when the
PR is otherwise green.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
