### PR TITLE
Add coverage for "if not is_pinned_requirement(…)" in get_hashes()

### DIFF
--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -66,6 +66,14 @@ def test_get_hashes_editable_empty_set(from_editable, pypi_repository):
     assert pypi_repository.get_hashes(ireq) == set()
 
 
+def test_get_hashes_unpinned_raises(from_line, pypi_repository):
+    # Under normal pip-tools usage, get_hashes() should never be called with an
+    # unpinned requirement. The TypeError represents a programming mistake.
+    ireq = from_line("django")
+    with pytest.raises(TypeError, match=r"^Expected pinned requirement, got django"):
+        pypi_repository.get_hashes(ireq)
+
+
 @pytest.mark.parametrize(("content", "content_length"), ((b"foo", 3), (b"foobar", 6)))
 def test_open_local_or_remote_file__local_file(tmp_path, content, content_length):
     """


### PR DESCRIPTION
This line is untested and so frequently appears as uncovered during
coverage analysis, erroneously marking the PR with a big red x when the
PR is otherwise green.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
