### PR TITLE
Use mypy for static type checking

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         toxenv:
           - checkqa
+          - mypy
           - readme
         python-version:
           - "3.x"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         toxenv:
           - checkqa
-          - mypy
           - readme
         python-version:
           - "3.x"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,13 @@ repos:
       language_version: python3
       additional_dependencies:
       - flake8-pytest-style
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.790
+    hooks:
+      - id: mypy
+        # Avoid error: Duplicate module named 'setup'
+        # https://github.com/python/mypy/issues/4008
+        exclude: ^tests/test_data/
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.0
     hooks:

--- a/piptools/logging.py
+++ b/piptools/logging.py
@@ -12,7 +12,7 @@ logging.basicConfig()
 class LogContext:
     stream = sys.stderr
 
-    def __init__(self, verbosity=0, indent_width=2):
+    def __init__(self, verbosity: int = 0, indent_width: int = 2):
         self.verbosity = verbosity
         self.current_indent = 0
         self._indent_width = indent_width

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -3,6 +3,7 @@ import shlex
 import sys
 import tempfile
 import warnings
+from typing import Any
 
 from click import Command
 from click.utils import safecall
@@ -25,7 +26,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.in"
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 
 
-def _get_default_option(option_name):
+def _get_default_option(option_name: str) -> Any:
     """
     Get default value of the pip's option (including option from pip.conf)
     by a given option name.

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -43,7 +43,7 @@ def key_from_req(req):
     return key
 
 
-def comment(text):
+def comment(text: str) -> str:
     return style(text, fg="green")
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,3 +69,17 @@ pytest-parametrize-values-row-type = tuple
 
 [isort]
 profile = black
+
+[mypy]
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+ignore_missing_imports = true
+no_implicit_optional = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
     py{36,37,38,39,py,py3}-pip{20.1,20.2,20.3,previous,latest,master}-coverage
     checkqa
+    mypy
     readme
 skip_missing_interpreters = True
 
@@ -32,6 +33,11 @@ skip_install = True
 deps = pre-commit
 commands_pre =
 commands = pre-commit run --all-files --show-diff-on-failure
+
+[testenv:mypy]
+deps = mypy
+commands_pre =
+commands = mypy piptools
 
 [testenv:readme]
 deps = twine

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
     py{36,37,38,39,py,py3}-pip{20.1,20.2,20.3,previous,latest,master}-coverage
     checkqa
-    mypy
     readme
 skip_missing_interpreters = True
 
@@ -33,11 +32,6 @@ skip_install = True
 deps = pre-commit
 commands_pre =
 commands = pre-commit run --all-files --show-diff-on-failure
-
-[testenv:mypy]
-deps = mypy
-commands_pre =
-commands = mypy piptools
 
 [testenv:readme]
 deps = twine


### PR DESCRIPTION
Type checking helps give confidence that APIs are being used correctly,
especially during large refactoring (e.g. eventually dropping Python 2
support).

This initial pass only includes type comments that were necessary to
make mypy pass. Future pull requests will add types for the rest of the
project once the workflow is established.

pip has started including type annotation in a subset of its code. When
major changes to pip are released, the type checking will help identify
API mismatches and areas to adjust.

mypy is configured to be as strict as possible without introducing
errors. The configuration is a subset of the --strict CLI argument.

Refs #972

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
