### PR TITLE
Remove unnecessary util function force_text()

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -254,17 +254,6 @@ def get_hashes_from_ireq(ireq):
     return result
 
 
-def force_text(s):
-    """
-    Return a string representing `s`.
-    """
-    if s is None:
-        return ""
-    if not isinstance(s, str):
-        return str(s)
-    return s
-
-
 def get_compile_command(click_ctx):
     """
     Returns a normalized compile command depending on cli context.
@@ -294,7 +283,7 @@ def get_compile_command(click_ctx):
             # Re-add click-stripped '--' if any start with '-'
             if any(val.startswith("-") and val != "-" for val in value):
                 right_args.append("--")
-            right_args.extend([shlex.quote(force_text(val)) for val in value])
+            right_args.extend([shlex.quote(val) for val in value])
             continue
 
         # Get the latest option name (usually it'll be a long name)
@@ -343,8 +332,6 @@ def get_compile_command(click_ctx):
                     # Instead, we try to get more legible quoting via repr:
                     left_args.append(f"{option_long_name}={repr(val)}")
                 else:
-                    left_args.append(
-                        f"{option_long_name}={shlex.quote(force_text(val))}"
-                    )
+                    left_args.append(f"{option_long_name}={shlex.quote(str(val))}")
 
     return " ".join(["pip-compile", *sorted(left_args), *sorted(right_args)])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,6 @@ from piptools.utils import (
     as_tuple,
     dedup,
     flat_map,
-    force_text,
     format_requirement,
     format_specifier,
     get_compile_command,
@@ -201,13 +200,6 @@ def test_name_from_req_with_project_name(from_line):
     ireq = from_line("foo==1.8")
     ireq.req.project_name = "bar"
     assert name_from_req(ireq.req) == "bar"
-
-
-@pytest.mark.parametrize(
-    ("value", "expected_text"), ((None, ""), (42, "42"), ("foo", "foo"), ("bãr", "bãr"))
-)
-def test_force_text(value, expected_text):
-    assert force_text(value) == expected_text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
With Python 2 support dropped, the str/bytes boundary is much more explicit. It is known when a value is str or could be something else.

Coercing non-str values to str can now be handled using the builtin `str()`.

##### Contributor checklist

- [x] Provided the tests for the changes. (already exist)
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
