### PR TITLE
Add test for format_specifier() with editable requirements

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,7 +81,7 @@ def test_format_requirement_ireq_with_hashes_and_markers(from_line):
     assert format_requirement(ireq, marker, hashes=ireq_hashes) == expected
 
 
-def test_format_specifier(from_line):
+def test_format_specifier(from_line, from_editable):
     ireq = from_line("foo")
     assert format_specifier(ireq) == "<any>"
 
@@ -92,6 +92,11 @@ def test_format_specifier(from_line):
     assert format_specifier(ireq) == "~=1.1,>1.2,<1.5"
     ireq = from_line("foo~=1.1,<1.5,>1.2")
     assert format_specifier(ireq) == "~=1.1,>1.2,<1.5"
+
+    ireq = from_editable("git+https://github.com/django/django.git#egg=django")
+    assert format_specifier(ireq) == "<any>"
+    ireq = from_editable("file:///home/user/package")
+    assert format_specifier(ireq) == "<any>"
 
 
 def test_as_tuple(from_line):


### PR DESCRIPTION
Tests against the mutation:

    diff --git a/piptools/utils.py b/piptools/utils.py
    index e6f9cef..4fe85c7 100644
    --- a/piptools/utils.py
    +++ b/piptools/utils.py
    @@ -95,7 +95,7 @@ def format_specifier(ireq):
         InstallRequirements to the terminal.
         """
         # TODO: Ideally, this is carried over to the pip library itself
    -    specs = ireq.specifier if ireq.req is not None else []
    +    specs = ireq.specifier
         specs = sorted(specs, key=lambda x: x.version)
         return ",".join(str(s) for s in specs) or "<any>"
