### PR TITLE
Remove unused member OutputWriter.src_files

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -461,7 +461,6 @@ def cli(
     ##
 
     writer = OutputWriter(
-        src_files,
         output_file,
         click_ctx=ctx,
         dry_run=dry_run,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -47,7 +47,6 @@ def _comes_from_as_string(ireq):
 class OutputWriter:
     def __init__(
         self,
-        src_files,
         dst_file,
         click_ctx,
         dry_run,
@@ -64,7 +63,6 @@ class OutputWriter:
         find_links,
         emit_find_links,
     ):
-        self.src_files = src_files
         self.dst_file = dst_file
         self.click_ctx = click_ctx
         self.dry_run = dry_run

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -27,7 +27,6 @@ def writer(tmpdir_cwd):
 
     with cli.make_context("pip-compile", cli_args) as ctx:
         writer = OutputWriter(
-            src_files=["src_file", "src_file2"],
             dst_file=ctx.params["output_file"],
             click_ctx=ctx,
             dry_run=True,


### PR DESCRIPTION
Unused since 7d12a5df9df6f502910d30c94c0e5c8578017d41.