### PR TITLE
Remove unnecessary piptools/click.py compat shim

### DIFF
--- a/piptools/__init__.py
+++ b/piptools/__init__.py
@@ -1,6 +1,6 @@
 import locale
 
-from piptools.click import secho
+from click import secho
 
 # Needed for locale.getpreferredencoding(False) to work
 # in pip._internal.utils.encoding.auto_decode

--- a/piptools/click.py
+++ b/piptools/click.py
@@ -1,4 +1,0 @@
-import click
-from click import *  # noqa
-
-click.disable_unicode_literals_warning = True

--- a/piptools/logging.py
+++ b/piptools/logging.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 import sys
 
-from . import click
+import click
 
 # Initialise the builtin logging module for other component using it.
 # Ex: pip

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -7,6 +7,7 @@ import tempfile
 from contextlib import contextmanager
 from shutil import rmtree
 
+from click import progressbar
 from pip._internal.cache import WheelCache
 from pip._internal.cli.progress_bars import BAR_TYPES
 from pip._internal.commands import create_command
@@ -24,7 +25,6 @@ from pip._vendor import contextlib2
 from pip._vendor.requests import RequestException
 
 from .._compat import PIP_VERSION
-from ..click import progressbar
 from ..exceptions import NoCandidateFound
 from ..logging import log
 from ..utils import (

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -2,10 +2,10 @@ import copy
 from functools import partial
 from itertools import chain, count, groupby
 
+import click
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_tracker import update_env_context_manager
 
-from . import click
 from .logging import log
 from .utils import (
     UNSAFE_PACKAGES,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -5,13 +5,13 @@ import tempfile
 import warnings
 from typing import Any
 
+import click
 from click import Command
 from click.utils import safecall
 from pip._internal.commands import create_command
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 
-from .. import click
 from .._compat import parse_requirements
 from ..cache import DependencyCache
 from ..exceptions import PipToolsError

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -3,10 +3,11 @@ import os
 import shlex
 import sys
 
+import click
 from pip._internal.commands import create_command
 from pip._internal.utils.misc import get_installed_distributions
 
-from .. import click, sync
+from .. import sync
 from .._compat import parse_requirements
 from ..exceptions import PipToolsError
 from ..logging import log

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -4,10 +4,10 @@ import sys
 import tempfile
 from subprocess import run  # nosec
 
+import click
 from pip._internal.commands.freeze import DEV_PKGS
 from pip._internal.utils.compat import stdlib_pkgs
 
-from . import click
 from .exceptions import IncompatibleRequirements
 from .logging import log
 from .utils import (

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -2,12 +2,11 @@ import shlex
 from collections import OrderedDict
 from itertools import chain
 
+from click import style
 from click.utils import LazyFile
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.vcs import is_url
-
-from .click import style
 
 UNSAFE_PACKAGES = {"setuptools", "distribute", "pip"}
 COMPILE_EXCLUDE_OPTIONS = {

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -2,7 +2,8 @@ import os
 import re
 from itertools import chain
 
-from .click import unstyle
+from click import unstyle
+
 from .logging import log
 from .utils import (
     UNSAFE_PACKAGES,


### PR DESCRIPTION
Unnecessary since dropping Python 2 support.

The attribute `click.disable_unicode_literals_warning` only affects
Python 2. On Python 3, it is a nop. For details, see:

- https://click.palletsprojects.com/en/7.x/python3/?highlight=disable_unicode_literals_warning#unicode-literals
- https://github.com/pallets/click/blob/7.1.2/src/click/_unicodefun.py#L32-L33

This removes the need to have a click compatibility shim. Now import the
package directly.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
