### PR TITLE
Add --split-annotate option

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -136,6 +136,12 @@ class BaseCommand(Command):
     help="Annotate results, indicating where dependencies come from",
 )
 @click.option(
+    "--split-annotate/--no-split-annotate",
+    is_flag=True,
+    default=False,
+    help="Split annotate result lines",
+)
+@click.option(
     "-U",
     "--upgrade",
     is_flag=True,
@@ -240,6 +246,7 @@ def cli(
     index,
     emit_trusted_host,
     annotate,
+    split_annotate,
     upgrade,
     upgrade_packages,
     output_file,
@@ -468,6 +475,7 @@ def cli(
         emit_index_url=emit_index_url,
         emit_trusted_host=emit_trusted_host,
         annotate=annotate,
+        split_annotate=split_annotate,
         generate_hashes=generate_hashes,
         default_index_url=repository.DEFAULT_INDEX_URL,
         index_urls=repository.finder.index_urls,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -55,6 +55,7 @@ class OutputWriter:
         emit_index_url,
         emit_trusted_host,
         annotate,
+        split_annotate,
         generate_hashes,
         default_index_url,
         index_urls,
@@ -71,6 +72,7 @@ class OutputWriter:
         self.emit_index_url = emit_index_url
         self.emit_trusted_host = emit_trusted_host
         self.annotate = annotate
+        self.split_annotate = split_annotate
         self.generate_hashes = generate_hashes
         self.default_index_url = default_index_url
         self.index_urls = index_urls
@@ -226,13 +228,17 @@ class OutputWriter:
             required_by.add(_comes_from_as_string(ireq))
         if required_by:
             required_by = sorted(required_by)
-            if len(required_by) == 1:
-                source = required_by[0]
-                annotation = "    # via " + source
-            else:
+            if self.split_annotate:
                 annotation_lines = ["    # via"]
                 for source in required_by:
                     annotation_lines.append("    #   " + source)
                 annotation = "\n".join(annotation_lines)
-            line = f"{line}\n{comment(annotation)}"
+                line = f"{line}\n{comment(annotation)}"
+            else:
+                annotation = ", ".join(required_by)
+                line = "{:24}{}{}".format(
+                    line,
+                    " \\\n    " if ireq_hashes else "  ",
+                    comment("# via " + annotation),
+                )
         return line


### PR DESCRIPTION
Add --split-annotate option to pip-compile to allow annotations to be formatted one per line

This is a partial revert of https://github.com/jazzband/pip-tools/pull/1237 to restore the default behavior up to 5.4.0


(this is currently a WIP: I need to update tests)

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
