### PR TITLE
Consider specifiers for equality operator to pin a dependency in make_install_requirement

### DIFF
--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -63,9 +63,7 @@ class LocalRequirementsRepository(BaseRepository):
         existing_pin = self.existing_pins.get(key)
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             project, version, _ = as_tuple(existing_pin)
-            return make_install_requirement(
-                project, version, ireq
-            )
+            return make_install_requirement(project, version, ireq)
         else:
             return self.repository.find_best_match(ireq, prereleases)
 

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -64,7 +64,7 @@ class LocalRequirementsRepository(BaseRepository):
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             project, version, _ = as_tuple(existing_pin)
             return make_install_requirement(
-                project, version, ireq.extras, constraint=ireq.constraint
+                project, version, ireq
             )
         else:
             return self.repository.find_best_match(ireq, prereleases)

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -159,8 +159,7 @@ class PyPIRepository(BaseRepository):
         return make_install_requirement(
             best_candidate.name,
             best_candidate.version,
-            ireq.extras,
-            constraint=ireq.constraint,
+            ireq,
         )
 
     def resolve_reqs(self, download_dir, ireq, wheel_cache):

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -84,7 +84,8 @@ def make_install_requirement(
             break
 
     return install_req_from_line(
-        str(f"{name}{extras_string}{version_specifier}{version}"), constraint=ireq.constraint
+        str(f"{name}{extras_string}{version_specifier}{version}"),
+        constraint=ireq.constraint,
     )
 
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -67,7 +67,7 @@ def comment(text: str) -> str:
 
 
 def make_install_requirement(
-    name: str, version: Version, ireq: InstallRequirement
+    name: str, version: Union[str, Version], ireq: InstallRequirement
 ) -> InstallRequirement:
     # If no extras are specified, the extras string is blank
     extras_string = ""
@@ -78,8 +78,7 @@ def make_install_requirement(
 
     version_specifier = "=="
     for specifier in ireq.specifier:
-        specifier_version = Version(specifier.version)
-        if specifier.operator == "===" and specifier_version == version:
+        if specifier.operator == "===" and specifier.version == str(version):
             version_specifier = "==="
             break
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -76,14 +76,15 @@ def make_install_requirement(
         # Sort extras for stability
         extras_string = f"[{','.join(sorted(extras))}]"
 
-    version_specifier = "=="
+    version_pin_operator = "=="
+    version_as_str = str(version)
     for specifier in ireq.specifier:
-        if specifier.operator == "===" and specifier.version == str(version):
-            version_specifier = "==="
+        if specifier.operator == "===" and specifier.version == version_as_str:
+            version_pin_operator = "==="
             break
 
     return install_req_from_line(
-        str(f"{name}{extras_string}{version_specifier}{version}"),
+        str(f"{name}{extras_string}{version_pin_operator}{version}"),
         constraint=ireq.constraint,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ class FakeRepository(BaseRepository):
             raise NoCandidateFound(ireq, tried_versions, ["https://fake.url.foo"])
         best_version = max(versions, key=Version)
         return make_install_requirement(
-            key_from_ireq(ireq), best_version, ireq.extras, constraint=ireq.constraint
+            key_from_ireq(ireq), best_version, ireq
         )
 
     def get_dependencies(self, ireq):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,9 +68,7 @@ class FakeRepository(BaseRepository):
             ]
             raise NoCandidateFound(ireq, tried_versions, ["https://fake.url.foo"])
         best_version = max(versions, key=Version)
-        return make_install_requirement(
-            key_from_ireq(ireq), best_version, ireq
-        )
+        return make_install_requirement(key_from_ireq(ireq), best_version, ireq)
 
     def get_dependencies(self, ireq):
         if ireq.editable or is_url_requirement(ireq):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1555,3 +1555,27 @@ def test_duplicate_reqs_combined(
     assert out.exit_code == 0, out
     assert str(test_package_2) in out.stderr
     assert "test-package-1==0.1" in out.stderr
+
+
+@pytest.mark.network
+def test_triple_equal_pinned_depency_is_used(runner):
+    """
+    Test that pip-compile properly emits the pinned requirement with ===
+    torchvision 0.8.2 requires torch==1.7.1 which can resolve to versions with
+    patches (e.g. torch 1.7.1+cu110), we want torch===1.7.1 without patches
+    """
+    with open("requirements.in", "w") as reqs_in:
+        reqs_in.write("torch===1.7.1\n")
+        reqs_in.write("torchvision===0.8.2\n")
+
+    out = runner.invoke(
+        cli,
+        [
+            "--find-links",
+            "https://download.pytorch.org/whl/torch_stable.html",
+        ],
+    )
+
+    assert out.exit_code == 0, out
+    assert "torch===1.7.1" in out.stderr
+    assert "torchvision===0.8.2" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1557,7 +1557,9 @@ def test_duplicate_reqs_combined(
     assert "test-package-1==0.1" in out.stderr
 
 
-def test_triple_equal_pinned_depency_is_used(runner, make_package, make_wheel, tmpdir):
+def test_triple_equal_pinned_dependency_is_used(
+    runner, make_package, make_wheel, tmpdir
+):
     """
     Test that pip-compile properly emits the pinned requirement with ===
     torchvision 0.8.2 requires torch==1.7.1 which can resolve to versions with
@@ -1576,10 +1578,10 @@ def test_triple_equal_pinned_depency_is_used(runner, make_package, make_wheel, t
 
     with open("requirements.in", "w") as reqs_in:
         reqs_in.write("test-package-1===1.7.1\n")
-        reqs_in.write("test-package-2===0.8.2\n")
+        reqs_in.write("test-package-2==0.8.2\n")
 
     out = runner.invoke(cli, ["--find-links", str(dists_dir)])
 
     assert out.exit_code == 0, out
     assert "test-package-1===1.7.1" in out.stderr
-    assert "test-package-2===0.8.2" in out.stderr
+    assert "test-package-2==0.8.2" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1557,7 +1557,6 @@ def test_duplicate_reqs_combined(
     assert "test-package-1==0.1" in out.stderr
 
 
-@pytest.mark.network
 def test_triple_equal_pinned_depency_is_used(runner, make_package, make_wheel, tmpdir):
     """
     Test that pip-compile properly emits the pinned requirement with ===

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1564,26 +1564,31 @@ def test_duplicate_reqs_combined(
             "",
             ["test-package-1===0.1.0\n"],
             ["test-package-1===0.1.0"],
+            id="pin package with ===",
         ),
         pytest.param(
             "",
             ["test-package-1==0.1.0\n"],
             ["test-package-1==0.1.0"],
+            id="pin package with ==",
         ),
         pytest.param(
             "test-package-1==0.1.0",
             ["test-package-1===0.1.0\n", "test-package-2==0.1.0\n"],
             ["test-package-1===0.1.0", "test-package-2==0.1.0"],
+            id="dep === pin preferred over == pin, main package == pin",
         ),
         pytest.param(
             "test-package-1==0.1.0",
             ["test-package-1===0.1.0\n", "test-package-2===0.1.0\n"],
             ["test-package-1===0.1.0", "test-package-2===0.1.0"],
+            id="dep === pin preferred over == pin, main package === pin",
         ),
         pytest.param(
             "test-package-1==0.1.0",
             ["test-package-2===0.1.0\n"],
             ["test-package-1==0.1.0", "test-package-2===0.1.0"],
+            id="dep == pin conserved, main package === pin",
         ),
     ),
 )

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1576,6 +1576,26 @@ def test_triple_equal_pinned_dependency_is_used(
     )
     make_wheel(test_package_2, dists_dir)
 
+    # Case 1 ===
+    with open("requirements.in", "w") as reqs_in:
+        reqs_in.write("test-package-1===1.7.1\n")
+
+    out = runner.invoke(cli, ["--find-links", str(dists_dir)])
+
+    assert out.exit_code == 0, out
+    assert "test-package-1===1.7.1" in out.stderr
+
+    # Case 2 ==
+    with open("requirements.in", "w") as reqs_in:
+        reqs_in.write("test-package-1==1.7.1\n")
+
+    out = runner.invoke(cli, ["--find-links", str(dists_dir)])
+
+    assert out.exit_code == 0, out
+    assert "test-package-1==1.7.1" in out.stderr
+
+    # Case 3 test_package_1 pinned by user with ===
+    # but pinned by package with ==, prefer ===
     with open("requirements.in", "w") as reqs_in:
         reqs_in.write("test-package-1===1.7.1\n")
         reqs_in.write("test-package-2==0.8.2\n")
@@ -1585,3 +1605,26 @@ def test_triple_equal_pinned_dependency_is_used(
     assert out.exit_code == 0, out
     assert "test-package-1===1.7.1" in out.stderr
     assert "test-package-2==0.8.2" in out.stderr
+
+    # Case 4 test_package_1 pinned by user with ===
+    # but pinned by package with ==, prefer ===
+    # Different pin for test_package_2
+    with open("requirements.in", "w") as reqs_in:
+        reqs_in.write("test-package-1===1.7.1\n")
+        reqs_in.write("test-package-2===0.8.2\n")
+
+    out = runner.invoke(cli, ["--find-links", str(dists_dir)])
+
+    assert out.exit_code == 0, out
+    assert "test-package-1===1.7.1" in out.stderr
+    assert "test-package-2===0.8.2" in out.stderr
+
+    # Case 5 only package 2 pinned with ===
+    with open("requirements.in", "w") as reqs_in:
+        reqs_in.write("test-package-2===0.8.2\n")
+
+    out = runner.invoke(cli, ["--find-links", str(dists_dir)])
+
+    assert out.exit_code == 0, out
+    assert "test-package-1==1.7.1" in out.stderr
+    assert "test-package-2===0.8.2" in out.stderr


### PR DESCRIPTION
Resolves #1114

Haven't written the test yet, as I would like to know if the spirit of the change suits the authors first
Tried to run `tox -e checkqa` as proposed in contribution guidelines but had a failure with github auth

- Changed function signature to take ireq directly rather than passing its
members one by one
- Changed type hint for version as I was getting a pip Version rather than
a string, maybe there are some parts of the code calling with string though
- Can confirm it generates a pinned torch with === in my use case as
expected

<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Prefer === over == when generating requirements.txt if a dependency was pinned with ===

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
