### PR TITLE
Fix compiling input setup file in nested folders

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -275,8 +275,10 @@ def cli(
         if src_files == ("-",):
             raise click.BadParameter("--output-file is required if input is from stdin")
         # Use default requirements output file if there is a setup.py the source file
-        elif src_files == ("setup.py",):
-            file_name = DEFAULT_REQUIREMENTS_OUTPUT_FILE
+        elif os.path.basename(src_files[0]) == "setup.py":
+            file_name = os.path.join(
+                os.path.dirname(src_files[0]), DEFAULT_REQUIREMENTS_OUTPUT_FILE
+            )
         # An output file must be provided if there are multiple source files
         elif len(src_files) > 1:
             raise click.BadParameter(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -107,6 +107,27 @@ def test_command_line_setuptools_output_file(
     assert os.path.exists(expected_output_file)
 
 
+def test_command_line_setuptools_nested_output_file(pip_conf, tmpdir, runner):
+    """
+    Test the output file for setup.py in nested folder as a requirement file.
+    """
+    proj_dir = tmpdir.mkdir("proj")
+
+    with open(os.path.join(str(proj_dir), "setup.py"), "w") as package:
+        package.write(
+            dedent(
+                """\
+                from setuptools import setup
+                setup(install_requires=[])
+                """
+            )
+        )
+
+    out = runner.invoke(cli, [str(proj_dir / "setup.py")])
+    assert out.exit_code == 0
+    assert (proj_dir / "requirements.txt").exists()
+
+
 def test_find_links_option(runner):
     with open("requirements.in", "w") as req_in:
         req_in.write("-f ./libs3")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -113,7 +113,7 @@ def test_command_line_setuptools_nested_output_file(pip_conf, tmpdir, runner):
     """
     proj_dir = tmpdir.mkdir("proj")
 
-    with open(os.path.join(str(proj_dir), "setup.py"), "w") as package:
+    with open(str(proj_dir / "setup.py"), "w") as package:
         package.write(
             dedent(
                 """\


### PR DESCRIPTION
<!--- Describe the changes here. --->
Closes #1312 

**Changelog-friendly one-liner**: Fix compiling input `setup.py` file in nested folders

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).



