### PR TITLE
Write out default index when it is provided as`--extra-index-url`

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -103,7 +103,7 @@ class OutputWriter:
     def write_index_options(self) -> Iterator[str]:
         if self.emit_index_url:
             for index, index_url in enumerate(dedup(self.index_urls)):
-                if index_url.rstrip("/") == self.default_index_url:
+                if index == 0 and index_url.rstrip("/") == self.default_index_url:
                     continue
                 flag = "--index-url" if index == 0 else "--extra-index-url"
                 yield f"{flag} {index_url}"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -276,7 +276,7 @@ def test_write_format_controls(writer):
                 "--extra-index-url https://index-url2.com",
             ],
         ),
-        # Ignore URLs equal to the default index-url
+        # Not ignore URLs equal to the default index-url
         # (note: the previous case is exception)
         (
             [
@@ -286,6 +286,7 @@ def test_write_format_controls(writer):
             ],
             [
                 "--index-url https://index-url1.com",
+                "--extra-index-url https://default-index-url.com",
                 "--extra-index-url https://index-url2.com",
             ],
         ),


### PR DESCRIPTION
If the default index is provided as `--extra-index-url` it can not safely be dropped from the written output since this changes behavior when the output is synced.

While jazzband/pip-tools#756 Explicitly introduced tests for the opposite, this seams to have been a mistake since otherwise the following lines comment about making an exception would be nonsensical.

**Changelog-friendly one-liner**:  Write out default index when it is provided as `--extra-index-url`.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
