### PR TITLE
Fixup relative and absolute path handling

### DIFF
--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -5,14 +5,18 @@ from typing import Callable, Iterable, Iterator, Optional, cast
 
 import pip
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.models.link import Link
 from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement
 from pip._internal.req import parse_requirements as _parse_requirements
-from pip._internal.req.constructors import install_req_from_parsed_requirement
+from pip._internal.req.constructors import (
+    install_req_from_link_and_ireq,
+    install_req_from_parsed_requirement,
+)
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import Requirement
 
-from ..utils import abs_ireq, working_dir
+from ..utils import abs_ireq, fragment_string, working_dir
 
 PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split(".")))
 
@@ -43,13 +47,28 @@ def parse_requirements(
         # with non-URI (non file:) syntax, e.g. '-e ..'
         with working_dir(from_dir):
             ireq = install_req_from_parsed_requirement(parsed_req, isolated=isolated)
+            # The resulting ireq has two problems:
+            # - It's now absolute (ahead of schedule),
+            #   so abs_ireq will not know to apply the _was_relative attribute,
+            #   which is needed for the writer to use the relpath.
+            # - Sometimes the fragment is lost!
 
-        # But the resulting ireq is absolute (ahead of schedule),
-        # so abs_ireq will not apply the _was_relative attribute,
-        # which is needed for the writer to use the relpath.
+        # To account for the second:
+        if not fragment_string(ireq):
+            fragment = Link(parsed_req.requirement)._parsed_url.fragment
+            if fragment:
+                link_with_fragment = Link(
+                    url=f"{ireq.link.url}#{fragment}",
+                    comes_from=ireq.link.comes_from,
+                    requires_python=ireq.link.requires_python,
+                    yanked_reason=ireq.link.yanked_reason,
+                    cache_link_parsing=ireq.link.cache_link_parsing,
+                )
+                ireq = install_req_from_link_and_ireq(link_with_fragment, ireq)
+
         a_ireq = abs_ireq(ireq, from_dir)
 
-        # To account for that, we guess if the path was initially relative and
+        # To account for the first, we guess if the path was initially relative and
         # set _was_relative ourselves:
         bare_path = file_url_schemes_re.sub("", parsed_req.requirement)
         is_win = platform.system() == "Windows"

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -58,7 +58,7 @@ def parse_requirements(
                 # This can happen when the url is a relpath with a fragment,
                 # so we try again with the fragment stripped
                 preq_without_fragment = ParsedRequirement(
-                    requirement=re.sub(r"#[^#]+=.+$", "", parsed_req.requirement),
+                    requirement=re.sub(r"#[^#]+$", "", parsed_req.requirement),
                     is_editable=parsed_req.is_editable,
                     comes_from=parsed_req.comes_from,
                     constraint=parsed_req.constraint,
@@ -80,7 +80,7 @@ def parse_requirements(
             fragment = Link(parsed_req.requirement)._parsed_url.fragment
             if fragment:
                 link_with_fragment = Link(
-                    url=f"{ireq.link.url}#{fragment}",
+                    url=f"{ireq.link.url_without_fragment}#{fragment}",
                     comes_from=ireq.link.comes_from,
                     requires_python=ireq.link.requires_python,
                     yanked_reason=ireq.link.yanked_reason,
@@ -92,7 +92,9 @@ def parse_requirements(
 
         # To account for the second, we guess if the path was initially relative and
         # set _was_relative ourselves:
-        bare_path = file_url_schemes_re.sub("", parsed_req.requirement)
+        bare_path = file_url_schemes_re.sub(
+            "", parsed_req.requirement.split(" @ ", 1)[-1]
+        )
         is_win = platform.system() == "Windows"
         if is_win:
             bare_path = bare_path.lstrip("/")

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -1,4 +1,6 @@
 import optparse
+import platform
+import re
 from typing import Callable, Iterable, Iterator, Optional, cast
 
 import pip
@@ -10,8 +12,11 @@ from pip._internal.req.constructors import install_req_from_parsed_requirement
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import Requirement
 
+from ..utils import abs_ireq, working_dir
+
 PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split(".")))
 
+file_url_schemes_re = re.compile(r"^((git|hg|svn|bzr)\+)?file:")
 
 __all__ = [
     "get_build_tracker",
@@ -29,11 +34,36 @@ def parse_requirements(
     options: Optional[optparse.Values] = None,
     constraint: bool = False,
     isolated: bool = False,
+    from_dir: Optional[str] = None,
 ) -> Iterator[InstallRequirement]:
     for parsed_req in _parse_requirements(
         filename, session, finder=finder, options=options, constraint=constraint
     ):
-        yield install_req_from_parsed_requirement(parsed_req, isolated=isolated)
+        # This context manager helps pip locate relative paths specified
+        # with non-URI (non file:) syntax, e.g. '-e ..'
+        with working_dir(from_dir):
+            ireq = install_req_from_parsed_requirement(parsed_req, isolated=isolated)
+
+        # But the resulting ireq is absolute (ahead of schedule),
+        # so abs_ireq will not apply the _was_relative attribute,
+        # which is needed for the writer to use the relpath.
+        a_ireq = abs_ireq(ireq, from_dir)
+
+        # To account for that, we guess if the path was initially relative and
+        # set _was_relative ourselves:
+        bare_path = file_url_schemes_re.sub("", parsed_req.requirement)
+        is_win = platform.system() == "Windows"
+        if is_win:
+            bare_path = bare_path.lstrip("/")
+        if (
+            a_ireq.link is not None
+            and a_ireq.link.scheme.endswith("file")
+            and not bare_path.startswith("/")
+        ):
+            if not (is_win and re.match(r"[a-zA-Z]:", bare_path)):
+                a_ireq._was_relative = True
+
+        yield a_ireq
 
 
 if PIP_VERSION[:2] <= (22, 0):

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -4,12 +4,14 @@ import re
 from typing import Callable, Iterable, Iterator, Optional, cast
 
 import pip
+from pip._internal.exceptions import InstallationError
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.link import Link
 from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement
 from pip._internal.req import parse_requirements as _parse_requirements
 from pip._internal.req.constructors import install_req_from_parsed_requirement
+from pip._internal.req.req_file import ParsedRequirement
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import Requirement
 
@@ -48,14 +50,32 @@ def parse_requirements(
         # This context manager helps pip locate relative paths specified
         # with non-URI (non file:) syntax, e.g. '-e ..'
         with working_dir(from_dir):
-            ireq = install_req_from_parsed_requirement(parsed_req, isolated=isolated)
-            # The resulting ireq has two problems:
-            # - It's now absolute (ahead of schedule),
-            #   so abs_ireq will not know to apply the _was_relative attribute,
-            #   which is needed for the writer to use the relpath.
-            # - Sometimes the fragment is lost!
+            try:
+                ireq = install_req_from_parsed_requirement(
+                    parsed_req, isolated=isolated
+                )
+            except InstallationError:
+                # This can happen when the url is a relpath with a fragment,
+                # so we try again with the fragment stripped
+                preq_without_fragment = ParsedRequirement(
+                    requirement=re.sub(r"#[^#]+=.+$", "", parsed_req.requirement),
+                    is_editable=parsed_req.is_editable,
+                    comes_from=parsed_req.comes_from,
+                    constraint=parsed_req.constraint,
+                    options=parsed_req.options,
+                    line_source=parsed_req.line_source,
+                )
+                ireq = install_req_from_parsed_requirement(
+                    preq_without_fragment, isolated=isolated
+                )
 
-        # To account for the second:
+        # At this point the ireq has two problems:
+        # - Sometimes the fragment is lost (even without an InstallationError)
+        # - It's now absolute (ahead of schedule),
+        #   so abs_ireq will not know to apply the _was_relative attribute,
+        #   which is needed for the writer to use the relpath.
+
+        # To account for the first:
         if not fragment_string(ireq):
             fragment = Link(parsed_req.requirement)._parsed_url.fragment
             if fragment:
@@ -70,7 +90,7 @@ def parse_requirements(
 
         a_ireq = abs_ireq(ireq, from_dir)
 
-        # To account for the first, we guess if the path was initially relative and
+        # To account for the second, we guess if the path was initially relative and
         # set _was_relative ourselves:
         bare_path = file_url_schemes_re.sub("", parsed_req.requirement)
         is_win = platform.system() == "Windows"

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -9,14 +9,16 @@ from pip._internal.models.link import Link
 from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement
 from pip._internal.req import parse_requirements as _parse_requirements
-from pip._internal.req.constructors import (
-    install_req_from_link_and_ireq,
-    install_req_from_parsed_requirement,
-)
+from pip._internal.req.constructors import install_req_from_parsed_requirement
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import Requirement
 
-from ..utils import abs_ireq, fragment_string, working_dir
+from ..utils import (
+    abs_ireq,
+    fragment_string,
+    install_req_from_link_and_ireq,
+    working_dir,
+)
 
 PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split(".")))
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -297,6 +297,8 @@ def cli(
                 ).format(DEFAULT_REQUIREMENTS_FILE)
             )
 
+    src_files = tuple(src if src == "-" else os.path.abspath(src) for src in src_files)
+
     if not output_file:
         # An output file must be provided for stdin
         if src_files == ("-",):
@@ -313,8 +315,9 @@ def cli(
             )
         # Otherwise derive the output file from the source file
         else:
-            base_name = src_files[0].rsplit(".", 1)[0]
-            file_name = base_name + ".txt"
+            file_name = os.path.splitext(src_files[0])[0] + ".txt"
+            if file_name == src_files[0]:
+                file_name += ".txt"
 
         output_file = click.open_file(file_name, "w+b", atomic=True, lazy=True)
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -160,6 +160,15 @@ def _get_default_option(option_name: str) -> Any:
     ),
 )
 @click.option(
+    "--write-relative-to-output",
+    is_flag=True,
+    default=False,
+    help=(
+        "Construct relative paths as relative to the output file's parent. "
+        "Will be written as relative to the current folder otherwise."
+    ),
+)
+@click.option(
     "--allow-unsafe/--no-allow-unsafe",
     is_flag=True,
     default=False,
@@ -258,6 +267,7 @@ def cli(
     upgrade: bool,
     upgrade_packages: Tuple[str, ...],
     output_file: Union[LazyFile, IO[Any], None],
+    write_relative_to_output: bool,
     allow_unsafe: bool,
     strip_extras: bool,
     generate_hashes: bool,
@@ -361,6 +371,11 @@ def cli(
             finder=tmp_repository.finder,
             session=tmp_repository.session,
             options=tmp_repository.options,
+            from_dir=(
+                os.path.dirname(os.path.abspath(output_file.name))
+                if write_relative_to_output
+                else None
+            ),
         )
 
         # Exclude packages from --upgrade-package/-P from the existing
@@ -502,6 +517,7 @@ def cli(
         find_links=repository.finder.find_links,
         emit_find_links=emit_find_links,
         emit_options=emit_options,
+        write_relative_to_output=write_relative_to_output,
     )
     writer.write(
         results=results,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -303,15 +303,15 @@ def cli(
         # An output file must be provided for stdin
         if src_files == ("-",):
             raise click.BadParameter("--output-file is required if input is from stdin")
-        # Use default requirements output file if there is a setup.py the source file
-        elif os.path.basename(src_files[0]) in METADATA_FILENAMES:
-            file_name = os.path.join(
-                os.path.dirname(src_files[0]), DEFAULT_REQUIREMENTS_OUTPUT_FILE
-            )
         # An output file must be provided if there are multiple source files
         elif len(src_files) > 1:
             raise click.BadParameter(
                 "--output-file is required if two or more input files are given."
+            )
+        # Use default requirements output file if there is only a setup.py source file
+        elif os.path.basename(src_files[0]) in METADATA_FILENAMES:
+            file_name = os.path.join(
+                os.path.dirname(src_files[0]), DEFAULT_REQUIREMENTS_OUTPUT_FILE
             )
         # Otherwise derive the output file from the source file
         else:

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -71,6 +71,15 @@ version_option_kwargs = {"package_name": "pip-tools"} if IS_CLICK_VER_8_PLUS els
     help="Ignore package index (only looking at --find-links URLs instead)",
 )
 @click.option(
+    "--read-relative-to-input",
+    is_flag=True,
+    default=False,
+    help=(
+        "Resolve relative paths as relative to the input file's parent. "
+        "Will be resolved as relative to the current folder otherwise."
+    ),
+)
+@click.option(
     "--python-executable",
     help="Custom python executable path if targeting an environment other than current.",
 )
@@ -96,6 +105,7 @@ def cli(
     extra_index_url: Tuple[str, ...],
     trusted_host: Tuple[str, ...],
     no_index: bool,
+    read_relative_to_input: bool,
     python_executable: Optional[str],
     verbose: int,
     quiet: int,
@@ -139,7 +149,17 @@ def cli(
     # Parse requirements file. Note, all options inside requirements file
     # will be collected by the finder.
     requirements = flat_map(
-        lambda src: parse_requirements(src, finder=finder, session=session), src_files
+        lambda src: parse_requirements(
+            src,
+            finder=finder,
+            session=session,
+            from_dir=(
+                os.path.dirname(os.path.abspath(src))
+                if read_relative_to_input
+                else os.getcwd()
+            ),
+        ),
+        src_files,
     )
 
     try:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -193,21 +193,10 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
 
     # If we get here then we have a requirement that supports direct reference.
     # We need to remove the egg if it exists and keep the rest of the fragments.
-    direct_reference = f"{ireq.name.lower()} @ {ireq.link.url_without_fragment}"
-    fragments = []
-
-    # Check if there is any fragment to add to the URI.
-    if ireq.link.subdirectory_fragment:
-        fragments.append(f"subdirectory={ireq.link.subdirectory_fragment}")
-
-    if ireq.link.has_hash:
-        fragments.append(f"{ireq.link.hash_name}={ireq.link.hash}")
-
-    # Then add the fragments into the URI, if any.
-    if fragments:
-        direct_reference += f"#{'&'.join(fragments)}"
-
-    return direct_reference
+    return (
+        f"{ireq.name.lower()} @ {ireq.link.url_without_fragment}"
+        f"{fragment_string(ireq, omit_egg=True)}"
+    )
 
 
 def format_specifier(ireq: InstallRequirement) -> str:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -202,7 +202,8 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
     # We need to remove the egg if it exists and keep the rest of the fragments.
     extras = f"[{','.join(xtr for xtr in sorted(ireq.extras))}]" if ireq.extras else ""
     return (
-        f"{ireq.name.lower()}{extras} @ {ireq.link.url_without_fragment}"
+        f"{canonicalize_name(ireq.name)}{extras} @ "
+        f"{ireq.link.url_without_fragment}"
         f"{fragment_string(ireq, omit_egg=True)}"
     )
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -152,9 +152,7 @@ def format_requirement(
         # for which ireq.link.is_file == False
     else:
         fragment = fragment_string(ireq)
-        extras = (
-            f"[{','.join(xtr for xtr in sorted(ireq.extras))}]" if ireq.extras else ""
-        )
+        extras = f"[{','.join(sorted(ireq.extras))}]" if ireq.extras else ""
         delimiter = "#" if extras and not fragment else ""
         if not from_dir:
             line = (

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -200,7 +200,7 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
 
     # If we get here then we have a requirement that supports direct reference.
     # We need to remove the egg if it exists and keep the rest of the fragments.
-    extras = f"[{','.join(xtr for xtr in sorted(ireq.extras))}]" if ireq.extras else ""
+    extras = f"[{','.join(sorted(ireq.extras))}]" if ireq.extras else ""
     return (
         f"{canonicalize_name(ireq.name)}{extras} @ "
         f"{ireq.link.url_without_fragment}"

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -419,8 +419,6 @@ def abs_ireq(
     )
 
     a_ireq = install_req_from_link_and_ireq(abs_link, ireq)
-    if hasattr(ireq, "_source_ireqs"):
-        a_ireq._source_ireqs = ireq._source_ireqs
     a_ireq._was_relative = True
 
     return a_ireq
@@ -559,12 +557,13 @@ def install_req_from_link_and_ireq(
         )
     else:
         extras = ()
-    return InstallRequirement(
+    fresh_ireq = InstallRequirement(
         req=ireq.req,
         comes_from=ireq.comes_from,
         editable=ireq.editable,
         link=link,
         extras=extras,
+        constraint=ireq.constraint,
         markers=ireq.markers,
         use_pep517=ireq.use_pep517,
         isolated=ireq.isolated,
@@ -572,3 +571,6 @@ def install_req_from_link_and_ireq(
         global_options=ireq.global_options,
         hash_options=ireq.hash_options,
     )
+    if hasattr(ireq, "_source_ireqs"):
+        fresh_ireq._source_ireqs = ireq._source_ireqs
+    return fresh_ireq

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -25,10 +25,7 @@ import click
 from click.utils import LazyFile
 from pip._internal.models.link import Link
 from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import (
-    install_req_from_line,
-    install_req_from_link_and_ireq,
-)
+from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.utils.urls import path_to_url, url_to_path
 from pip._internal.vcs import is_url
@@ -541,3 +538,21 @@ def get_sys_path_for_python_executable(python_executable: str) -> List[str]:
     assert isinstance(paths, list)
     assert all(isinstance(i, str) for i in paths)
     return [os.path.abspath(path) for path in paths]
+
+
+def install_req_from_link_and_ireq(link, ireq):
+    # type: (Link, InstallRequirement) -> InstallRequirement
+    # After dropping support for pip < 21.1, we can instead:
+    # from pip._internal.req.constructors import install_req_from_link_and_ireq
+    return InstallRequirement(
+        req=ireq.req,
+        comes_from=ireq.comes_from,
+        editable=ireq.editable,
+        link=link,
+        markers=ireq.markers,
+        use_pep517=ireq.use_pep517,
+        isolated=ireq.isolated,
+        install_options=ireq.install_options,
+        global_options=ireq.global_options,
+        hash_options=ireq.hash_options,
+    )

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -556,7 +556,7 @@ def install_req_from_link_and_ireq(
             for xtr in link._parsed_url.fragment.rsplit("[", 1)[-1][:-1].split(",")
         )
     else:
-        extras = ()
+        extras = tuple(ireq.extras)
     fresh_ireq = InstallRequirement(
         req=ireq.req,
         comes_from=ireq.comes_from,

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -25,7 +25,10 @@ import click
 from click.utils import LazyFile
 from pip._internal.models.link import Link
 from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_line
+from pip._internal.req.constructors import (
+    install_req_from_line,
+    install_req_from_link_and_ireq,
+)
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.utils.urls import path_to_url, url_to_path
 from pip._internal.vcs import is_url
@@ -407,24 +410,11 @@ def abs_ireq(
         yanked_reason=ireq.link.yanked_reason,
         cache_link_parsing=ireq.link.cache_link_parsing,
     )
-    a_ireq = InstallRequirement(
-        req=ireq.req,
-        comes_from=ireq.comes_from,
-        editable=ireq.editable,
-        link=abs_link,  # <--
-        markers=ireq.markers,
-        use_pep517=ireq.use_pep517,
-        isolated=ireq.isolated,
-        install_options=ireq.install_options,
-        global_options=ireq.global_options,
-        hash_options=ireq.hash_options,
-        constraint=ireq.constraint,
-        extras=ireq.extras,
-        user_supplied=ireq.user_supplied,
-    )
+
+    a_ireq = install_req_from_link_and_ireq(abs_link, ireq)
     if hasattr(ireq, "_source_ireqs"):
         a_ireq._source_ireqs = ireq._source_ireqs
-    a_ireq._was_relative = True  # <--
+    a_ireq._was_relative = True
 
     return a_ireq
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -196,8 +196,9 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
 
     # If we get here then we have a requirement that supports direct reference.
     # We need to remove the egg if it exists and keep the rest of the fragments.
+    extras = f"[{','.join(xtr for xtr in sorted(ireq.extras))}]" if ireq.extras else ""
     return (
-        f"{ireq.name.lower()} @ {ireq.link.url_without_fragment}"
+        f"{ireq.name.lower()}{extras} @ {ireq.link.url_without_fragment}"
         f"{fragment_string(ireq, omit_egg=True)}"
     )
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -109,9 +109,7 @@ def is_url_requirement(ireq: InstallRequirement) -> bool:
     return bool(ireq.original_link)
 
 
-def fragment_string(
-    ireq: InstallRequirement, omit_egg: bool = False, omit_extras: bool = True
-) -> str:
+def fragment_string(ireq: InstallRequirement, omit_egg: bool = False) -> str:
     """
     Return a string like "#egg=pkgname&subdirectory=folder", or "".
     """
@@ -122,10 +120,9 @@ def fragment_string(
         fragment = re.sub(r"[#&]egg=[^#&]+", "", fragment).lstrip("#&")
         if fragment:
             fragment = f"#{fragment}"
-    if omit_extras:
-        fragment = re.sub(r"\[[^\]]+\]$", "", fragment).lstrip("#")
-        if fragment:
-            fragment = f"#{fragment}"
+    fragment = re.sub(r"\[[^\]]+\]$", "", fragment).lstrip("#")
+    if fragment:
+        fragment = f"#{fragment}"
     return fragment
 
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -540,15 +540,22 @@ def get_sys_path_for_python_executable(python_executable: str) -> List[str]:
     return [os.path.abspath(path) for path in paths]
 
 
-def install_req_from_link_and_ireq(link, ireq):
-    # type: (Link, InstallRequirement) -> InstallRequirement
-    # After dropping support for pip < 21.1, we can instead:
-    # from pip._internal.req.constructors import install_req_from_link_and_ireq
+def install_req_from_link_and_ireq(
+    link: Link, ireq: InstallRequirement
+) -> InstallRequirement:
+    if not ireq.extras and link._parsed_url.fragment.endswith("]"):
+        extras = tuple(
+            xtr.strip()
+            for xtr in link._parsed_url.fragment.rsplit("[", 1)[-1][:-1].split(",")
+        )
+    else:
+        extras = ()
     return InstallRequirement(
         req=ireq.req,
         comes_from=ireq.comes_from,
         editable=ireq.editable,
         link=link,
+        extras=extras,
         markers=ireq.markers,
         use_pep517=ireq.use_pep517,
         isolated=ireq.isolated,

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -109,7 +109,9 @@ def is_url_requirement(ireq: InstallRequirement) -> bool:
     return bool(ireq.original_link)
 
 
-def fragment_string(ireq: InstallRequirement, omit_egg: bool = False) -> str:
+def fragment_string(
+    ireq: InstallRequirement, omit_egg: bool = False, omit_extras: bool = True
+) -> str:
     """
     Return a string like "#egg=pkgname&subdirectory=folder", or "".
     """
@@ -118,6 +120,10 @@ def fragment_string(ireq: InstallRequirement, omit_egg: bool = False) -> str:
     fragment = f"#{ireq.link._parsed_url.fragment.replace(os.path.sep, '/')}"
     if omit_egg:
         fragment = re.sub(r"[#&]egg=[^#&]+", "", fragment).lstrip("#&")
+        if fragment:
+            fragment = f"#{fragment}"
+    if omit_extras:
+        fragment = re.sub(r"\[[^\]]+\]$", "", fragment).lstrip("#")
         if fragment:
             fragment = f"#{fragment}"
     return fragment
@@ -147,26 +153,32 @@ def format_requirement(
         )
         # pip doesn't support relative paths in git+file scheme urls,
         # for which ireq.link.is_file == False
-    elif not from_dir:
-        line = (
-            f"-e {path_to_url(ireq.local_file_path)}"
-            if ireq.editable
-            else _build_direct_reference_best_efforts(ireq)
-        )
     else:
-        try:
-            path_url = "file:" + os.path.relpath(
-                ireq.local_file_path, from_dir
-            ).replace(os.path.sep, "/")
-        except ValueError:
-            # On Windows, a relative path is not always possible (no common ancestor)
+        fragment = fragment_string(ireq)
+        extras = (
+            f"[{','.join(xtr for xtr in sorted(ireq.extras))}]" if ireq.extras else ""
+        )
+        delimiter = "#" if extras and not fragment else ""
+        if not from_dir:
             line = (
-                f"-e {path_to_url(ireq.local_file_path)}"
+                f"-e {path_to_url(ireq.local_file_path)}{fragment}{delimiter}{extras}"
                 if ireq.editable
                 else _build_direct_reference_best_efforts(ireq)
             )
         else:
-            line = f"{'-e ' if ireq.editable else ''}{path_url}{fragment_string(ireq)}"
+            try:
+                path_url = "file:" + os.path.relpath(
+                    ireq.local_file_path, from_dir
+                ).replace(os.path.sep, "/")
+            except ValueError:
+                # On Windows, a relative path is not always possible (no common ancestor)
+                line = (
+                    f"-e {path_to_url(ireq.local_file_path)}{fragment}{delimiter}{extras}"
+                    if ireq.editable
+                    else _build_direct_reference_best_efforts(ireq)
+                )
+            else:
+                line = f"{'-e ' if ireq.editable else ''}{path_url}{fragment}{delimiter}{extras}"
 
     if marker:
         line = f"{line} ; {marker}"

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -116,6 +116,7 @@ class OutputWriter:
         find_links: List[str],
         emit_find_links: bool,
         emit_options: bool,
+        write_relative_to_output: bool,
     ) -> None:
         self.dst_file = dst_file
         self.click_ctx = click_ctx
@@ -135,6 +136,7 @@ class OutputWriter:
         self.find_links = find_links
         self.emit_find_links = emit_find_links
         self.emit_options = emit_options
+        self.write_relative_to_output = write_relative_to_output
 
     def _sort_key(self, ireq: InstallRequirement) -> Tuple[bool, str]:
         return (not ireq.editable, key_from_ireq(ireq))
@@ -287,11 +289,16 @@ class OutputWriter:
         hashes: Optional[Dict[InstallRequirement, Set[str]]] = None,
     ) -> str:
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
+        from_dir = (
+            os.getcwd()
+            if not self.write_relative_to_output or self.dst_file.name == "-"
+            else os.path.dirname(os.path.abspath(self.dst_file.name))
+        )
         line = format_requirement(
             ireq,
             marker=marker,
             hashes=ireq_hashes,
-            from_dir=(os.getcwd() if hasattr(ireq, "_was_relative") else None),
+            from_dir=(from_dir if hasattr(ireq, "_was_relative") else None),
         )
         if self.strip_extras:
             line = re.sub(r"\[.+?\]", "", line)
@@ -303,12 +310,12 @@ class OutputWriter:
         required_by = set()
         if hasattr(ireq, "_source_ireqs"):
             required_by |= {
-                _comes_from_as_string(src_ireq)
+                _comes_from_as_string(src_ireq, from_dir=from_dir)
                 for src_ireq in ireq._source_ireqs
                 if src_ireq.comes_from
             }
         elif ireq.comes_from:
-            required_by.add(_comes_from_as_string(ireq))
+            required_by.add(_comes_from_as_string(ireq, from_dir=from_dir))
 
         if required_by:
             if self.annotation_style == "split":

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -287,8 +287,12 @@ class OutputWriter:
         hashes: Optional[Dict[InstallRequirement, Set[str]]] = None,
     ) -> str:
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
-
-        line = format_requirement(ireq, marker=marker, hashes=ireq_hashes)
+        line = format_requirement(
+            ireq,
+            marker=marker,
+            hashes=ireq_hashes,
+            from_dir=(os.getcwd() if hasattr(ireq, "_was_relative") else None),
+        )
         if self.strip_extras:
             line = re.sub(r"\[.+?\]", "", line)
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -289,11 +289,12 @@ class OutputWriter:
         hashes: Optional[Dict[InstallRequirement, Set[str]]] = None,
     ) -> str:
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
-        from_dir = (
+        out_dir = (
             os.getcwd()
-            if not self.write_relative_to_output or self.dst_file.name == "-"
+            if self.dst_file.name == "-"
             else os.path.dirname(os.path.abspath(self.dst_file.name))
         )
+        from_dir = out_dir if self.write_relative_to_output else os.getcwd()
         line = format_requirement(
             ireq,
             marker=marker,
@@ -310,12 +311,12 @@ class OutputWriter:
         required_by = set()
         if hasattr(ireq, "_source_ireqs"):
             required_by |= {
-                _comes_from_as_string(src_ireq, from_dir=from_dir)
+                _comes_from_as_string(src_ireq, from_dir=out_dir)
                 for src_ireq in ireq._source_ireqs
                 if src_ireq.comes_from
             }
         elif ireq.comes_from:
-            required_by.add(_comes_from_as_string(ireq, from_dir=from_dir))
+            required_by.add(_comes_from_as_string(ireq, from_dir=out_dir))
 
         if required_by:
             if self.annotation_style == "split":

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2365,3 +2365,16 @@ def test_cli_compile_strip_extras(runner, make_package, make_sdist, tmpdir):
     assert out.exit_code == 0, out
     assert "test-package-2==0.1" in out.stderr
     assert "[more]" not in out.stderr
+
+
+@pytest.mark.parametrize("extras", (("dev",), ("test",), ("dev", "test")))
+def test_local_file_uri_with_extras(pip_conf, runner, extras):
+    """
+    Test [extras] notation is included output.
+    """
+    uri = path_to_url(os.path.join(PACKAGES_PATH, "small_fake_with_extras"))
+    out = runner.invoke(
+        cli, ["--output-file", "-", "-"], input=f"{uri}#[{','.join(extras)}]"
+    )
+    assert out.exit_code == 0
+    assert f"small-fake-with-extras[{','.join(sorted(extras))}] @ " in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -784,6 +784,43 @@ def test_input_file_without_extension(pip_conf, runner):
     assert os.path.exists("requirements.txt")
 
 
+def test_input_file_with_txt_extension(pip_conf, runner, tmp_path):
+    """
+    Compile an input file ending in .txt to a separate output file (*.txt.txt),
+    without overwriting the input file.
+    """
+    in_file = tmp_path / "requirements.txt"
+    content = "small-fake-a==0.1"
+
+    in_file.write_text(content)
+
+    out = runner.invoke(cli, [str(in_file)])
+
+    assert out.exit_code == 0
+    assert in_file.read_text().strip() == content
+    assert os.path.exists(f"{in_file}.txt")
+
+
+def test_input_file_without_extension_and_dotted_path(pip_conf, runner, tmp_path):
+    """
+    Compile a file without an extension, in a subdir with a dot,
+    into an input-adjacent file with .txt as the extension.
+    """
+    dotted_dir = tmp_path / "some.folder"
+    in_path = tmp_path / dotted_dir / "reqs"
+    txt_path = tmp_path / dotted_dir / "reqs.txt"
+
+    dotted_dir.mkdir(parents=True, exist_ok=True)
+
+    in_path.write_text("small-fake-a==0.1\n")
+
+    out = runner.invoke(cli, [str(in_path)])
+
+    assert out.exit_code == 0
+    assert "small-fake-a==0.1" in out.stderr
+    assert txt_path.exists()
+
+
 def test_upgrade_packages_option(pip_conf, runner):
     """
     piptools respects --upgrade-package/-P inline list.

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -719,6 +719,21 @@ def test_direct_reference_with_extras(runner):
     assert "pytest-cov==" in out.stderr
 
 
+def test_url_package_with_extras(runner):
+    with open("requirements.in", "w") as req_in:
+        req_in.write(
+            "git+https://github.com/jazzband/pip-tools@6.2.0#[testing,coverage]"
+        )
+    out = runner.invoke(cli, ["-n", "--rebuild"])
+    assert out.exit_code == 0
+    assert (
+        "pip-tools[coverage,testing] @ git+https://github.com/jazzband/pip-tools@6.2.0"
+        in out.stderr
+    )
+    assert "pytest==" in out.stderr
+    assert "pytest-cov==" in out.stderr
+
+
 @pytest.mark.parametrize("flags", (("--write-relative-to-output",), ()))
 def test_local_editable_vcs_package(runner, tmp_path, make_package, flags):
     """

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -633,6 +633,64 @@ def test_local_file_uri_package(
     assert dependency in out.stderr
 
 
+@pytest.mark.parametrize(
+    ("line", "rewritten_line"),
+    (
+        pytest.param(
+            "./small_fake_a",
+            "file:small_fake_a",
+            id="relative path",
+        ),
+        pytest.param(
+            "./small_fake_with_extras[dev,test]",
+            "file:small_fake_with_extras#[dev,test]",
+            id="relative path with extras",
+        ),
+        pytest.param(
+            "./small_fake_a#egg=name",
+            "file:small_fake_a#egg=name",
+            id="relative path with egg",
+        ),
+        pytest.param(
+            "./small_fake_with_extras#egg=name[dev,test]",
+            "file:small_fake_with_extras#egg=name[dev,test]",
+            id="relative path with egg and extras",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_a",
+            f"small-fake-a @ {path_to_url(PACKAGES_PATH)}/small_fake_a",
+            id="absolute path",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_with_extras[dev,test]",
+            (
+                "small-fake-with-extras[dev,test] @ "
+                f"{path_to_url(PACKAGES_PATH)}/small_fake_with_extras"
+            ),
+            id="absolute path with extras",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_a#egg=test",
+            f"small-fake-a @ {path_to_url(PACKAGES_PATH)}/small_fake_a",
+            id="absolute path with egg",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_with_extras#egg=name[dev,test]",
+            (
+                "small-fake-with-extras[dev,test] @ "
+                f"{path_to_url(PACKAGES_PATH)}/small_fake_with_extras"
+            ),
+            id="absolute path with egg and extras",
+        ),
+    ),
+)
+def test_local_file_path_package(pip_conf, runner, line, rewritten_line):
+    with working_dir(PACKAGES_PATH):
+        out = runner.invoke(cli, ["--output-file", "-", "-"], input=line)
+    assert out.exit_code == 0
+    assert rewritten_line in out.stderr
+
+
 def test_relative_file_uri_package(pip_conf, runner):
     # Copy wheel into temp dir
     shutil.copy(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -643,7 +643,7 @@ def test_local_file_uri_package(
         ),
         pytest.param(
             "./small_fake_with_extras[dev,test]",
-            "file:small_fake_with_extras#[dev,test]",
+            "./small_fake_with_extras[dev,test]",
             id="relative path with extras",
         ),
         pytest.param(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -9,6 +9,7 @@ import pytest
 from pip._internal.utils.urls import path_to_url
 
 from piptools.scripts.compile import cli
+from piptools.utils import working_dir
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 
@@ -644,6 +645,53 @@ def test_relative_file_uri_package(pip_conf, runner):
     out = runner.invoke(cli, ["-n", "--rebuild"])
     assert out.exit_code == 0
     assert "file:small_fake_with_deps-0.1-py2.py3-none-any.whl" in out.stderr
+
+
+@pytest.mark.parametrize(
+    ("flags", "expected"),
+    (
+        (("--write-relative-to-output",), "-e file:deeper/fake-setuptools-a"),
+        ((), "-e file:../deep/deeper/fake-setuptools-a"),
+    ),
+)
+@pytest.mark.parametrize("relpath_prefix", ("file:", "./"))
+def test_write_relative_to_output(
+    pip_conf, runner, tmp_path, relpath_prefix, flags, expected
+):
+    """
+    Relative paths in output are correct between CWD, output, and local packages.
+    """
+    run_dir = tmp_path / "working"
+    in_path = tmp_path / "reqs.in"
+    txt_path = tmp_path / "deep" / "reqs.txt"
+    pkg_path = tmp_path / "deep" / "deeper" / "fake-setuptools-a"
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    pkg_path.mkdir(parents=True, exist_ok=True)
+
+    (pkg_path / "setup.py").write_text(
+        dedent(
+            """\
+            from setuptools import setup
+            setup(
+                name="fake-setuptools-a",
+                install_requires=["small-fake-a==0.1"]
+            )
+            """
+        )
+    )
+
+    with working_dir(run_dir):
+        in_path.write_text(
+            f"-e {relpath_prefix}{os.path.relpath(pkg_path).replace(os.path.sep, '/')}"
+        )
+        out = runner.invoke(
+            cli,
+            ["-o", os.path.relpath(txt_path), *flags, os.path.relpath(in_path)],
+        )
+
+    assert out.exit_code == 0
+    assert expected in out.stderr
 
 
 def test_direct_reference_with_extras(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -711,7 +711,10 @@ def test_direct_reference_with_extras(runner):
         )
     out = runner.invoke(cli, ["-n", "--rebuild"])
     assert out.exit_code == 0
-    assert "pip-tools @ git+https://github.com/jazzband/pip-tools@6.2.0" in out.stderr
+    assert (
+        "pip-tools[coverage,testing] @ git+https://github.com/jazzband/pip-tools@6.2.0"
+        in out.stderr
+    )
     assert "pytest==" in out.stderr
     assert "pytest-cov==" in out.stderr
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -651,16 +651,22 @@ def test_relative_file_uri_package(pip_conf, runner):
 @pytest.mark.parametrize(
     ("flags", "expected"),
     (
+        (
+            ("--write-relative-to-output", "--read-relative-to-input"),
+            "-e file:deeper/fake-setuptools-a",
+        ),
         (("--write-relative-to-output",), "-e file:deeper/fake-setuptools-a"),
         ((), "-e file:../deep/deeper/fake-setuptools-a"),
+        (("--read-relative-to-input",), "-e file:../deep/deeper/fake-setuptools-a"),
     ),
 )
 @pytest.mark.parametrize("relpath_prefix", ("file:", "./"))
-def test_write_relative_to_output(
+def test_read_write_relative(
     pip_conf, runner, tmp_path, relpath_prefix, flags, expected
 ):
     """
-    Relative paths in output are correct between CWD, output, and local packages.
+    Relative paths in output are correct between CWD, output, and local packages,
+    and relative paths in inputs are correctly resolved.
     """
     run_dir = tmp_path / "working"
     in_path = tmp_path / "reqs.in"
@@ -682,10 +688,13 @@ def test_write_relative_to_output(
         )
     )
 
-    with working_dir(run_dir):
+    with working_dir(
+        in_path.parent if "--read-relative-to-input" in flags else run_dir
+    ):
         in_path.write_text(
             f"-e {relpath_prefix}{os.path.relpath(pkg_path).replace(os.path.sep, '/')}"
         )
+    with working_dir(run_dir):
         out = runner.invoke(
             cli,
             ["-o", os.path.relpath(txt_path), *flags, os.path.relpath(in_path)],

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1368,6 +1368,58 @@ def test_annotate_option(pip_conf, runner, options, expected):
     assert out.exit_code == 0
 
 
+@pytest.mark.network
+@pytest.mark.parametrize("to_stdout", (True, False))
+@pytest.mark.parametrize(
+    "flags",
+    (
+        (),
+        ("--write-relative-to-output",),
+        ("--read-relative-to-input",),
+        ("--write-relative-to-output", "--read-relative-to-input"),
+    ),
+)
+@pytest.mark.parametrize(
+    ("input_filename", "input_content", "expected"),
+    (
+        ("requirements.in", "small-fake-a==0.1", " # via -r {}"),
+        (
+            "setup.py",
+            (
+                "from setuptools import setup\n"
+                "setup(name='fake-setuptools-a', install_requires=['small-fake-a==0.1'])"
+            ),
+            " # via fake-setuptools-a ({})",
+        ),
+    ),
+    ids=("requirements.in", "setup.py"),
+)
+def test_annotation_relative_paths(
+    runner, tmp_path, input_filename, input_content, expected, flags, to_stdout
+):
+    """
+    Annotations referencing files use paths relative to the output file.
+    """
+    run_dir = tmp_path
+
+    in_path = tmp_path / input_filename
+    in_path.write_text(input_content)
+
+    txt_path = tmp_path / "deeper" / "requirements.txt"
+    txt_path.parent.mkdir(parents=True, exist_ok=True)
+
+    output = "-" if to_stdout else str(txt_path)
+
+    with working_dir(run_dir):
+        out = runner.invoke(
+            cli,
+            ["--find-links", MINIMAL_WHEELS_PATH, "-o", output, *flags, str(in_path)],
+        )
+        assert out.exit_code == 0
+        with working_dir(None if to_stdout else txt_path.parent):
+            assert expected.format(os.path.relpath(in_path)) in out.stderr
+
+
 @pytest.mark.parametrize(
     ("option", "expected"),
     (

--- a/tests/test_data/packages/small_fake_with_extras/setup.py
+++ b/tests/test_data/packages/small_fake_with_extras/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name="small_fake_with_extras",
+    version=0.1,
+    install_requires=["small-fake-a", "small-fake-b"],
+    extras_require={
+        "dev": ["small-fake-a"],
+        "test": ["small-fake-b"],
+    },
+)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import logging
 import operator
 import os
 import platform
+import re
 import shlex
 import sys
 
@@ -144,7 +145,9 @@ def test_format_requirement_editable_vcs_with_password(from_editable):
 
 def test_format_requirement_editable_local_path(from_editable):
     ireq = from_editable("file:///home/user/package")
-    assert format_requirement(ireq) == "-e file:///home/user/package"
+    assert re.match(
+        r"-e file:///([a-zA-Z]:/)?home/user/package$", format_requirement(ireq)
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ from piptools.utils import (
     key_from_ireq,
     lookup_table,
     lookup_table_from_tuples,
+    working_dir,
 )
 
 
@@ -540,3 +541,22 @@ def test_get_sys_path_for_python_executable():
     # not testing for equality, because pytest adds extra paths into current sys.path
     for path in result:
         assert path in sys.path
+
+
+@pytest.mark.parametrize(
+    ("folder_name", "use_abspath"),
+    (("subfolder", True), ("subfolder", False), (None, False)),
+)
+def test_working_dir(tmpdir_cwd, folder_name, use_abspath):
+    if folder_name is not None:
+        os.mkdir(folder_name)
+        expected_within = os.path.abspath(folder_name)
+    else:
+        expected_within = tmpdir_cwd
+    if use_abspath:
+        folder_name = expected_within
+
+    with working_dir(folder_name):
+        assert os.getcwd() == expected_within
+
+    assert os.getcwd() == tmpdir_cwd

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -69,6 +69,23 @@ def test_format_requirement_annotation(from_line, writer):
     assert writer._format_requirement(ireq) == "test==1.2\n    " + comment("# via xyz")
 
 
+@pytest.mark.parametrize(
+    ("comes_from", "expected"),
+    (
+        ("xyz (z:/pyproject.toml)", "# via xyz (z:/pyproject.toml)"),
+        ("-r z:/pyproject.toml (line 1)", "# via -r z:/pyproject.toml"),
+    ),
+)
+def test_format_requirement_annotation_impossible_relative_path(
+    from_line, writer, comes_from, expected
+):
+    "A relative path can't be constructed across drives on a Windows filesystem."
+    ireq = from_line("test==1.2")
+    ireq.comes_from = comes_from
+
+    assert writer._format_requirement(ireq) == "test==1.2\n    " + comment(expected)
+
+
 def test_format_requirement_annotation_source_ireqs(from_line, writer):
     "Annotations credit an ireq's source_ireq's comes_from attribute."
     ireq = from_line("test==1.2")
@@ -79,7 +96,7 @@ def test_format_requirement_annotation_source_ireqs(from_line, writer):
 
     assert (
         writer._format_requirement(ireq2)
-        == f"testwithsrc==3.0\n{comment('    # via xyz')}"
+        == f"testwithsrc==3.0\n    {comment('# via xyz')}"
     )
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -68,6 +68,20 @@ def test_format_requirement_annotation(from_line, writer):
     assert writer._format_requirement(ireq) == "test==1.2\n    " + comment("# via xyz")
 
 
+def test_format_requirement_annotation_source_ireqs(from_line, writer):
+    "Annotations credit an ireq's source_ireq's comes_from attribute."
+    ireq = from_line("test==1.2")
+    ireq.comes_from = "xyz"
+
+    ireq2 = from_line("testwithsrc==3.0")
+    ireq2._source_ireqs = [ireq]
+
+    assert (
+        writer._format_requirement(ireq2)
+        == f"testwithsrc==3.0\n{comment('    # via xyz')}"
+    )
+
+
 def test_format_requirement_annotation_lower_case(from_line, writer):
     ireq = from_line("Test==1.2")
     ireq.comes_from = "xyz"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -47,6 +47,7 @@ def writer(tmpdir_cwd):
             emit_find_links=True,
             strip_extras=False,
             emit_options=True,
+            write_relative_to_output=False,
         )
         yield writer
 


### PR DESCRIPTION
<details><summary>Initial Summary (Outdated)</summary>

```

Rewrite input file paths as relative to the output file, or as absolutes if using stdout:

- Change click arg output_file from click.File to click.Path,
  so we can get its absolute path
- Change to output file's parent folder before opening it,
  helping upstream pip code to use correct relative paths
- Return to the starting dir after compilation,
  for test or other calls from code which don't expect dir changes
- Rewrite src_files as absolute paths as soon as we have them,
  to resolve relative paths properly (CLI args are relative to CWD)
- When deriving the output path from a single input path, stay safer and more predictable,
  particularly if the basename has no dot, and the path does (see example in #1067)
- Rewrite src_files as relative to the output path once that's known,
  unless output is stdout
- Don't overwrite an input file ending in '.txt' when deriving the output file path
- Add tests:
    - test_annotation_relative_paths
    - test_input_file_with_txt_extension
    - test_input_file_without_extension_and_dotted_path

Fixes #1107

Contributes to #1067

Minor tag-alongs:
  - fix some comment typos
  - git-ignore sublime text project and workspace files

QUESTIONS:
1. If output is stdout, should paths (in annotations) be absolute,
  or relative to current working folder? 
  With this PR, they're absolute, and I think that is appropriate.
2. With this PR, `output_file` changes its type, early on. 
  Does that bother anyone? It starts as a `click.Path`, then 
  after paths are resolved by our logic, it's replaced by a `click.File`. 
  It's a small window of `click.Path`-ness. An example consequence
  is seen in this PR's change to `test_writer.py`.
3. What is the best result of using `name.txt` as an input file, without specifying the output file?
  With this PR, it outputs to `name.txt.txt`, which is the best I can think of.
4. What additional tests would be good to have, if any? 
  More annotation variants, like with `-c`? More complicated relative paths?

**Changelog-friendly one-liners**: 
- Rewrite input file paths as relative to the output file, or as absolutes if using stdout
- Don't overwrite an input file ending in '.txt' when deriving the output file path
- Don't confuse dots in folder names with file extensions when deriving the output file path

```
</details>

<details><summary>Summary, Take 2 (also outdated)</summary>

Fixup relative and absolute path handling:

These changes have been made with the general guideline of
storing paths as absolute as soon as we can, and rendering
them as relative or absolute as needed.

| Path | Initial Interpretation | Output Format (file) | Output Format (stdout) |
| --- | --- | --- | --- |
| source file | relative to invocation dir | (annotation) relative to output file | absolute |
| ireq from source file | relative to its source file | relative to output file, unless initially absolute | absolute |
| ireq from `--upgrade-package` | relative to invocation dir | ~relative to output file~ I *think*: relative to output file if passed as relative, absolute if passed as absolute, pathless if passed as pathless | absolute |
| `git+file:` ireq from source file | relative to its source file | absolute (`pip` doesn't support relative paths in that form) | absolute |

<details><summary>Itemized Changes by File</summary>

`utils.py`
----------

- Changed:
  - `format_requirement`:
    - Add optional `str` kwarg `from_dir`:
      - If used, it'll rewrite local paths as relative (to `from_dir`).
    - Replace alternative path separators in relpaths with forward slashes.
    - Use pip's `path_to_url` for abs paths.
    - Ensure fragment is attached if present originally.
- Added:
  - Function `abs_ireq`:

    ```python
    def abs_ireq(ireq: InstallRequirement, from_dir: str) -> InstallRequirement:
        """
        Return the given InstallRequirement if its source isn't a relative path;
        Otherwise, return a new one with the relative path rewritten as absolute.

        In this case, an extra attribute is added: _was_relative,
        which is always True when present at all.
        """
    ```
  - Context manager `working_dir`:
 
    ```python
    @contextmanager
    def working_dir(folder: Optional[str]) -> Iterator[None]:
        """Change the current directory within the context, then change it back."""
    ```
  - Function `fragment_string`:

    ```python
    def fragment_string(ireq: InstallRequirement) -> str:
        """
        Return a string like "#egg=pkgname&subdirectory=folder", or "".
        """
    ```


`pip_compat.py`
---------------

- Changed:
  - `parse_requirements`:
    - Add optional `str` kwarg `from_dir` to `parse_requirements`.
      If left to its default, `None`, the parent of the source file is used.
      Either way it's passed to `abs_ireq`, so any yielded local ireqs
      have absolute `.link`s, and some have `._was_relative`.
    - Ensure pip's `install_req_from_parsed_requirement` is called from a sensible folder, 
      to better resolve relative paths; and try to detect if each ireq was initially relative, 
      to "manually" mark the resulting (absolute) ireq with `_was_relative`.

`compile.py`
------------

- Change `Click` argument type for the output file from `File` to `Path`.
  When `Click`'s `File` object is initialized with the absolute path,
  that full path is preserved as the `.name` attribute. So we now instantiate
  the output `File` ourselves *after* resolving its absolute path.
- Resolve `src_files` to their absolute paths.
- When deriving the output path from a single input path,
  ensure it's properly adjacent to the input,
  and stay safer and more predictable when the basename has no dot and the path does,
  or the input file ends in `.txt` (see #1067, #1107, and tests below).
- Use `abs_ireq` when collecting `upgrade_install_reqs` (`--upgrade-package`),
  passing the invocation dir as `from_dir`.
- No support for relative paths is introduced for `setup.py` `install_requires`,
  given the discussion @ https://discuss.python.org/t/what-is-the-correct-interpretation-of-path-based-pep-508-uri-reference/2815/18
- Ensure a suitable `from_dir` is passed to `parse_requirements`
  when parsing from `setup.py` or stdin, which really parses a temp file.
  This means `setup.py`'s parent folder, or the invocation dir if the source is stdin.

`writer.py`
-----------

- Added:
  - `comes_from_line_project_re` pattern for parsing and rewriting
    `comes_from` `str`s that point to `setup.py`s and `pyproject.toml`s.
- Changed:
  - `strip_comes_from_line_re`:
    - Extend/replace the pattern as `comes_from_line_re`,
      with named groups for `opts` (`-r`/`-c`), `path`, and `line_num`.
  - `_comes_from_as_string`:
    - Add optional `str` kwarg `from_dir`.
      If the `ireq.comes_from` is already a `str` and `from_dir` is passed,
      in addition to stripping the line number as before, rewrite the path as relative.
    - Add handling for `comes_from_line_project_re` matches.
  - `_format_requirement`:
    - If the `ireq` has `._was_relative` and the output is a file,
      pass the output file's parent as `from_dir` to `format_requirement`,
      ensuring the written path for the `ireq` is relative in that case.
    - Pass the parent of the output file, if any, as `from_dir` to `_comes_from_as_string`.

`test_cli_compile.py`
---------------------

- Added:
  - `test_relative_local_package`
    - Relative paths are properly resolved between input, output, and local packages.
    - Input file paths/URIs can be relative, as long as they start with `file:` or `.`.
  - `test_input_file_with_txt_extension`
    - Compile an input file ending in `.txt` to a separate output file (`*.txt.txt`),
      without overwriting the input file.
  - `test_input_file_without_extension_and_dotted_path`
    - Compile a file without an extension, in a subdir with a dot,
      into an input-adjacent file with `.txt` as the extension.
  - `test_annotation_relative_paths`
    - Annotations referencing `reqs.in` files use paths relative to the `reqs.txt`.
  - `test_local_vcs_package`
    - git+file urls are rewritten to use absolute paths, and otherwise remain intact.
- Changed:
  - `test_duplicate_reqs_combined`
    - Use pip's `path_to_url` to detect the normalized package path in URL form.

`test_writer.py`
----------------

- Changed:
  - `writer` fixture:
    - Open an output file object to pass to `OutputWriter`,
      rather than passing the click `ctx` entry (now just a `Path`).
  - `test_write_header`:
    - Access the user-supplied output file path via
      `writer.click_ctx.params["output_file"]` (now just a `Path`), rather than
      checking that for a `.name`.
  - `test_iter_lines__hash_missing`:
    - Use regex match to recognize Windows drive names.
  - `test_iter_lines__no_warn_if_only_unhashable_packages`:
    - Use regex match to recognize Windows drive names.
- Added:
  - `test_format_requirement_annotation_source_ireqs`

`test_utils.py`
---------------

- Changed:
  - `test_format_requirement_editable_local_path`
    - Use regex match to recognize Windows drive names.
- Added:
  - `test_working_dir`
  - `test_local_abs_ireq_preserves_source_ireqs`

</details>

---

**Changelog-friendly one-liners**:
- Support relative paths in input files, as long as they lead with `file:`, `<vcs>+file:`, or `.`.
- If a local requirement path is relative in the input, interpret it as relative to that input file, and write it as relative to the output file, if any. Otherwise, write the absolute path.
- Rewrite input file paths (in annotations) as relative to the output file, or as absolute if using stdout.
- Don't overwrite an input file ending in '.txt' when deriving the output file path.
- Don't confuse dots in folder names with file extensions when deriving the output file path.
- Write requirement paths using forward slashes rather than backslashes, on Windows.

</details>

**Changelog-friendly one-liners**:
- Support relative paths in input files, as long as they lead with `file:`, `<vcs>+file:`, or `.`.
- Relative paths in input files become relative paths in output files.
- `pip-compile` will interpret relative paths in an input file as relative to that input file, rather than the current folder, if `--read-relative-to-input` is passed.
- `pip-compile` will reconstruct relative req paths as relative to the output file, rather than the current folder, if `--write-relative-to-output` is passed.
- `pip-sync` will interpret relative paths in an input file as relative to that input file, rather than the current folder, if `--read-relative-to-input` is passed.
- Annotation paths are now relative to the output file.
- Don't overwrite an input file ending in '.txt' when deriving the output file path.
- Don't confuse dots in folder names with file extensions when deriving the output file path.
- Include extras more reliably in output lines, like `pkg[extra1,extra2]`.

---

- Fixes #1107
- Fixes #204
- Fixes #1165
- Related #1067
- Related #453 (Not addressed in this PR)
- Related #673 
- Related #702 

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
