### PR TITLE
Revert back piptools._compat.contextlib

### DIFF
--- a/piptools/_compat/contextlib.py
+++ b/piptools/_compat/contextlib.py
@@ -1,4 +1,10 @@
 # Ported from python 3.7 contextlib.py
+from types import TracebackType
+from typing import Optional, Type, TypeVar
+
+_T = TypeVar("_T")
+
+
 class nullcontext:
     """Context manager that does no additional processing.
     Used as a stand-in for a normal context manager, when a particular
@@ -6,13 +12,20 @@ class nullcontext:
     cm = optional_cm if condition else nullcontext()
     with cm:
         # Perform operation, using optional_cm if condition is True
+
+    TODO: replace with `contextlib.nullcontext()` after Python 3.6 being dropped
     """
 
-    def __init__(self, enter_result=None):
+    def __init__(self, enter_result: Optional[_T] = None) -> None:
         self.enter_result = enter_result
 
-    def __enter__(self):
+    def __enter__(self) -> Optional[_T]:
         return self.enter_result
 
-    def __exit__(self, *excinfo):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
         pass

--- a/piptools/_compat/contextlib.py
+++ b/piptools/_compat/contextlib.py
@@ -1,0 +1,18 @@
+# Ported from python 3.7 contextlib.py
+class nullcontext:
+    """Context manager that does no additional processing.
+    Used as a stand-in for a normal context manager, when a particular
+    block of code is only sometimes used with a normal context manager:
+    cm = optional_cm if condition else nullcontext()
+    with cm:
+        # Perform operation, using optional_cm if condition is True
+    """
+
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *excinfo):
+        pass

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -21,10 +21,9 @@ from pip._internal.utils.logging import indent_log, setup_logging
 from pip._internal.utils.misc import normalize_path
 from pip._internal.utils.temp_dir import TempDirectory, global_tempdir_manager
 from pip._internal.utils.urls import path_to_url, url_to_path
-from pip._vendor import contextlib2
 from pip._vendor.requests import RequestException
 
-from .._compat import PIP_VERSION
+from .._compat import PIP_VERSION, contextlib
 from ..exceptions import NoCandidateFound
 from ..logging import log
 from ..utils import (
@@ -407,7 +406,7 @@ class PyPIRepository(BaseRepository):
                     width=32,
                 )
             else:
-                context_manager = contextlib2.nullcontext(chunks)
+                context_manager = contextlib.nullcontext(chunks)
 
             # Iterate over the chosen context manager
             with context_manager as bar:


### PR DESCRIPTION
The module `pip._vendor.contextlib2` has been recently removed in  https://github.com/pypa/pip/pull/9384, which breaks `pip-tools` (see [failing cron jobs](https://github.com/jazzband/pip-tools/actions/runs/626139126) for the pip's master branch).

This PR brings back the `piptools._compat.contextlib.nullcontext()` conext manager removed in #1283 .

/cc @jdufresne 