### PR TITLE
Prefer dict literals over dict constructor

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -157,15 +157,15 @@ class PyPIRepository(BaseRepository):
         with get_requirement_tracker() as req_tracker, TempDirectory(
             kind="resolver"
         ) as temp_dir, indent_log():
-            preparer_kwargs = dict(
-                temp_build_dir=temp_dir,
-                options=self.options,
-                req_tracker=req_tracker,
-                session=self.session,
-                finder=self.finder,
-                use_user_site=False,
-                download_dir=download_dir,
-            )
+            preparer_kwargs = {
+                "temp_build_dir": temp_dir,
+                "options": self.options,
+                "req_tracker": req_tracker,
+                "session": self.session,
+                "finder": self.finder,
+                "use_user_site": False,
+                "download_dir": download_dir,
+            }
             preparer = self.command.make_requirement_preparer(**preparer_kwargs)
 
             reqset = RequirementSet()

--- a/tests/test_minimal_upgrade.py
+++ b/tests/test_minimal_upgrade.py
@@ -34,7 +34,7 @@ from piptools.utils import key_from_ireq
 )
 def test_no_upgrades(base_resolver, repository, from_line, input, pins, expected):
     input = [from_line(line) for line in input]
-    existing_pins = dict()
+    existing_pins = {}
     for line in pins:
         ireq = from_line(line)
         existing_pins[key_from_ireq(ireq)] = ireq


### PR DESCRIPTION
More idiomatic and (very very slightly) faster.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
