### PR TITLE
Remove unused PyPIRepository cache directories

### DIFF
--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -10,11 +10,6 @@ class BaseRepository(metaclass=ABCMeta):
         """Should clear any caches used by the implementation."""
 
     @abstractmethod
-    @contextmanager
-    def freshen_build_caches(self) -> Iterator[None]:
-        """Should start with fresh build/source caches."""
-
-    @abstractmethod
     def find_best_match(
         self, ireq: InstallRequirement, prereleases: Optional[bool]
     ) -> InstallRequirement:

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -68,11 +68,6 @@ class LocalRequirementsRepository(BaseRepository):
     def clear_caches(self) -> None:
         self.repository.clear_caches()
 
-    @contextmanager
-    def freshen_build_caches(self) -> Iterator[None]:
-        with self.repository.freshen_build_caches():
-            yield
-
     def find_best_match(
         self, ireq: InstallRequirement, prereleases: Optional[bool] = None
     ) -> InstallationCandidate:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -3,7 +3,6 @@ import hashlib
 import itertools
 import logging
 import os
-import tempfile
 from contextlib import contextmanager
 from shutil import rmtree
 from typing import Any, ContextManager, Dict, Iterator, List, Optional, Set, cast
@@ -84,36 +83,10 @@ class PyPIRepository(BaseRepository):
         self._dependencies_cache: Dict[InstallRequirement, Set[InstallRequirement]] = {}
 
         # Setup file paths
-        self._build_dir: Optional[tempfile.TemporaryDirectory[str]] = None
-        self._source_dir: Optional[tempfile.TemporaryDirectory[str]] = None
         self._cache_dir = normalize_path(str(cache_dir))
         self._download_dir = os.path.join(self._cache_dir, "pkgs")
 
         self._setup_logging()
-
-    @contextmanager
-    def freshen_build_caches(self) -> Iterator[None]:
-        """
-        Start with fresh build/source caches.  Will remove any old build
-        caches from disk automatically.
-        """
-        self._build_dir = tempfile.TemporaryDirectory("build")
-        self._source_dir = tempfile.TemporaryDirectory("source")
-        try:
-            yield
-        finally:
-            self._build_dir.cleanup()
-            self._build_dir = None
-            self._source_dir.cleanup()
-            self._source_dir = None
-
-    @property
-    def build_dir(self) -> Optional[str]:
-        return self._build_dir.name if self._build_dir else None
-
-    @property
-    def source_dir(self) -> Optional[str]:
-        return self._source_dir.name if self._source_dir else None
 
     def clear_caches(self) -> None:
         rmtree(self._download_dir, ignore_errors=True)

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -175,20 +175,14 @@ class Resolver:
 
                 log.debug("")
                 log.debug(magenta(f"{f'ROUND {current_round}':^60}"))
-                # If a package version (foo==2.0) was built in a previous round,
-                # and in this round a different version of foo needs to be built
-                # (i.e. foo==1.0), the directory will exist already, which will
-                # cause a pip build failure.  The trick is to start with a new
-                # build cache dir for every round, so this can never happen.
-                with self.repository.freshen_build_caches():
-                    has_changed, best_matches = self._resolve_one_round()
-                    log.debug("-" * 60)
-                    log.debug(
-                        "Result of round {}: {}".format(
-                            current_round,
-                            "not stable" if has_changed else "stable, done",
-                        )
+                has_changed, best_matches = self._resolve_one_round()
+                log.debug("-" * 60)
+                log.debug(
+                    "Result of round {}: {}".format(
+                        current_round,
+                        "not stable" if has_changed else "stable, done",
                     )
+                )
                 if not has_changed:
                     break
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,10 +41,6 @@ class FakeRepository(BaseRepository):
         with open("tests/test_data/fake-editables.json") as f:
             self.editables = json.load(f)
 
-    @contextmanager
-    def freshen_build_caches(self):
-        yield
-
     def get_hashes(self, ireq):
         # Some fake hashes
         return {

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -135,20 +135,6 @@ def test_open_local_or_remote_file__remote_file(
         mock_response.close.assert_called_once()
 
 
-def test_pypirepo_build_dir_is_str(pypi_repository):
-    assert pypi_repository.build_dir is None
-    with pypi_repository.freshen_build_caches():
-        assert isinstance(pypi_repository.build_dir, str)
-    assert pypi_repository.build_dir is None
-
-
-def test_pypirepo_source_dir_is_str(pypi_repository):
-    assert pypi_repository.source_dir is None
-    with pypi_repository.freshen_build_caches():
-        assert isinstance(pypi_repository.source_dir, str)
-    assert pypi_repository.source_dir is None
-
-
 def test_relative_path_cache_dir_is_normalized(from_line):
     relative_cache_dir = "pypi-repo-cache"
     pypi_repository = PyPIRepository([], cache_dir=relative_cache_dir)


### PR DESCRIPTION
Unused since 50ecc4e8fd76d3540d2f6db68683ee6292af562a.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
