### PR TITLE
Prefer dict over OrderedDict

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -207,7 +207,7 @@ def dedup(iterable: Iterable[_T]) -> Iterable[_T]:
     """Deduplicate an iterable object like iter(set(iterable)) but
     order-preserved.
     """
-    return iter(collections.OrderedDict.fromkeys(iterable))
+    return iter(dict.fromkeys(iterable))
 
 
 def get_hashes_from_ireq(ireq: InstallRequirement) -> Set[str]:


### PR DESCRIPTION
Starting with Python 3.6, the builtin dict retains its order. Using
OrderedDict is no longer necessary.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
