### PR TITLE
Fix a bug where pip-compile setup.py would fail due to URL dependency

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -7,10 +7,7 @@ from typing import Any
 import click
 from click.utils import safecall
 from pip._internal.commands import create_command
-from pip._internal.req.constructors import (
-    install_req_from_line,
-    install_req_from_req_string,
-)
+from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._vendor.pep517 import meta
 
@@ -359,7 +356,7 @@ def cli(
             comes_from = f"{dist.metadata.get_all('Name')[0]} ({src_file})"
             constraints.extend(
                 [
-                    install_req_from_req_string(req, comes_from=comes_from)
+                    install_req_from_line(req, comes_from=comes_from)
                     for req in dist.requires or []
                 ]
             )


### PR DESCRIPTION
Fixes #1346.

**Changelog-friendly one-liner**: Fix a bug where `pip-compile setup.py` would fail with URL deps.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
