### PR TITLE
Declare pep517 dependency

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -6,10 +6,10 @@ from typing import Any, BinaryIO, Optional, Tuple, cast
 
 import click
 from click.utils import LazyFile, safecall
+from pep517 import meta
 from pip._internal.commands import create_command
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
-from pip._vendor.pep517 import meta
 
 from .._compat import parse_requirements
 from ..cache import DependencyCache

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ packages = find:
 zip_safe = false
 install_requires =
     click >= 7
+    pep517
     pip >= 20.3
 
 [options.packages.find]


### PR DESCRIPTION
Fixes #1352 

**Changelog-friendly one-liner**: Declare pep517 dependency

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
