### PR TITLE
Parallelize pytest runs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ exclude = tests
 testing =
     pytest
     pytest-rerunfailures
+    pytest-xdist
 coverage = pytest-cov
 
 [options.entry_points]
@@ -48,6 +49,9 @@ console_scripts =
     pip-sync = piptools.scripts.sync:cli
 
 [tool:pytest]
+addopts =
+    # `pytest-xdist`:
+    --numprocesses=auto
 norecursedirs = .* build dist venv test_data piptools/_compat/*
 testpaths = tests piptools
 filterwarnings =


### PR DESCRIPTION
$sbj. This change makes a single pytest run almost 4x faster on my machine:
|        command         |       time       |
|------------------------|------------------|
| $ tox -e py -- -n auto | 17.90s           |
| $ tox -e py -- -n 0    | 68.54s (0:01:08) |

I'm pretty sure it'll have a positive impact on the CI completion time too. UPD: in GHA it's about 2x faster in this mode.

**Changelog-friendly one-liner**: (misc/non user facing?) Enabled pytest to run tests in parallel.

##### Contributor checklist

- [x] (not exactly but...)Provided the tests for the changes.
- [x] (likely irrelevant)Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] (irrelevant)Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
