### PR TITLE
Extra requirement support (extras_require)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ repos:
       - id: black
         args: [--target-version=py36]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.7.0
+    rev: 5.8.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.11.0
     hooks:
       - id: pyupgrade
         args: [--py36-plus]

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -24,7 +24,7 @@ from ..utils import (
     dedup,
     is_pinned_requirement,
     key_from_ireq,
-    req_is_in_extras,
+    req_check_markers,
 )
 from ..writer import OutputWriter
 
@@ -398,8 +398,7 @@ def cli(
         ireq for key, ireq in upgrade_install_reqs.items() if key in allowed_upgrades
     )
 
-    # Filter out pip environment markers which do not match (PEP496)
-    constraints = [req for req in constraints if req_is_in_extras(req, extras=extras)]
+    constraints = [req for req in constraints if req_check_markers(req, extras=extras)]
 
     log.debug("Using indexes:")
     with log.indentation():

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -71,7 +71,7 @@ def _get_default_option(option_name: str) -> Any:
     "--extra",
     "extras",
     multiple=True,
-    help="names of extras_require to install",
+    help="Names of extras_require to install",
 )
 @click.option(
     "-f",

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -393,7 +393,7 @@ def cli(
                 )
             )
 
-    if not setup_file_found:
+    if extras and not setup_file_found:
         msg = "--extra has effect only with setup.py and PEP-517 input formats"
         raise click.BadParameter(msg)
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -20,7 +20,13 @@ from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..repositories.base import BaseRepository
 from ..resolver import Resolver
-from ..utils import UNSAFE_PACKAGES, dedup, is_pinned_requirement, key_from_ireq
+from ..utils import (
+    UNSAFE_PACKAGES,
+    dedup,
+    drop_extras,
+    is_pinned_requirement,
+    key_from_ireq,
+)
 from ..writer import OutputWriter
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.in"
@@ -402,6 +408,8 @@ def cli(
     )
 
     constraints = [req for req in constraints if req.match_markers(extras)]
+    for req in constraints:
+        drop_extras(req)
 
     log.debug("Using indexes:")
     with log.indentation():

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -348,6 +348,7 @@ def cli(
     ###
 
     constraints = []
+    setup_file_found = False
     for src_file in src_files:
         is_setup_file = os.path.basename(src_file) in METADATA_FILENAMES
         if src_file == "-":
@@ -371,6 +372,7 @@ def cli(
                 req.comes_from = comes_from
             constraints.extend(reqs)
         elif is_setup_file:
+            setup_file_found = True
             dist = meta.load(os.path.dirname(os.path.abspath(src_file)))
             comes_from = f"{dist.metadata.get_all('Name')[0]} ({src_file})"
             constraints.extend(
@@ -388,6 +390,10 @@ def cli(
                     options=repository.options,
                 )
             )
+
+    if not setup_file_found:
+        msg = "--extra has effect only with setup.py and PEP-517 input formats"
+        raise click.BadParameter(msg)
 
     primary_packages = {
         key_from_ireq(ireq) for ireq in constraints if not ireq.constraint

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -68,8 +68,8 @@ def _get_default_option(option_name: str) -> Any:
     help="Clear any caches upfront, rebuild from scratch",
 )
 @click.option(
-    "-e",
-    "--extras",
+    "--extra",
+    "extras",
     multiple=True,
     help="names of extras_require to install",
 )

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -230,8 +230,9 @@ def _drop_extras(markers: List[_T]) -> List[_T]:
         # sub-expression (inside braces)
         if isinstance(token, list):
             markers[i] = _drop_extras(token)  # type: ignore
-            if not markers[i]:
-                to_remove.append(i)
+            if markers[i]:
+                continue
+            to_remove.append(i)
             continue
         # test expression (like `extra == "dev"`)
         assert isinstance(token, tuple)

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    List,
     Optional,
     Set,
     Tuple,
@@ -208,6 +209,56 @@ def dedup(iterable: Iterable[_T]) -> Iterable[_T]:
     order-preserved.
     """
     return iter(dict.fromkeys(iterable))
+
+
+def drop_extras(ireq: InstallRequirement) -> None:
+    """Remove "extra" markers (PEP-508) from requirement."""
+    if ireq.markers is None:
+        return
+    ireq.markers._markers = _drop_extras(ireq.markers._markers)
+    if not ireq.markers._markers:
+        ireq.markers = None
+
+
+def _drop_extras(markers: List[_T]) -> List[_T]:
+    # drop `extra` tokens
+    to_remove: List[int] = []
+    for i, token in enumerate(markers):
+        # operator (and/or)
+        if isinstance(token, str):
+            continue
+        # sub-expression (inside braces)
+        if isinstance(token, list):
+            markers[i] = _drop_extras(token)  # type: ignore
+            if not markers[i]:
+                to_remove.append(i)
+            continue
+        # test expression (like `extra == "dev"`)
+        assert isinstance(token, tuple)
+        if token[0].value == "extra":
+            to_remove.append(i)
+    for i in reversed(to_remove):
+        markers.pop(i)
+
+    # drop duplicate bool operators (and/or)
+    to_remove = []
+    for i, (token1, token2) in enumerate(zip(markers, markers[1:])):
+        if not isinstance(token1, str):
+            continue
+        if not isinstance(token2, str):
+            continue
+        if token1 == "and":
+            to_remove.append(i)
+        else:
+            to_remove.append(i + 1)
+    for i in reversed(to_remove):
+        markers.pop(i)
+    if markers and isinstance(markers[0], str):
+        markers.pop(0)
+    if markers and isinstance(markers[-1], str):
+        markers.pop(-1)
+
+    return markers
 
 
 def get_hashes_from_ireq(ireq: InstallRequirement) -> Set[str]:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -163,6 +163,18 @@ def is_pinned_requirement(ireq: InstallRequirement) -> bool:
     return spec.operator in {"==", "==="} and not spec.version.endswith(".*")
 
 
+def req_is_in_extras(ireq: InstallRequirement, extras: Tuple[str, ...]) -> bool:
+    """
+    Check if the requirement isn't extra or is included into extras to install.
+    """
+    if not ireq.markers or ireq.markers.evaluate({"extra": None}):
+        return True
+    for extra in extras:
+        if ireq.markers.evaluate({"extra": extra}):
+            return True
+    return False
+
+
 def as_tuple(ireq: InstallRequirement) -> Tuple[str, str, Tuple[str, ...]]:
     """
     Pulls out the (name: str, version:str, extras:(str)) tuple from

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -163,9 +163,10 @@ def is_pinned_requirement(ireq: InstallRequirement) -> bool:
     return spec.operator in {"==", "==="} and not spec.version.endswith(".*")
 
 
-def req_is_in_extras(ireq: InstallRequirement, extras: Tuple[str, ...]) -> bool:
+def req_check_markers(ireq: InstallRequirement, extras: Tuple[str, ...]) -> bool:
     """
-    Check if the requirement isn't extra or is included into extras to install.
+    1. Check if the environment markers match (PEP-496).
+    2. Check if the requirement isn't extra or is included into extras to install.
     """
     if not ireq.markers or ireq.markers.evaluate({"extra": None}):
         return True

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -163,19 +163,6 @@ def is_pinned_requirement(ireq: InstallRequirement) -> bool:
     return spec.operator in {"==", "==="} and not spec.version.endswith(".*")
 
 
-def req_check_markers(ireq: InstallRequirement, extras: Tuple[str, ...]) -> bool:
-    """
-    1. Check if the environment markers match (PEP-496).
-    2. Check if the requirement isn't extra or is included into extras to install.
-    """
-    if not ireq.markers or ireq.markers.evaluate({"extra": None}):
-        return True
-    for extra in extras:
-        if ireq.markers.evaluate({"extra": extra}):
-            return True
-    return False
-
-
 def as_tuple(ireq: InstallRequirement) -> Tuple[str, str, Tuple[str, ...]]:
     """
     Pulls out the (name: str, version:str, extras:(str)) tuple from

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,6 +346,9 @@ def make_module(tmpdir):
 
 @pytest.fixture
 def fake_dists(tmpdir, make_package, make_wheel):
+    """
+    Generate distribution packages `small-fake-{a..f}`
+    """
     dists_path = os.path.join(tmpdir, "dists")
     pkgs = [
         make_package("small-fake-a", version="0.1"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -325,10 +325,36 @@ def make_sdist(run_setup_file):
 
 
 @pytest.fixture
+def make_module(tmpdir):
+    """
+    Make a metadata file with the given name and content and a fake module.
+    """
+
+    def _make_module(fname, content):
+        path = os.path.join(tmpdir, "sample_lib")
+        os.mkdir(path)
+        path = os.path.join(tmpdir, "sample_lib", "__init__.py")
+        with open(path, "w") as stream:
+            stream.write("'example module'\n__version__ = '1.2.3'")
+        path = os.path.join(tmpdir, fname)
+        with open(path, "w") as stream:
+            stream.write(dedent(content))
+        return path
+
+    return _make_module
+
+
+@pytest.fixture
 def fake_dists(tmpdir, make_package, make_wheel):
     dists_path = os.path.join(tmpdir, "dists")
-    pkg = make_package("small-fake-a", version="0.1")
-    make_wheel(pkg, dists_path)
-    pkg = make_package("small-fake-b", version="0.2")
-    make_wheel(pkg, dists_path)
+    pkgs = [
+        make_package("small-fake-a", version="0.1"),
+        make_package("small-fake-b", version="0.2"),
+        make_package("small-fake-c", version="0.3"),
+        make_package("small-fake-d", version="0.4"),
+        make_package("small-fake-e", version="0.5"),
+        make_package("small-fake-f", version="0.6"),
+    ]
+    for pkg in pkgs:
+        make_wheel(pkg, dists_path)
     return dists_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,3 +322,13 @@ def make_sdist(run_setup_file):
         return run_setup_file(package_dir, "sdist", "--dist-dir", str(dist_dir), *args)
 
     return _make_sdist
+
+
+@pytest.fixture
+def fake_dists(tmpdir, make_package, make_wheel):
+    dists_path = os.path.join(tmpdir, "dists")
+    pkg = make_package("small-fake-a", version="0.1")
+    make_wheel(pkg, dists_path)
+    pkg = make_package("small-fake-b", version="0.2")
+    make_wheel(pkg, dists_path)
+    return dists_path

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1658,109 +1658,103 @@ def test_triple_equal_pinned_dependency_is_used(
         assert line in out.stderr
 
 
-@pytest.mark.network
-@pytest.mark.parametrize(
-    ("fname", "content"),
-    (
-        pytest.param(
-            "setup.cfg",
-            """
-                [metadata]
-                name = sample_lib
-                author = Vincent Driessen
-                author_email = me@nvie.com
+METADATA_TEST_CASES = (
+    pytest.param(
+        "setup.cfg",
+        """
+            [metadata]
+            name = sample_lib
+            author = Vincent Driessen
+            author_email = me@nvie.com
 
-                [options]
-                packages = find:
-                install_requires =
-                    small-fake-a==0.1
-                    small-fake-b==0.2
+            [options]
+            packages = find:
+            install_requires =
+                small-fake-a==0.1
+                small-fake-b==0.2
 
-                [options.extras_require]
-                dev =
-                    small-fake-c==0.3
-                    small-fake-d==0.4
-                test =
-                    small-fake-e==0.5
-                    small-fake-f==0.6
-            """,
-            id="setup.cfg",
-        ),
-        pytest.param(
-            "setup.py",
-            """
-                from setuptools import setup
+            [options.extras_require]
+            dev =
+                small-fake-c==0.3
+                small-fake-d==0.4
+            test =
+                small-fake-e==0.5
+                small-fake-f==0.6
+        """,
+        id="setup.cfg",
+    ),
+    pytest.param(
+        "setup.py",
+        """
+            from setuptools import setup
 
-                setup(
-                    name="sample_lib",
-                    version=0.1,
-                    install_requires=["small-fake-a==0.1", "small-fake-b==0.2"],
-                    extras_require={
-                        "dev": ["small-fake-c==0.3", "small-fake-d==0.4"],
-                        "test": ["small-fake-e==0.5", "small-fake-f==0.6"],
-                    },
-                )
-            """,
-            id="setup.py",
-        ),
-        pytest.param(
-            "pyproject.toml",
-            """
-                [build-system]
-                requires = ["flit_core >=2,<4"]
-                build-backend = "flit_core.buildapi"
+            setup(
+                name="sample_lib",
+                version=0.1,
+                install_requires=["small-fake-a==0.1", "small-fake-b==0.2"],
+                extras_require={
+                    "dev": ["small-fake-c==0.3", "small-fake-d==0.4"],
+                    "test": ["small-fake-e==0.5", "small-fake-f==0.6"],
+                },
+            )
+        """,
+        id="setup.py",
+    ),
+    pytest.param(
+        "pyproject.toml",
+        """
+            [build-system]
+            requires = ["flit_core >=2,<4"]
+            build-backend = "flit_core.buildapi"
 
-                [tool.flit.metadata]
-                module = "sample_lib"
-                author = "Vincent Driessen"
-                author-email = "me@nvie.com"
+            [tool.flit.metadata]
+            module = "sample_lib"
+            author = "Vincent Driessen"
+            author-email = "me@nvie.com"
 
-                requires = ["small-fake-a==0.1", "small-fake-b==0.2"]
+            requires = ["small-fake-a==0.1", "small-fake-b==0.2"]
 
-                [tool.flit.metadata.requires-extra]
-                dev  = ["small-fake-c==0.3", "small-fake-d==0.4"]
-                test = ["small-fake-e==0.5", "small-fake-f==0.6"]
-            """,
-            id="flit",
-        ),
-        pytest.param(
-            "pyproject.toml",
-            """
-                [build-system]
-                requires = ["poetry_core>=1.0.0"]
-                build-backend = "poetry.core.masonry.api"
+            [tool.flit.metadata.requires-extra]
+            dev  = ["small-fake-c==0.3", "small-fake-d==0.4"]
+            test = ["small-fake-e==0.5", "small-fake-f==0.6"]
+        """,
+        id="flit",
+    ),
+    pytest.param(
+        "pyproject.toml",
+        """
+            [build-system]
+            requires = ["poetry_core>=1.0.0"]
+            build-backend = "poetry.core.masonry.api"
 
-                [tool.poetry]
-                name = "sample_lib"
-                version = "0.1.0"
-                description = ""
-                authors = ["Vincent Driessen <me@nvie.com>"]
+            [tool.poetry]
+            name = "sample_lib"
+            version = "0.1.0"
+            description = ""
+            authors = ["Vincent Driessen <me@nvie.com>"]
 
-                [tool.poetry.dependencies]
-                python = "*"
-                small-fake-a = "0.1"
-                small-fake-b = "0.2"
+            [tool.poetry.dependencies]
+            python = "*"
+            small-fake-a = "0.1"
+            small-fake-b = "0.2"
 
-                small-fake-c = "0.3"
-                small-fake-d = "0.4"
-                small-fake-e = "0.5"
-                small-fake-f = "0.6"
+            small-fake-c = "0.3"
+            small-fake-d = "0.4"
+            small-fake-e = "0.5"
+            small-fake-f = "0.6"
 
-                [tool.poetry.extras]
-                dev  = ["small-fake-c", "small-fake-d"]
-                test = ["small-fake-e", "small-fake-f"]
-            """,
-            id="poetry",
-        ),
+            [tool.poetry.extras]
+            dev  = ["small-fake-c", "small-fake-d"]
+            test = ["small-fake-e", "small-fake-f"]
+        """,
+        id="poetry",
     ),
 )
-def test_input_formats(make_package, make_wheel, runner, tmpdir, fname, content):
-    dists_path = os.path.join(tmpdir, "dists")
-    pkg = make_package("small-fake-a", version="0.1")
-    make_wheel(pkg, dists_path)
-    pkg = make_package("small-fake-b", version="0.2")
-    make_wheel(pkg, dists_path)
 
+
+@pytest.mark.network
+@pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
+def test_input_formats(fake_dists, runner, tmpdir, fname, content):
     path = os.path.join(tmpdir, "sample_lib")
     os.mkdir(path)
     path = os.path.join(tmpdir, "sample_lib", "__init__.py")
@@ -1770,7 +1764,7 @@ def test_input_formats(make_package, make_wheel, runner, tmpdir, fname, content)
     with open(path, "w") as stream:
         stream.write(dedent(content))
 
-    out = runner.invoke(cli, ["-n", "--find-links", dists_path, path])
+    out = runner.invoke(cli, ["-n", "--find-links", fake_dists, path])
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr
     assert "small-fake-b==0.2" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1770,7 +1770,7 @@ def test_input_formats(fake_dists, runner, make_module, fname, content):
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_one_extra(fake_dists, runner, make_module, fname, content):
     meta_path = make_module(fname=fname, content=content)
-    out = runner.invoke(cli, ["-n", "-e", "dev", "--find-links", fake_dists, meta_path])
+    out = runner.invoke(cli, ["-n", "--extra", "dev", "--find-links", fake_dists, meta_path])
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr
     assert "small-fake-b==0.2" in out.stderr
@@ -1785,7 +1785,7 @@ def test_one_extra(fake_dists, runner, make_module, fname, content):
 def test_multiple_extras(fake_dists, runner, make_module, fname, content):
     meta_path = make_module(fname=fname, content=content)
     out = runner.invoke(
-        cli, ["-n", "-e", "dev", "-e", "test", "--find-links", fake_dists, meta_path]
+        cli, ["-n", "--extra", "dev", "--extra", "test", "--find-links", fake_dists, meta_path]
     )
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1754,21 +1754,41 @@ METADATA_TEST_CASES = (
 
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
-def test_input_formats(fake_dists, runner, tmpdir, fname, content):
-    path = os.path.join(tmpdir, "sample_lib")
-    os.mkdir(path)
-    path = os.path.join(tmpdir, "sample_lib", "__init__.py")
-    with open(path, "w") as stream:
-        stream.write("'example module'\n__version__ = '1.2.3'")
-    path = os.path.join(tmpdir, fname)
-    with open(path, "w") as stream:
-        stream.write(dedent(content))
-
-    out = runner.invoke(cli, ["-n", "--find-links", fake_dists, path])
+def test_input_formats(fake_dists, runner, make_module, fname, content):
+    meta_path = make_module(fname=fname, content=content)
+    out = runner.invoke(cli, ["-n", "--find-links", fake_dists, meta_path])
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr
     assert "small-fake-b==0.2" in out.stderr
     assert "small-fake-c" not in out.stderr
     assert "small-fake-d" not in out.stderr
+    assert "small-fake-e" not in out.stderr
+    assert "small-fake-f" not in out.stderr
+
+
+@pytest.mark.network
+@pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
+def test_one_extra(fake_dists, runner, make_module, fname, content):
+    meta_path = make_module(fname=fname, content=content)
+    out = runner.invoke(cli, ["-n", "-e", "dev", "--find-links", fake_dists, meta_path])
+    assert out.exit_code == 0, out.stderr
+    assert "small-fake-a==0.1" in out.stderr
+    assert "small-fake-b==0.2" in out.stderr
+    assert "small-fake-c==0.3" in out.stderr
+    assert "small-fake-d==0.4" in out.stderr
+    assert "small-fake-e" not in out.stderr
+    assert "small-fake-f" not in out.stderr
+
+
+@pytest.mark.network
+@pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
+def test_multiple_extras(fake_dists, runner, make_module, fname, content):
+    meta_path = make_module(fname=fname, content=content)
+    out = runner.invoke(cli, ["-n", "-e", "dev", "--find-links", fake_dists, meta_path])
+    assert out.exit_code == 0, out.stderr
+    assert "small-fake-a==0.1" in out.stderr
+    assert "small-fake-b==0.2" in out.stderr
+    assert "small-fake-c==0.3" in out.stderr
+    assert "small-fake-d==0.4" in out.stderr
     assert "small-fake-e" not in out.stderr
     assert "small-fake-f" not in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1755,6 +1755,9 @@ METADATA_TEST_CASES = (
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_input_formats(fake_dists, runner, make_module, fname, content):
+    """
+    Test different dependency formats as input file.
+    """
     meta_path = make_module(fname=fname, content=content)
     out = runner.invoke(cli, ["-n", "--find-links", fake_dists, meta_path])
     assert out.exit_code == 0, out.stderr
@@ -1769,6 +1772,9 @@ def test_input_formats(fake_dists, runner, make_module, fname, content):
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_one_extra(fake_dists, runner, make_module, fname, content):
+    """
+    Test one `--extra` (dev) passed, other extras (test) must be ignored.
+    """
     meta_path = make_module(fname=fname, content=content)
     out = runner.invoke(
         cli, ["-n", "--extra", "dev", "--find-links", fake_dists, meta_path]
@@ -1785,6 +1791,9 @@ def test_one_extra(fake_dists, runner, make_module, fname, content):
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_multiple_extras(fake_dists, runner, make_module, fname, content):
+    """
+    Test passing multiple `--extra` params.
+    """
     meta_path = make_module(fname=fname, content=content)
     out = runner.invoke(
         cli,
@@ -1809,6 +1818,9 @@ def test_multiple_extras(fake_dists, runner, make_module, fname, content):
 
 
 def test_extras_fail_with_requirements_in(runner, tmpdir):
+    """
+    Test that passing `--extra` with `requirements.in` input file fails.
+    """
     path = os.path.join(tmpdir, "requirements.in")
     with open(path, "w") as stream:
         stream.write("\n")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1767,6 +1767,7 @@ def test_input_formats(fake_dists, runner, make_module, fname, content):
     assert "small-fake-d" not in out.stderr
     assert "small-fake-e" not in out.stderr
     assert "small-fake-f" not in out.stderr
+    assert "extra ==" not in out.stderr
 
 
 @pytest.mark.network
@@ -1786,6 +1787,7 @@ def test_one_extra(fake_dists, runner, make_module, fname, content):
     assert "small-fake-d==0.4" in out.stderr
     assert "small-fake-e" not in out.stderr
     assert "small-fake-f" not in out.stderr
+    assert "extra ==" not in out.stderr
 
 
 @pytest.mark.network
@@ -1815,6 +1817,7 @@ def test_multiple_extras(fake_dists, runner, make_module, fname, content):
     assert "small-fake-d==0.4" in out.stderr
     assert "small-fake-e==0.5" in out.stderr
     assert "small-fake-f==0.6" in out.stderr
+    assert "extra ==" not in out.stderr
 
 
 def test_extras_fail_with_requirements_in(runner, tmpdir):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1784,11 +1784,13 @@ def test_one_extra(fake_dists, runner, make_module, fname, content):
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_multiple_extras(fake_dists, runner, make_module, fname, content):
     meta_path = make_module(fname=fname, content=content)
-    out = runner.invoke(cli, ["-n", "-e", "dev", "--find-links", fake_dists, meta_path])
+    out = runner.invoke(
+        cli, ["-n", "-e", "dev", "-e", "test", "--find-links", fake_dists, meta_path]
+    )
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr
     assert "small-fake-b==0.2" in out.stderr
     assert "small-fake-c==0.3" in out.stderr
     assert "small-fake-d==0.4" in out.stderr
-    assert "small-fake-e" not in out.stderr
-    assert "small-fake-f" not in out.stderr
+    assert "small-fake-e==0.5" in out.stderr
+    assert "small-fake-f==0.6" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1770,7 +1770,9 @@ def test_input_formats(fake_dists, runner, make_module, fname, content):
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_one_extra(fake_dists, runner, make_module, fname, content):
     meta_path = make_module(fname=fname, content=content)
-    out = runner.invoke(cli, ["-n", "--extra", "dev", "--find-links", fake_dists, meta_path])
+    out = runner.invoke(
+        cli, ["-n", "--extra", "dev", "--find-links", fake_dists, meta_path]
+    )
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr
     assert "small-fake-b==0.2" in out.stderr
@@ -1785,7 +1787,17 @@ def test_one_extra(fake_dists, runner, make_module, fname, content):
 def test_multiple_extras(fake_dists, runner, make_module, fname, content):
     meta_path = make_module(fname=fname, content=content)
     out = runner.invoke(
-        cli, ["-n", "--extra", "dev", "--extra", "test", "--find-links", fake_dists, meta_path]
+        cli,
+        [
+            "-n",
+            "--extra",
+            "dev",
+            "--extra",
+            "test",
+            "--find-links",
+            fake_dists,
+            meta_path,
+        ],
     )
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1806,3 +1806,13 @@ def test_multiple_extras(fake_dists, runner, make_module, fname, content):
     assert "small-fake-d==0.4" in out.stderr
     assert "small-fake-e==0.5" in out.stderr
     assert "small-fake-f==0.6" in out.stderr
+
+
+def test_extras_fail_with_requirements_in(runner, tmpdir):
+    path = os.path.join(tmpdir, "requirements.in")
+    with open(path, "w") as stream:
+        stream.write("\n")
+    out = runner.invoke(cli, ["-n", "--extra", "something", path])
+    assert out.exit_code == 2
+    exp = "--extra has effect only with setup.py and PEP-517 input formats"
+    assert exp in out.stderr

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -398,6 +398,10 @@ def test_lookup_table_with_empty_values():
             "os_name == 'unix' and os_name == 'nt'",
         ),
         (
+            "(os_name == 'unix' or os_name == 'nt') and extra == 'dev'",
+            "os_name == 'unix' or os_name == 'nt'",
+        ),
+        (
             "(os_name == 'unix' and extra == 'test' or python_version < '3.5')"
             " or os_name == 'nt'",
             "(os_name == 'unix' or python_version < '3.5') or os_name == 'nt'",


### PR DESCRIPTION
<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: Add `--extra` to specify `extras_require` dependencies.

Supports setup.py and anything PEP-517 compatible. Tested for setup.py, setup.cfg, poetry, and flit.

Close #625.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
