### PR TITLE
Fix year in release dates of 6.* versions to 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 6.0.1 (2020-03-15)
+# 6.0.1 (2021-03-15)
 
 Bug Fixes:
 
@@ -10,7 +10,7 @@ Dependencies:
 - Add `pep517` dependency
   ([#1353](https://github.com/jazzband/pip-tools/pull/1353)). Thanks @atugushev
 
-# 6.0.0 (2020-03-12)
+# 6.0.0 (2021-03-12)
 
 Backwards Incompatible Changes:
 


### PR DESCRIPTION
Releases of versions 6.* were timestamped with incorrect dates in year 2020.

**Changelog-friendly one-liner**: Fix year in release dates of 6.* versions in CHANGELOG.md to 2021.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
