### PR TITLE
Restore ability to set compile cache with env var PIP_TOOLS_CACHE_DIR

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -185,7 +185,9 @@ def _get_default_option(option_name: str) -> Any:
     "--cache-dir",
     help="Store the cache data in DIRECTORY.",
     default=CACHE_DIR,
+    envvar="PIP_TOOLS_CACHE_DIR",
     show_default=True,
+    show_envvar=True,
     type=click.Path(file_okay=False, writable=True),
 )
 @click.option(


### PR DESCRIPTION
Fixes bug introduced in #1238 and exposed by #1357

#1238's intent was to remove unnecessary environment variable handling that pip was taking care of. This pip-tools environment variable was an accidental casualty. This became apparent when parallel tests proved unstable, due to a shared cache path, while we already have an autouse fixture to isolate them (using `PIP_TOOLS_CACHE_DIR` env var).

**Changelog-friendly one-liner**: Restore ability to set compile cache with env var `PIP_TOOLS_CACHE_DIR`

##### Contributor checklist

- [ ] Provided the tests for the changes. -- I expect existing tests become stable again
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
