### PR TITLE
Test pip against the `main` default branch

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -6,7 +6,7 @@ on:
     - cron: 0 0 * * *
 
 jobs:
-  master:
+  main:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -22,7 +22,7 @@ jobs:
           - 3.7
           - 3.8
         pip-version:
-          - master
+          - main
     env:
       PY_COLORS: 1
       TOXENV: pip${{ matrix.pip-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
-    py{36,37,38,39,py3}-pip{20.3,previous,latest,master}-coverage
+    py{36,37,38,39,py3}-pip{20.3,previous,latest,main}-coverage
     checkqa
     readme
 skip_missing_interpreters = True
@@ -13,7 +13,7 @@ extras =
 deps =
     pipprevious: pip==20.3.*
     piplatest: pip
-    pipmaster: -e git+https://github.com/pypa/pip.git@master#egg=pip
+    pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
     pip20.3: pip==20.3.*
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}


### PR DESCRIPTION
Fixes [failing](https://github.com/jazzband/pip-tools/runs/2250498330?check_suite_focus=true) cron jobs due to `pip` renamed the default branch to `main`. See https://github.com/pypa/pip/issues/8948.

