### PR TITLE
Add PyPy jobs to PR CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,35 @@ jobs:
         with:
           file: ./coverage.xml
           name: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pip-version }}
+
+  pypy:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - Ubuntu
+          - MacOS
+          # TODO: fix test_realistic_complex_sub_dependencies test on Windows
+          # - Windows
+        python-version:
+          - pypy3
+        pip-version:
+          - latest
+    env:
+      PY_COLORS: 1
+      TOXENV: pip${{ matrix.pip-version }}
+      TOX_PARALLEL_NO_SPINNER: 1
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: pip install tox
+      - name: Prepare test environment
+        run: tox --notest -p auto --parallel-live
+      - name: Test pip ${{ matrix.pip-version }}
+        run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           # TODO: fix test_realistic_complex_sub_dependencies test on Windows
           # - Windows
         python-version:
-          - pypy3.7
+          - pypy-3.7
         pip-version:
           - latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           # TODO: fix test_realistic_complex_sub_dependencies test on Windows
           # - Windows
         python-version:
-          - pypy3
+          - pypy3.7
         pip-version:
           - latest
     env:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -11,8 +11,8 @@ from piptools.scripts.compile import cli
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 
+is_pypy = "__pypy__" in sys.builtin_module_names
 
-is_pypy = '__pypy__' in sys.builtin_module_names
 
 @pytest.fixture(autouse=True)
 def _temp_dep_cache(tmpdir, monkeypatch):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -12,6 +12,8 @@ from piptools.scripts.compile import cli
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 
 
+is_pypy = '__pypy__' in sys.builtin_module_names
+
 @pytest.fixture(autouse=True)
 def _temp_dep_cache(tmpdir, monkeypatch):
     monkeypatch.setenv("PIP_TOOLS_CACHE_DIR", str(tmpdir / "cache"))
@@ -1760,6 +1762,7 @@ METADATA_TEST_CASES = (
 
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
+@pytest.mark.xfail(is_pypy, reason="https://github.com/jazzband/pip-tools/issues/1375")
 def test_input_formats(fake_dists, runner, make_module, fname, content):
     """
     Test different dependency formats as input file.
@@ -1778,6 +1781,7 @@ def test_input_formats(fake_dists, runner, make_module, fname, content):
 
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
+@pytest.mark.xfail(is_pypy, reason="https://github.com/jazzband/pip-tools/issues/1375")
 def test_one_extra(fake_dists, runner, make_module, fname, content):
     """
     Test one `--extra` (dev) passed, other extras (test) must be ignored.
@@ -1798,6 +1802,7 @@ def test_one_extra(fake_dists, runner, make_module, fname, content):
 
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
+@pytest.mark.xfail(is_pypy, reason="https://github.com/jazzband/pip-tools/issues/1375")
 def test_multiple_extras(fake_dists, runner, make_module, fname, content):
     """
     Test passing multiple `--extra` params.


### PR DESCRIPTION
Ref https://github.com/jazzband/pip-tools/issues/1375#issuecomment-813212856

**Changelog-friendly one-liner**: Added PyPy jobs to PR builds

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
