### PR TITLE
Add support for target Python pip-args to PyPIRepository

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -10,6 +10,7 @@ from typing import Any, ContextManager, Dict, Iterator, List, Optional, Set, cas
 
 from click import progressbar
 from pip._internal.cache import WheelCache
+from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.progress_bars import BAR_TYPES
 from pip._internal.commands import create_command
 from pip._internal.commands.install import InstallCommand
@@ -17,6 +18,7 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.index import PackageIndex
 from pip._internal.models.link import Link
+from pip._internal.models.target_python import TargetPython
 from pip._internal.models.wheel import Wheel
 from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement, RequirementSet
@@ -71,8 +73,11 @@ class PyPIRepository(BaseRepository):
 
         self._options: optparse.Values = options
         self._session = self.command._build_session(options)
+        self._target_python = make_target_python(options)
         self._finder = self.command._build_package_finder(
-            options=options, session=self.session
+            options=options,
+            session=self.session,
+            target_python=self._target_python,
         )
 
         # Caches
@@ -102,6 +107,10 @@ class PyPIRepository(BaseRepository):
     @property
     def session(self) -> PipSession:
         return self._session
+
+    @property
+    def target_python(self) -> TargetPython:
+        return self._target_python
 
     @property
     def finder(self) -> PackageFinder:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -185,7 +185,9 @@ def _get_default_option(option_name: str) -> Any:
     "--cache-dir",
     help="Store the cache data in DIRECTORY.",
     default=CACHE_DIR,
+    envvar="PIP_TOOLS_CACHE_DIR",
     show_default=True,
+    show_envvar=True,
     type=click.Path(file_okay=False, writable=True),
 )
 @click.option(

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -384,21 +384,33 @@ def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tm
     assert deps.pop().name == "test-package-1"
 
 
-@pytest.mark.parametrize('pip_args, expected', [
-    ([], ''),
-    (["--python-version", "36"], "version_info='3.6'"),
+@pytest.mark.parametrize(
+    ("pip_args", "expected"),
     (
-        ["--python-version", "36", "--platform", "darwin"],
-        "platforms=['darwin'] version_info='3.6'",
-    ),
-    (
-        ["--python-version", "36", "--platform", "darwin", "--abi", "cp36m", "--implementation", "cp"],
+        ([], ""),
+        (["--python-version", "36"], "version_info='3.6'"),
         (
-            "platforms=['darwin'] version_info='3.6' abis=['cp36m'] "
-            "implementation='cp'"
+            ["--python-version", "36", "--platform", "darwin"],
+            "platforms=['darwin'] version_info='3.6'",
+        ),
+        (
+            [
+                "--python-version",
+                "36",
+                "--platform",
+                "darwin",
+                "--abi",
+                "cp36m",
+                "--implementation",
+                "cp",
+            ],
+            (
+                "platforms=['darwin'] version_info='3.6' abis=['cp36m'] "
+                "implementation='cp'"
+            ),
         ),
     ),
-])
+)
 def test_target_python_specification(pip_args, expected):
     """
     Test to verify that target python args passed via pip-args correctly specify the target_python
@@ -418,6 +430,3 @@ def test_target_python_default_current_version():
 
     assert pypi_repository.target_python._given_py_version_info is None
     assert pypi_repository.target_python.py_version_info == current_python_version
-
-
-    


### PR DESCRIPTION
Resolves #1382.

This change adds support for using the target python arguments in pip (platform, version, implementation, and abi), by utilizing the TargetPython class from Pip. This should enable targeting environments different than the current python environment by pip tools commands. 

ex: pip compile --pip-args "--platform manylinux2014_x86_64"

Thank you!


Adds support for target python pip-args (version, platform, implementation, and abi) to PyPIRepository

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
