### PR TITLE
Add correct space after venv label

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Similar to ``pip``, ``pip-tools`` must be installed in each of your project's
 .. code-block:: bash
 
     $ source /path/to/venv/bin/activate
-    (venv)$ python -m pip install pip-tools
+    (venv) $ python -m pip install pip-tools
 
 **Note**: all of the remaining example commands assume you've activated your
 project's virtual environment.


### PR DESCRIPTION
<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

Add correct space after venv label in README

##### Detailed Description

This formatting is what users will typically see after activating a `venv`.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
