### PR TITLE
Adding documentation about pre-commit hooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -358,6 +358,26 @@ You might want to customize ``pip-compile`` args by configuring ``args`` and/or 
             files: ^requirements/production\.(in|txt)$
             args: [--index-url=https://example.com, requirements/production.in]
 
+If you have multiple requirement files make sure you create a hook for each file. 
+
+.. code-bloack:: yaml 
+
+    repos:
+    -   repo: https://github.com/jazzband/pip-tools
+        rev: 5.3.1
+        hooks:
+          - id: pip-compile
+            name: pip-compile setup.py
+            files: ^setup\.py$
+          - id: pip-compile
+            name: pip-compile requirements-dev.in
+            args: [requirements-dev.in]
+            files: ^requirements-dev\.(in|txt)$
+          - id: pip-compile
+            name: pip-compile requirements-lint.in
+            args: [requirements-lint.in]
+            files: ^requirements-lint\.(in|txt)$
+
 
 Example usage for ``pip-sync``
 ==============================


### PR DESCRIPTION
<!--- Describe the changes here. --->

This commit adds documentation about using pre-commit when a user has multiple requiments. A user need to have multiple hooks for each requirements file and this commit makes that informationn explicit in the documentation.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
