### PR TITLE
Refactor producing cache keys in GHA jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,30 +52,55 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Log python version info (${{ matrix.python-version }})
         run: python --version --version
-      - name: Pip cache
+
+      - name: Calculate cache metadata
+        id: cache-meta
+        shell: python
+        run: |
+          import hashlib
+          import subprocess
+          import sys
+
+          cache_dir_cmd = sys.executable, '-m', 'pip', 'cache', 'dir'
+          cache_dir = subprocess.check_output(
+              cache_dir_cmd,
+              universal_newlines=True,
+          ).strip()
+
+          version_hash = hashlib.sha512(sys.version.encode()).hexdigest()
+
+          print(
+              '::set-output name=pip-cache-dir:{cache_dir!s}'.
+              format(cache_dir=cache_dir)
+          )
+          print(
+              '::set-output name=python-version-hash:{version_hash!s}'.
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=cache-key-pip-prefix:"
+              "${{ runner.os }}-py{version_hash!s}-pip-".
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=pip-pip-cache-key-files:"
+              "${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-"
+              "${{ hashFiles('tox.ini') }}-"
+              "${{ hashFiles('.pre-commit-config.yaml') }}".
+              format(version_hash=version_hash)
+          )
+      - name: pip cache
         uses: actions/cache@v2
         with:
-          path: >-
-            ${{
-              runner.os == 'Linux' &&
-              '~/.cache/pip'
-              || ''
-            }}${{
-              runner.os == 'macOS' &&
-              '~/Library/Caches/pip'
-              || ''
-            }}${{
-              runner.os == 'Windows' &&
-              '~\AppData\Local\pip\Cache'
-              || ''
-            }}
+          path: ${{ steps.cache-meta.outputs.pip-cache-dir }}
           key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+            ${{
+                steps.cache-meta.outputs.cache-key-pip-prefix
+            }}${{
+                steps.cache-meta.outputs.cache-key-files
+            }}
+          restore-keys: ${{ steps.cache-meta.outputs.cache-key-prefix }}
+
       - name: Install test dependencies
         run: python -m pip install -U tox virtualenv
       - name: Prepare test environment

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,30 +33,55 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pip cache
+
+      - name: Calculate cache metadata
+        id: cache-meta
+        shell: python
+        run: |
+          import hashlib
+          import subprocess
+          import sys
+
+          cache_dir_cmd = sys.executable, '-m', 'pip', 'cache', 'dir'
+          cache_dir = subprocess.check_output(
+              cache_dir_cmd,
+              universal_newlines=True,
+          ).strip()
+
+          version_hash = hashlib.sha512(sys.version.encode()).hexdigest()
+
+          print(
+              '::set-output name=pip-cache-dir:{cache_dir!s}'.
+              format(cache_dir=cache_dir)
+          )
+          print(
+              '::set-output name=python-version-hash:{version_hash!s}'.
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=cache-key-pip-prefix:"
+              "${{ runner.os }}-py{version_hash!s}-pip-".
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=pip-cache-key-files:"
+              "${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-"
+              "${{ hashFiles('tox.ini') }}-"
+              "${{ hashFiles('.pre-commit-config.yaml') }}".
+              format(version_hash=version_hash)
+          )
+      - name: pip cache
         uses: actions/cache@v2
         with:
-          path: >-
-            ${{
-              runner.os == 'Linux' &&
-              '~/.cache/pip'
-              || ''
-            }}${{
-              runner.os == 'macOS' &&
-              '~/Library/Caches/pip'
-              || ''
-            }}${{
-              runner.os == 'Windows' &&
-              '~\AppData\Local\pip\Cache'
-              || ''
-            }}
+          path: ${{ steps.cache-meta.outputs.pip-cache-dir }}
           key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+            ${{
+                steps.cache-meta.outputs.cache-key-pip-prefix
+            }}${{
+                steps.cache-meta.outputs.pip-cache-key-files
+            }}
+          restore-keys: ${{ steps.cache-meta.outputs.cache-key-prefix }}
+
       - name: Install test dependencies
         run: python -m pip install -U tox virtualenv
       - name: Prepare test environment

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -28,37 +28,77 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pip cache
+
+      - name: Calculate cache metadata
+        id: cache-meta
+        shell: python
+        run: |
+          import hashlib
+          import subprocess
+          import sys
+
+          cache_dir_cmd = sys.executable, '-m', 'pip', 'cache', 'dir'
+          cache_dir = subprocess.check_output(
+              cache_dir_cmd,
+              universal_newlines=True,
+          ).strip()
+
+          version_hash = hashlib.sha512(sys.version.encode()).hexdigest()
+
+          print(
+              '::set-output name=pip-cache-dir:{cache_dir!s}'.
+              format(cache_dir=cache_dir)
+          )
+          print('::set-output name=pre-commit-cache-dir:~/.cache/pre-commit')
+          print(
+              '::set-output name=python-version-hash:{version_hash!s}'.
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=cache-key-pip-prefix:"
+              "${{ runner.os }}-py{version_hash!s}-pip-".
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=cache-key-pre-commit-prefix:"
+              "${{ runner.os }}-py{version_hash!s}-pre-commit-".
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=pip-cache-key-files:"
+              "${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-"
+              "${{ hashFiles('tox.ini') }}-"
+              "${{ hashFiles('.pre-commit-config.yaml') }}".
+              format(version_hash=version_hash)
+          )
+          print(
+              "::set-output name=pre-commit-cache-key-files:"
+              "${{ hashFiles('.pre-commit-config.yaml') }}".
+              format(version_hash=version_hash)
+          )
+      - name: pip cache
         uses: actions/cache@v2
         with:
-          path: >-
-            ${{
-              runner.os == 'Linux' &&
-              '~/.cache/pip'
-              || ''
-            }}${{
-              runner.os == 'macOS' &&
-              '~/Library/Caches/pip'
-              || ''
-            }}${{
-              runner.os == 'Windows' &&
-              '~\AppData\Local\pip\Cache'
-              || ''
-            }}
+          path: ${{ steps.cache-meta.outputs.pip-cache-dir }}
           key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-      - name: Prepare cache key
-        id: cache-key
-        run: echo "::set-output name=sha-256::$(python -VV | sha256sum | cut -d' ' -f1)"
-      - uses: actions/cache@v1
+            ${{
+                steps.cache-meta.outputs.cache-key-pip-prefix
+            }}${{
+                steps.cache-meta.outputs.pip-cache-key-files
+            }}
+          restore-keys: ${{ steps.cache-meta.outputs.cache-key-prefix }}
+      - name: pre-commit cache
+        uses: actions/cache@v1
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ steps.cache-key.outputs.sha-256 }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ${{ steps.cache-meta.outputs.pre-commit-cache-dir }}
+          key: >-
+            ${{
+                steps.cache-meta.outputs.cache-key-pre-commit-prefix
+            }}${{
+                steps.cache-meta.outputs.pre-commit-cache-key-files
+            }}
+          restore-keys: ${{ steps.cache-meta.outputs.cache-key-pre-commit-prefix }}
+
       - name: Install tox
         run: pip install tox
       - name: Prepare test environment


### PR DESCRIPTION
This change makes the GHA cache dirs and keys calculated dynamically per recommendation @ https://github.com/jazzband/pip-tools/pull/1378#issuecomment-824278917.

**Changelog-friendly one-liner**: $sbj (not user-facing)

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
