### PR TITLE
Improve instructions for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,10 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 
 Here are a few additional or emphasized guidelines to follow when contributing to `pip-tools`:
 
-- Always provide tests for your changes.
+- To set up your project's environment, have a look at [Python Packaging User Guide](https://packaging.python.org)
+  and [Real Python Tutorials](https://realpython.com)
+- Install pip-tools in development mode and its test dependencies with `pip install -e '.[testing]'`.
+- Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
 - Before merging, assign the PR to a milestone for a version to help with the release process.
@@ -17,75 +20,6 @@ The only exception to those guidelines is for trivial changes, such as
 documentation corrections or contributions that do not change pip-tools itself.
 
 Contributions following these guidelines are always welcomed, encouraged and appreciated.
-
-## Development Guidelines
-
-### Installation
-
-This project requires Python 3.6 or higher.
-
-At the project's root, create a virtual environment, using your current Python 3 version:
-
-```console
-$ python3 -m venv .venv
-```
-
-Activate the virtual environment:
-
-```console
-$ source .venv/bin/activate
-```
-
-Install `pip-tools` in development mode and its test dependencies:
-
-```console
-$ pip install -e .[testing]
-```
-
-If you are using `zsh`, you need to escape the brackets: `\[testing\]`.
-
-
-### Testing with pytest
-
-This project uses [pytest](https://docs.pytest.org/en/stable/contents.html) to run the tests.
-
-Inside your virtual environment, at the project's root, use:
-
-```console
-$ pytest
-```
-
-
-### Testing with tox
-
-This project uses [tox](https://tox.readthedocs.io/en/latest/) to test different environments.
-
-To install several Python versions, use [pyenv](https://github.com/pyenv/pyenv).
-To help `tox` find out which Python versions are installed, at the root of the project, declare the versions using
-`pyenv local  <version> <version2> ...`. For example:
-
-```console
-$ pyenv local 3.7.10 3.8.9 3.9.4
-```
-
-Inside your virtual environment, install `tox`:
-
-```console
-$ pip install tox
-```
-
-Prepare `tox` to use the Python versions:
-
-```console
-$ tox --notest -p auto --parallel-live
-```
-
-Run `tox` in parallel:
-
-```console
-$ tox -p auto
-```
-
 
 ## Project Release Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 Here are a few additional or emphasized guidelines to follow when contributing to `pip-tools`:
 
 - If you need to have a virtualenv outside of `tox`, it is possible to reuse its configuration to provision it as [described in the docs](https://tox.readthedocs.io/en/latest/example/devenv.html#creating-development-environments-using-the-devenv-option).
-- Always provide tests for your changes and run `tox -p all` to make sure they are passing the checks.
+- Always provide tests for your changes and run `tox -p all` to make sure they are passing the checks locally.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
 - Before merging, assign the PR to a milestone for a version to help with the release process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ using your current python version:
 
 Activate the virtual environment:
 
-    source ./.venv/bin/activate
+    source .venv/bin/activate
 
 ## Project Contribution Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,3 @@ To help keeping track of the releases and their changes, here's the current rele
 Please be mindful of other before and when performing a release, and use this access responsibly.
 
 Do not hesitate to ask questions if you have any before performing a release.
-
-```
-
-```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Here are a few additional or emphasized guidelines to follow when contributing t
   and [Real Python Tutorials](https://realpython.com)
 - Install pip-tools in development mode and its test dependencies with `pip install -e '.[testing]'`.
 - Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
+- Always provide tests for your changes.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
 - Before merging, assign the PR to a milestone for a version to help with the release process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 
 Here are a few additional or emphasized guidelines to follow when contributing to `pip-tools`:
 
-- Use `tox` to create a [development environment](https://tox.readthedocs.io/en/latest/example/devenv.html#creating-development-environments-using-the-devenv-option)
+- Use `tox` to create a [development environment](https://tox.readthedocs.io/en/latest/example/devenv.html#creating-development-environments-using-the-devenv-option).
 - Always provide tests for your changes and run `tox -p all` to make sure they are passing the checks.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 
 Here are a few additional or emphasized guidelines to follow when contributing to `pip-tools`:
 
-- Use `tox` to create a [development environment](https://tox.readthedocs.io/en/latest/example/devenv.html#creating-development-environments-using-the-devenv-option).
+- If you need to have a virtualenv outside of `tox`, it is possible to reuse its configuration to provision it as [described in the docs](https://tox.readthedocs.io/en/latest/example/devenv.html#creating-development-environments-using-the-devenv-option).
 - Always provide tests for your changes and run `tox -p all` to make sure they are passing the checks.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,27 @@ This is a [Jazzband](https://jazzband.co/) project. By contributing you agree
 to abide by the [Contributor Code of Conduct](https://jazzband.co/about/conduct)
 and follow the [guidelines](https://jazzband.co/about/guidelines).
 
+## Getting started
+
+Install tox:
+
+    pip install tox
+
+Create a virtual environment, with `pip-tools` in development mode and its test dependencies,
+using your current python version:
+
+    tox --devenv .venv -e py
+
+Activate the virtual env:
+
+    source ./.venv/bin/activate
+
 ## Project Contribution Guidelines
 
 Here are a few additional or emphasized guidelines to follow when contributing to pip-tools:
 
-- Install pip-tools in development mode and its test dependencies with `pip install -e .[testing]`.
 - Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
-- Always provide tests for your changes.
+- Always provide tests for your changes, use `tox -e coverage` to run the tests with coverage reports.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
 - Before merging, assign the PR to a milestone for a version to help with the release process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,18 +8,22 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 
 Install tox:
 
-````console
+```console
 $ python -m pip install tox --user
-```\
+```
 
 Create a virtual environment, with `pip-tools` in development mode and its test dependencies,
 using your current python version:
 
-    tox --devenv .venv -e py
+```console
+$ tox --devenv .venv -e py
+```
 
 Activate the virtual environment:
 
-    source .venv/bin/activate
+```console
+$ source .venv/bin/activate
+```
 
 ## Project Contribution Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 
 Install tox:
 
-```console
+````console
 $ python -m pip install tox --user
 ```\
 
@@ -65,3 +65,4 @@ To help keeping track of the releases and their changes, here's the current rele
 Please be mindful of other before and when performing a release, and use this access responsibly.
 
 Do not hesitate to ask questions if you have any before performing a release.
+````

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 
 Install tox:
 
-    pip install tox
+```console
+$ python -m pip install tox --user
+```\
 
 Create a virtual environment, with `pip-tools` in development mode and its test dependencies,
 using your current python version:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,4 +69,7 @@ To help keeping track of the releases and their changes, here's the current rele
 Please be mindful of other before and when performing a release, and use this access responsibly.
 
 Do not hesitate to ask questions if you have any before performing a release.
-````
+
+```
+
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 Here are a few additional or emphasized guidelines to follow when contributing to `pip-tools`:
 
 - Use `tox` to create a [development environment](https://tox.readthedocs.io/en/latest/example/devenv.html#creating-development-environments-using-the-devenv-option)
-- Always provide tests for your changes and run `tox -p all` to make sure your changes are passing the checks.
+- Always provide tests for your changes and run `tox -p all` to make sure they are passing the checks.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
 - Before merging, assign the PR to a milestone for a version to help with the release process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ using your current python version:
 
     tox --devenv .venv -e py
 
-Activate the virtual env:
+Activate the virtual environment:
 
     source ./.venv/bin/activate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,33 +4,11 @@ This is a [Jazzband](https://jazzband.co/) project. By contributing you agree
 to abide by the [Contributor Code of Conduct](https://jazzband.co/about/conduct)
 and follow the [guidelines](https://jazzband.co/about/guidelines).
 
-## Getting started
-
-Install tox:
-
-```console
-$ python -m pip install tox --user
-```
-
-Create a virtual environment, with `pip-tools` in development mode and its test dependencies,
-using your current python version:
-
-```console
-$ tox --devenv .venv -e py
-```
-
-Activate the virtual environment:
-
-```console
-$ source .venv/bin/activate
-```
-
 ## Project Contribution Guidelines
 
-Here are a few additional or emphasized guidelines to follow when contributing to pip-tools:
+Here are a few additional or emphasized guidelines to follow when contributing to `pip-tools`:
 
-- Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
-- Always provide tests for your changes, use `tox -e coverage` to run the tests with coverage reports.
+- Always provide tests for your changes.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
 - Before merging, assign the PR to a milestone for a version to help with the release process.
@@ -39,6 +17,75 @@ The only exception to those guidelines is for trivial changes, such as
 documentation corrections or contributions that do not change pip-tools itself.
 
 Contributions following these guidelines are always welcomed, encouraged and appreciated.
+
+## Development Guidelines
+
+### Installation
+
+This project requires Python 3.6 or higher.
+
+At the project's root, create a virtual environment, using your current Python 3 version:
+
+```console
+$ python3 -m venv .venv
+```
+
+Activate the virtual environment:
+
+```console
+$ source .venv/bin/activate
+```
+
+Install `pip-tools` in development mode and its test dependencies:
+
+```console
+$ pip install -e .[testing]
+```
+
+If you are using `zsh`, you need to escape the brackets: `\[testing\]`.
+
+
+### Testing with pytest
+
+This project uses [pytest](https://docs.pytest.org/en/stable/contents.html) to run the tests.
+
+Inside your virtual environment, at the project's root, use:
+
+```console
+$ pytest
+```
+
+
+### Testing with tox
+
+This project uses [tox](https://tox.readthedocs.io/en/latest/) to test different environments.
+
+To install several Python versions, use [pyenv](https://github.com/pyenv/pyenv).
+To help `tox` find out which Python versions are installed, at the root of the project, declare the versions using
+`pyenv local  <version> <version2> ...`. For example:
+
+```console
+$ pyenv local 3.7.10 3.8.9 3.9.4
+```
+
+Inside your virtual environment, install `tox`:
+
+```console
+$ pip install tox
+```
+
+Prepare `tox` to use the Python versions:
+
+```console
+$ tox --notest -p auto --parallel-live
+```
+
+Run `tox` in parallel:
+
+```console
+$ tox -p auto
+```
+
 
 ## Project Release Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,8 @@ and follow the [guidelines](https://jazzband.co/about/guidelines).
 
 Here are a few additional or emphasized guidelines to follow when contributing to `pip-tools`:
 
-- To set up your project's environment, have a look at [Python Packaging User Guide](https://packaging.python.org)
-  and [Real Python Tutorials](https://realpython.com)
-- Install pip-tools in development mode and its test dependencies with `pip install -e '.[testing]'`.
-- Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
-- Always provide tests for your changes.
+- Use `tox` to create a [development environment](https://tox.readthedocs.io/en/latest/example/devenv.html#creating-development-environments-using-the-devenv-option)
+- Always provide tests for your changes and run `tox -p all` to make sure your changes are passing the checks.
 - Give a clear one-line description in the PR (that the maintainers can add to [CHANGELOG](CHANGELOG.md) afterwards).
 - Wait for the review of at least one other contributor before merging (even if you're a Jazzband member).
 - Before merging, assign the PR to a milestone for a version to help with the release process.

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ testing =
     pytest
     pytest-rerunfailures
     pytest-xdist
+    tox
 coverage = pytest-cov
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ testing =
     pytest
     pytest-rerunfailures
     pytest-xdist
-    tox
 coverage = pytest-cov
 
 [options.entry_points]


### PR DESCRIPTION
When I made my first PR, I was expecting tox to be in `testing`, because the doc says:

```
- Install pip-tools in development mode and its test dependencies with pip install -e .[testing].
- Check with `tox -e checkqa` to see your changes are not breaking the style conventions.
```

**Changelog-friendly one-liner**: Improve instructions for new contributors

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
