### PR TITLE
fix failing tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     pip20.3: pip==20.3.*
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
+        pipprevious,pip20.3: PIP_DISABLE_PIP_VERSION_CHECK=1
+        piplatest: PIP_USE_FEATURE=in-tree-build
 commands_pre =
     piplatest: python -m pip install -U pip
     pip --version

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,11 @@ extras =
     testing
     coverage: coverage
 deps =
+    setuptools<57
     pipprevious: pip==20.3.*
     piplatest: pip
     pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
     pip20.3: pip==20.3.*
-    setuptools<=57
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
         pipprevious,pip20.3: PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     piplatest: pip
     pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
     pip20.3: pip==20.3.*
+    setuptools<=57
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
         pipprevious,pip20.3: PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ extras =
     testing
     coverage: coverage
 deps =
+    # due to broken CI, to be removed as soon as it is fixed, compare https://github.com/pypa/setuptools/issues/2687
     setuptools<57
     pipprevious: pip==20.3.*
     piplatest: pip
@@ -18,8 +19,8 @@ deps =
     pip20.3: pip==20.3.*
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
-        pipprevious,pip20.3: PIP_DISABLE_PIP_VERSION_CHECK=1
-        piplatest: PIP_USE_FEATURE=in-tree-build
+    pipprevious,pip20.3: PIP_DISABLE_PIP_VERSION_CHECK=1
+    piplatest: PIP_USE_FEATURE=in-tree-build
 commands_pre =
     piplatest: python -m pip install -U pip
     pip --version


### PR DESCRIPTION
Closes #1403 .

**Changelog-friendly one-liner**: fix failing tox tests by pinning setuptools to old version and disabling pip version check on old version and using new feature "in-tree-build" in new version

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
