### PR TITLE
Fixed typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,13 @@ repos:
       - id: mypy
         # Avoid error: Duplicate module named 'setup'
         # https://github.com/python/mypy/issues/4008
+        # Keep exclude in sync with mypy own excludes
         exclude: ^tests/test_data/
+        additional_dependencies:
+          - click==8.0.1
+          - pep517==0.10.0
+          - toml==0.10.2
+          - pip==20.3.4
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.0
     hooks:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -2,7 +2,7 @@ import os
 import shlex
 import sys
 import tempfile
-from typing import Any, BinaryIO, List, Optional, Tuple, cast
+from typing import IO, Any, BinaryIO, List, Optional, Tuple, Union, cast
 
 import click
 from click.utils import LazyFile, safecall
@@ -231,7 +231,7 @@ def cli(
     annotate: bool,
     upgrade: bool,
     upgrade_packages: Tuple[str, ...],
-    output_file: Optional[LazyFile],
+    output_file: Union[LazyFile, IO[Any], None],
     allow_unsafe: bool,
     generate_hashes: bool,
     reuse_hashes: bool,
@@ -282,7 +282,9 @@ def cli(
 
         # Close the file at the end of the context execution
         assert output_file is not None
-        ctx.call_on_close(safecall(output_file.close_intelligently))
+        # only LazyFile has close_intelligently, newer IO[Any] does not
+        if isinstance(output_file, LazyFile):  # pragma: no cover
+            ctx.call_on_close(safecall(output_file.close_intelligently))
 
     ###
     # Setup

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,5 +93,9 @@ warn_return_any = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
+# Avoid error: Duplicate module named 'setup'
+# https://github.com/python/mypy/issues/4008
+exclude = ^tests/test_data/
+
 [mypy-tests.*]
 disallow_untyped_defs = false


### PR DESCRIPTION
**Changelog-friendly one-liner**: Fixed typing

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

pip 21.0 has internal changes that break at least our typing and we will need significant changes to support 21.x for typing. For the moment we ceil pip version for mypy and assure running mypy does get us consistentresults inside and outside pre-commit.

Fixes type change introduced by click 8

A previous version of this patch attempted to pin down pip version in setup.cfg but I soon found that piplatest tox env
started to fail as `in-tree-build` feature was unknown to it. I suppose we will have to bump minimal pip version required
to >=21 as soon we upgrade type hints .