### PR TITLE
Fix click v7 version_option compatibility

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -34,7 +34,7 @@ DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})
 
 # TODO: drop click 7 and remove this block, pass directly to version_option
-version_option_kwargs = {} if IS_CLICK_VER_8_PLUS else {"package_name": "pip-tools"}
+version_option_kwargs = {"package_name": "pip-tools"} if IS_CLICK_VER_8_PLUS else {}
 
 
 def _get_default_option(option_name: str) -> Any:

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -20,7 +20,7 @@ from ..utils import flat_map
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
 # TODO: drop click 7 and remove this block, pass directly to version_option
-version_option_kwargs = {} if IS_CLICK_VER_8_PLUS else {"package_name": "pip-tools"}
+version_option_kwargs = {"package_name": "pip-tools"} if IS_CLICK_VER_8_PLUS else {}
 
 
 @click.command(context_settings={"help_option_names": ("-h", "--help")})


### PR DESCRIPTION
It looks like the ternary was committed backwards in https://github.com/jazzband/pip-tools/pull/1400, since the `package_name` option was add in click 8, but is only being passed in click 7. That caused `pip-tools` to error on import when installed alongside click 7.

**Changelog-friendly one-liner**: Follow up https://github.com/jazzband/pip-tools/pull/1400 to fix click v7 compatibility.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
