### PR TITLE
Faster no-ops for VCS dependencies

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -23,9 +23,10 @@ from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.vcs import is_url
 from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.version import Version
-from pip._vendor.pkg_resources import get_distribution
+from pip._vendor.pkg_resources import Distribution, get_distribution
 
 from piptools.subprocess_utils import run_python_snippet
 
@@ -55,7 +56,7 @@ def key_from_ireq(ireq: InstallRequirement) -> str:
         return key_from_req(ireq.req)
 
 
-def key_from_req(req: InstallRequirement) -> str:
+def key_from_req(req: Union[Distribution, Requirement]) -> str:
     """Get an all-lowercase version of the requirement's name."""
     if hasattr(req, "key"):
         # from pkg_resources, such as installed dists for pip-sync

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ testing =
     pytest
     pytest-rerunfailures
     pytest-xdist
+    typing-extensions
 coverage = pytest-cov
 
 [options.entry_points]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -432,7 +432,10 @@ def _permissive_temp_dir() -> Iterator[str]:
     try:
         yield temp_dir
     finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        try:
+            shutil.rmtree(temp_dir)
+        except PermissionError:
+            pass
 
 
 @pytest.fixture(params=["editable", "non-editable"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -449,7 +449,7 @@ def small_fake_vcs_ireq(request, from_editable, from_line):
     not (eg with `git+` or just a bare `file:`) and can be editable or not.
     """
     editable = request.param == "editable"
-    with _permissive_temp_dir() as repo_dir, TemporaryDirectory() as source_dir:
+    with _permissive_temp_dir() as repo_dir, _permissive_temp_dir() as source_dir:
 
         def git(cmd: str, **kwargs: Any) -> subprocess.CompletedProcess:
             """Helper to run git commands in the temp repo."""


### PR DESCRIPTION
This allows pip-sync to no-op faster for VCS dependencies that haven't changed. Before this change when running `pip-sync` with a requirements file that has VCS packages it would always uninstall and reinstall those dependencies. This is because `pip` primarily operates on versions, and assumes that different code will have a different version. However this assumption breaks down with VCS packages, in which two different commits may very well have different code but the same version. Therefore to be safe we historically have had to reinstall these VCS dependencies.

This extends `pip-sync` to write some extra metadata to the installed package to be able to track what revision the package was installed from, and then skip the uninstall-and-reinstall if the revision that we want to install is the same as the revision that is already installed. This significantly speeds up no-op `pip-sync` invocations for requirements that have multiple VCS packages.

### Tests

The tests added are written as best I could for unit tests. I think a better test would likely be to spin up an entirely new virtualenv, do a sync in it, and verify that a subsequent sync doesn't reinstall anything, but the exsting tests seem less like full integration tests so I didn't go down that route. As is, there's a somewhat tricky bit of logic that reaches into the workings of `pip` that's mocked out in the tests (namely the `_reload_installed_distributions_by_key` function).

### Performance

Given a `requirements.in` of

```
-e git+https://github.com/python/mypy.git@v0.902#egg=mypy
-e git+https://github.com/psf/black.git@21.5b2#egg=black
-e git+https://github.com/yaml/pyyaml.git@5.4.1.1#egg=pyyaml
```

and a corresponding `requirements.txt` of

```
-e git+https://github.com/psf/black.git@21.5b2#egg=black
-e git+https://github.com/python/mypy.git@v0.902#egg=mypy
-e git+https://github.com/yaml/pyyaml.git@5.4.1.1#egg=pyyaml
appdirs==1.4.4
click==8.0.1
importlib-metadata==4.5.0
mypy-extensions==0.4.3
pathspec==0.8.1
regex==2021.4.4
toml==0.10.2
typed-ast==1.4.3
typing-extensions==3.10.0.0
zipp==3.4.1
```

I ran tests to determine how this affects the fresh install time as well as the no-op install time. I also did the tests but with non-editable VCS dependencies, both with the tag and with an exact commit hash (since pip has optimizations for the latter case):

| Environment                                          | Fresh install time (approx seconds) | No-op install time (approx seconds) |
| ---------------------------------------------------- | ----------------------------------- | ----------------------------------- |
| Editable, without optimization                       | 20                                  | 12                                  |
| Editable, with optimization                          | 20 🟡                               | 0.5 🟢                              |
| Non-editable, without optimization                   | 20                                  | 20                                  |
| Non-editable, with optimization                      | **25** 🔴                           | 5 🟢                                |
| Non-editable with exact commit, without optimization | 3                                   | 2                                   |
| Non-editable with exact commit, with optimization    | **7** 🔴                            | **4** 🔴                            |

As you can see, most of the number remain similar (for fresh installs) or significantly better (for no-op installs). There are some regressions in a few places, namely due to the extra time it takes to calculate the relevant information, both when detecting no-ops before installation and when writing that into the environment after installation.

**Changelog-friendly one-liner**: Faster no-ops for VCS dependencies

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
