### PR TITLE
Fix changelog category title template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,7 +23,7 @@ categories:
       - "dependency"
       - "docs"
 
-category-template: "$TITLE: "
+category-template: "$TITLE:"
 change-template: "- $TITLE ([#$NUMBER](https://github.com/jazzband/pip-tools/pull/$NUMBER)). Thanks @$AUTHOR"
 exclude-labels:
   - "skip-changelog"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,6 +23,7 @@ categories:
       - "dependency"
       - "docs"
 
+category-template: "$TITLE: "
 change-template: "- $TITLE ([#$NUMBER](https://github.com/jazzband/pip-tools/pull/$NUMBER)). Thanks @$AUTHOR"
 exclude-labels:
   - "skip-changelog"


### PR DESCRIPTION
To be consistent with the current template of the [changelog](https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md) and [release page](https://github.com/jazzband/pip-tools/releases).