### PR TITLE
Allow passing --no-upgrade option

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -125,7 +125,7 @@ def _get_default_option(option_name: str) -> Any:
 )
 @click.option(
     "-U",
-    "--upgrade",
+    "--upgrade/--no-upgrade",
     is_flag=True,
     default=False,
     help="Try to upgrade all dependencies to their latest versions",


### PR DESCRIPTION
This makes this option similar with the other boolean ones and allows
calling the tools with explicit --no-upgrade.

This change ease integration with other tools like CI/CD pipelines
where user may want to change the default behavior related to
upgrades.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog
- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
