### PR TITLE
Partially revert 5.1.2 change that broke extras (seeks to address #1451)

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -76,11 +76,12 @@ def combine_install_requirements(
 
     for ireq in source_ireqs[1:]:
         # NOTE we may be losing some info on dropped reqs here
-        combined_ireq.req.specifier &= ireq.req.specifier
-        if combined_ireq.constraint:
-            # We don't find dependencies for constraint ireqs, so copy them
-            # from non-constraints:
-            repository.copy_ireq_dependencies(ireq, combined_ireq)
+        if combined_ireq.req is not None and ireq.req is not None:
+            combined_ireq.req.specifier &= ireq.req.specifier
+            if combined_ireq.constraint:
+                # We don't find dependencies for constraint ireqs, so copy them
+                # from non-constraints:
+                repository.copy_ireq_dependencies(ireq, combined_ireq)
         combined_ireq.constraint &= ireq.constraint
         # Return a sorted, de-duped tuple of extras
         combined_ireq.extras = tuple(sorted({*combined_ireq.extras, *ireq.extras}))
@@ -227,11 +228,6 @@ class Resolver:
 
         """
         constraints = list(constraints)
-        for ireq in constraints:
-            if ireq.name is None:
-                # get_dependencies has side-effect of assigning name to ireq
-                # (so we can group by the name below).
-                self.repository.get_dependencies(ireq)
 
         # Sort first by name, i.e. the groupby key. Then within each group,
         # sort editables first.


### PR DESCRIPTION
This is a change that partially reverts c0b33e7f2224758524001e755cc338965ca0b2c0, which was released as a part of version 5.1.2 and introduced the issue described in #1451.

I've (currently) refrained from copying over the details of that issue here, but if you'd prefer that I copy that additional info over into this PR, please let me know 😊 

Regarding checklist below:

* Unsure if additional tests are necessary to revert this behavior.
* It looks like I lack the permissions necessary to add a label or adjust milestones within this PR.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog
- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Fixes #1451.
