### PR TITLE
Separate the contributor checklist in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,8 @@
 
 - [ ] Provided the tests for the changes.
 - [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog
+
+##### Maintainer checklist
+
 - [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
 - [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).


### PR DESCRIPTION
The fact that contributors can't complete the checklist (due to lack of permission) always confuses them. Let's split it and define explicitly the checklist actors.

