### PR TITLE
Generate PEP 440 direct reference whenever possible

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -115,7 +115,14 @@ def format_requirement(
     if ireq.editable:
         line = f"-e {ireq.link.url}"
     elif is_url_requirement(ireq):
-        line = ireq.link.url
+        if ireq.name:
+            line = (
+                ireq.link.url
+                if ireq.link.egg_fragment
+                else f"{ireq.name.lower()} @ {ireq.link.url}"
+            )
+        else:
+            line = ireq.link.url
     else:
         line = str(ireq.req).lower()
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -538,14 +538,14 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
             "pytest-django @ git+git://github.com/pytest-dev/pytest-django"
             "@21492afc88a19d4ca01cd0ac392a5325b14f95c7"
             "#egg=pytest-django",
-            "git+git://github.com/pytest-dev/pytest-django"
-            "@21492afc88a19d4ca01cd0ac392a5325b14f95c7#egg=pytest-django",
+            "pytest-django @ git+git://github.com/pytest-dev/pytest-django"
+            "@21492afc88a19d4ca01cd0ac392a5325b14f95c7",
         ),
         (
             "git+git://github.com/open-telemetry/opentelemetry-python.git"
             "@v1.3.0#subdirectory=opentelemetry-api"
             "&egg=opentelemetry-api",
-            "git+git://github.com/open-telemetry/opentelemetry-python.git"
+            "opentelemetry-api @ git+git://github.com/open-telemetry/opentelemetry-python.git"
             "@v1.3.0#subdirectory=opentelemetry-api",
         ),
     ),
@@ -832,8 +832,8 @@ def test_generate_hashes_with_url(runner):
         )
     out = runner.invoke(cli, ["--no-annotate", "--generate-hashes"])
     expected = (
-        "https://github.com/jazzband/pip-tools/archive/"
-        "7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip#egg=pip-tools \\\n"
+        "pip-tools @ https://github.com/jazzband/pip-tools/archive/"
+        "7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip \\\n"
         "    --hash=sha256:d24de92e18ad5bf291f25cfcdcf"
         "0171be6fa70d01d0bef9eeda356b8549715e7\n"
     )

--- a/tests/test_data/packages/fake_with_deps/setup.py
+++ b/tests/test_data/packages/fake_with_deps/setup.py
@@ -18,5 +18,6 @@ setup(
         "SQLAlchemy!=0.9.5,<2.0.0,>=0.7.8,>=1.0.0",
         "python-memcached>=1.57,<2.0",
         "xmltodict<=0.11,>=0.4.6",
+        "requests @ git+git://github.com/psf/requests@v2.25.1",
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,9 +32,74 @@ def test_format_requirement(from_line):
     assert format_requirement(ireq) == "test==1.2"
 
 
-def test_format_requirement_url(from_line):
-    ireq = from_line("https://example.com/example.zip")
-    assert format_requirement(ireq) == "https://example.com/example.zip"
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    (
+        pytest.param(
+            "https://example.com/example.zip",
+            "https://example.com/example.zip",
+            id="simple url",
+        ),
+        pytest.param(
+            "example @ https://example.com/example.zip",
+            "example @ https://example.com/example.zip",
+            id="direct reference",
+        ),
+        pytest.param(
+            "Example @ https://example.com/example.zip",
+            "example @ https://example.com/example.zip",
+            id="direct reference lowered case",
+        ),
+        pytest.param(
+            "example @ https://example.com/example.zip#egg=example",
+            "https://example.com/example.zip#egg=example",
+            id="url with egg in fragment",
+        ),
+        pytest.param(
+            "example @ https://example.com/example.zip#subdirectory=test&egg=example",
+            "https://example.com/example.zip#subdirectory=test&egg=example",
+            id="url with subdirectory and egg in fragment",
+        ),
+        pytest.param(
+            "example @ https://example.com/example.zip?egg=test#subdirectory=project_a",
+            "example @ https://example.com/example.zip?egg=test#subdirectory=project_a",
+            id="url with egg in query",
+        ),
+        pytest.param(
+            "file:./vendor/package.zip",
+            "file:./vendor/package.zip",
+            id="relative path",
+        ),
+        pytest.param(
+            "file:vendor/package.zip",
+            "file:vendor/package.zip",
+            id="relative path",
+        ),
+        pytest.param(
+            "file:vendor/package.zip#egg=example",
+            "file:vendor/package.zip#egg=example",
+            id="relative path with egg",
+        ),
+        pytest.param(
+            "file:///vendor/package.zip",
+            "file:///vendor/package.zip",
+            id="full path without direct reference",
+        ),
+        pytest.param(
+            "package @ file:///vendor/package.zip",
+            "package @ file:///vendor/package.zip",
+            id="full path with direct reference",
+        ),
+        pytest.param(
+            "package @ file:///vendor/package.zip#egg=example",
+            "file:///vendor/package.zip#egg=example",
+            id="full path with direct reference and egg",
+        ),
+    ),
+)
+def test_format_requirement_url(from_line, line, expected):
+    ireq = from_line(line)
+    assert format_requirement(ireq) == expected
 
 
 def test_format_requirement_editable_vcs(from_editable):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,48 +52,72 @@ def test_format_requirement(from_line):
         ),
         pytest.param(
             "example @ https://example.com/example.zip#egg=example",
-            "https://example.com/example.zip#egg=example",
-            id="url with egg in fragment",
+            "example @ https://example.com/example.zip",
+            id="direct reference with egg in fragment",
         ),
         pytest.param(
             "example @ https://example.com/example.zip#subdirectory=test&egg=example",
-            "https://example.com/example.zip#subdirectory=test&egg=example",
-            id="url with subdirectory and egg in fragment",
+            "example @ https://example.com/example.zip#subdirectory=test",
+            id="direct reference with subdirectory and egg in fragment",
         ),
         pytest.param(
-            "example @ https://example.com/example.zip?egg=test#subdirectory=project_a",
-            "example @ https://example.com/example.zip?egg=test#subdirectory=project_a",
-            id="url with egg in query",
+            "example @ https://example.com/example.zip#subdirectory=test"
+            "&egg=example&sha1=594b7dd32bec37d8bf70a6ffa8866d30e93f3c42",
+            "example @ https://example.com/example.zip#subdirectory=test"
+            "&sha1=594b7dd32bec37d8bf70a6ffa8866d30e93f3c42",
+            id="direct reference with subdirectory, hash and egg in fragment",
+        ),
+        pytest.param(
+            "example @ https://example.com/example.zip?egg=test",
+            "example @ https://example.com/example.zip?egg=test",
+            id="direct reference with egg in query",
         ),
         pytest.param(
             "file:./vendor/package.zip",
             "file:./vendor/package.zip",
-            id="relative path",
+            id="file scheme relative path",
         ),
         pytest.param(
             "file:vendor/package.zip",
             "file:vendor/package.zip",
-            id="relative path",
+            id="file scheme relative path",
         ),
         pytest.param(
             "file:vendor/package.zip#egg=example",
             "file:vendor/package.zip#egg=example",
-            id="relative path with egg",
+            id="file scheme relative path with egg",
+        ),
+        pytest.param(
+            "file:./vendor/package.zip#egg=example",
+            "file:./vendor/package.zip#egg=example",
+            id="file scheme relative path with egg",
         ),
         pytest.param(
             "file:///vendor/package.zip",
             "file:///vendor/package.zip",
-            id="full path without direct reference",
+            id="file scheme absolute path without direct reference",
+        ),
+        pytest.param(
+            "file:///vendor/package.zip#egg=test",
+            "test @ file:///vendor/package.zip",
+            id="file scheme absolute path with egg",
         ),
         pytest.param(
             "package @ file:///vendor/package.zip",
             "package @ file:///vendor/package.zip",
-            id="full path with direct reference",
+            id="file scheme absolute path with direct reference",
         ),
         pytest.param(
             "package @ file:///vendor/package.zip#egg=example",
-            "file:///vendor/package.zip#egg=example",
-            id="full path with direct reference and egg",
+            "package @ file:///vendor/package.zip",
+            id="file scheme absolute path with direct reference and egg",
+        ),
+        pytest.param(
+            "package @ file:///vendor/package.zip#egg=example&subdirectory=test"
+            "&sha1=594b7dd32bec37d8bf70a6ffa8866d30e93f3c42",
+            "package @ file:///vendor/package.zip#subdirectory=test"
+            "&sha1=594b7dd32bec37d8bf70a6ffa8866d30e93f3c42",
+            id="full path with direct reference, egg, subdirectory and hash",
         ),
     ),
 )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -152,7 +152,7 @@ def test_iter_lines__hash_missing(capsys, writer, from_line):
 
     expected_lines = (
         MESSAGE_UNHASHED_PACKAGE,
-        "file:///example/#egg=example",
+        "example @ file:///example/",
         "test==1.2 \\\n    --hash=FAKEHASH",
     )
     assert tuple(lines) == expected_lines
@@ -177,8 +177,8 @@ def test_iter_lines__no_warn_if_only_unhashable_packages(writer, from_line):
     lines = writer._iter_lines(ireqs, hashes=hashes)
 
     expected_lines = (
-        "file:///unhashable-pkg1/#egg=unhashable-pkg1",
-        "file:///unhashable-pkg2/#egg=unhashable-pkg2",
+        "unhashable-pkg1 @ file:///unhashable-pkg1/",
+        "unhashable-pkg2 @ file:///unhashable-pkg2/",
     )
     assert tuple(lines) == expected_lines
 


### PR DESCRIPTION
This PR converts a requirement as a direct reference whenever possible, to mimic `pip`'s behavior.
See these links for more information:

- https://github.com/jazzband/pip-tools/pull/1392#issuecomment-881797464
- https://www.python.org/dev/peps/pep-0440/
- https://www.python.org/dev/peps/pep-0508/


##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog
- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
