### PR TITLE
Change log level of hash message

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -331,7 +331,7 @@ class PyPIRepository(BaseRepository):
         with log.indentation():
             hashes = self._get_hashes_from_pypi(ireq)
             if hashes is None:
-                log.log("Couldn't get hashes from PyPI, fallback to hashing files")
+                log.info("Couldn't get hashes from PyPI, fallback to hashing files")
                 return self._get_hashes_from_files(ireq)
 
         return hashes

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -331,7 +331,7 @@ class PyPIRepository(BaseRepository):
         with log.indentation():
             hashes = self._get_hashes_from_pypi(ireq)
             if hashes is None:
-                log.info("Couldn't get hashes from PyPI, fallback to hashing files")
+                log.debug("Couldn't get hashes from PyPI, fallback to hashing files")
                 return self._get_hashes_from_files(ireq)
 
         return hashes

--- a/tests/test_repository_local.py
+++ b/tests/test_repository_local.py
@@ -19,10 +19,7 @@ def test_get_hashes_local_repository_cache_miss(
         assert hashes == EXPECTED
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert (
-        captured.err.strip()
-        == "Couldn't get hashes from PyPI, fallback to hashing files"
-    )
+    assert captured.err == ""
 
 
 def test_get_hashes_local_repository_cache_hit(from_line, repository):
@@ -59,13 +56,7 @@ def test_toggle_reuse_hashes_local_repository(
         assert local_repository.get_hashes(from_line("small-fake-a==0.1")) == expected
     captured = capsys.readouterr()
     assert captured.out == ""
-    if reuse_hashes:
-        assert captured.err == ""
-    else:
-        assert (
-            captured.err.strip()
-            == "Couldn't get hashes from PyPI, fallback to hashing files"
-        )
+    assert captured.err == ""
 
 
 class FakeRepositoryChecksForCopy(FakeRepository):

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -22,10 +22,7 @@ def test_generate_hashes_all_platforms(capsys, pip_conf, from_line, pypi_reposit
         assert pypi_repository.get_hashes(ireq) == expected
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert (
-        captured.err.strip()
-        == "Couldn't get hashes from PyPI, fallback to hashing files"
-    )
+    assert captured.err == ""
 
 
 @pytest.mark.network


### PR DESCRIPTION
Minor change. It seemed odd that this was the only log message in the entire code bash using `log()` directly. As a result, it was not effected by the verbosity level.

I'm open to using a different log level. I went with `info()` as it would not change the currently default behavior.

**Changelog-friendly one-liner**: Adjust log level for PyPI hash message.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog
- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
