### PR TITLE
Define the release and the version in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,32 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 """Configuration file for the Sphinx documentation builder."""
 
+from functools import partial
+from pathlib import Path
+
+from setuptools_scm import get_version
+
+# -- Path setup --------------------------------------------------------------
+
+PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
+get_scm_version = partial(get_version, root=PROJECT_ROOT_DIR)
+
 
 # -- Project information -----------------------------------------------------
 
 project = "pip-tools"
 author = f"{project} Contributors"
 copyright = f"The {author}"
+
+# The short X.Y version
+version = ".".join(
+    get_scm_version(local_scheme="no-local-version",).split(
+        "."
+    )[:3],
+)
+
+# The full version, including alpha/beta/rc tags
+release = get_scm_version()
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 furo >= 2021.7.5b38
 myst-parser >= 0.15.1
+setuptools-scm >= 6.0.1
 Sphinx >= 4.1.1


### PR DESCRIPTION
This change sets the release and the version in `conf.py` using `setuptools-scm`. It's been forgotten in the initial PR and now is fixed: https://pip-tools--1466.org.readthedocs.build/en/1466/.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog
- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
