### PR TITLE
Assign copyright @ docs to project contributors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 
 project = "pip-tools"
 author = f"{project} Contributors"
-copyright = f"2012, {author}"
+copyright = f"The {author}"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,8 @@
 # -- Project information -----------------------------------------------------
 
 project = "pip-tools"
-author = "Jazzband Contributors"
-copyright = f"2021, {author}"
+author = f"{project} Contributors"
+copyright = f"2012, {author}"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This change mentions the pip-tools contributors specifically in the copyright and it also drops the year per The Linux Foundation best practices recommendation.

Ref: https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog
- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
