### PR TITLE
Xfail `test_realistic_complex_sub_dependencies` on PyPy under Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,7 @@ jobs:
         os:
           - Ubuntu
           - MacOS
-          # TODO: fix test_realistic_complex_sub_dependencies test on Windows
-          # - Windows
+          - Windows
         python-version:
           - pypy-3.7
         pip-version:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -73,8 +73,7 @@ jobs:
         os:
           - Ubuntu
           - MacOS
-          # TODO: fix test_realistic_complex_sub_dependencies test on Windows
-          # - Windows
+          - Windows
         python-version:
           - pypy3
         pip-version:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -350,7 +350,7 @@ def test_emit_index_url_option(runner, option, expected_output):
 
 @pytest.mark.network
 @pytest.mark.xfail(
-    is_pypy, is_windows, reason="https://github.com/jazzband/pip-tools/issues/1148"
+    is_pypy and is_windows, reason="https://github.com/jazzband/pip-tools/issues/1148"
 )
 def test_realistic_complex_sub_dependencies(runner):
     wheels_dir = "wheels"

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -349,7 +349,9 @@ def test_emit_index_url_option(runner, option, expected_output):
 
 
 @pytest.mark.network
-@pytest.mark.xfail(is_pypy, is_windows, reason="https://github.com/jazzband/pip-tools/issues/1148")
+@pytest.mark.xfail(
+    is_pypy, is_windows, reason="https://github.com/jazzband/pip-tools/issues/1148"
+)
 def test_realistic_complex_sub_dependencies(runner):
     wheels_dir = "wheels"
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -13,6 +13,7 @@ from piptools.scripts.compile import cli
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 
 is_pypy = "__pypy__" in sys.builtin_module_names
+is_windows = sys.platform == "win32"
 
 
 @pytest.fixture(autouse=True)
@@ -348,6 +349,7 @@ def test_emit_index_url_option(runner, option, expected_output):
 
 
 @pytest.mark.network
+@pytest.mark.xfail(is_pypy, is_windows, reason="https://github.com/jazzband/pip-tools/issues/1148")
 def test_realistic_complex_sub_dependencies(runner):
     wheels_dir = "wheels"
 


### PR DESCRIPTION
Resolves #1148 

Make this test to xfail under PyPy, Windows.

cc @atugushev

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
