### PR TITLE
Add --newline=[LF|CRLF|native|preserve] option to compile, to override the line separator characters used

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -160,6 +160,12 @@ def _get_default_option(option_name: str) -> Any:
     ),
 )
 @click.option(
+    "--newline",
+    type=click.Choice(("LF", "CRLF", "native", "preserve"), case_sensitive=False),
+    default="preserve",
+    help="Override the newline control characters used",
+)
+@click.option(
     "--allow-unsafe/--no-allow-unsafe",
     is_flag=True,
     default=False,
@@ -266,6 +272,7 @@ def cli(
     upgrade: bool,
     upgrade_packages: Tuple[str, ...],
     output_file: Union[LazyFile, IO[Any], None],
+    newline: str,
     allow_unsafe: bool,
     strip_extras: bool,
     generate_hashes: bool,
@@ -492,6 +499,21 @@ def cli(
 
     log.debug("")
 
+    if newline == "preserve":
+        if os.path.exists(output_file.name):
+            with open(output_file.name, "rb") as existing_target:
+                existing_txt = existing_target.read().decode()
+            if "\r\n" in existing_txt:
+                newline = "CRLF"
+            elif "\n" in existing_txt:
+                newline = "LF"
+    linesep = {
+        "native": os.linesep,
+        "LF": "\n",
+        "CRLF": "\r\n",
+        "preserve": os.linesep,
+    }[newline]
+
     ##
     # Output
     ##
@@ -511,6 +533,7 @@ def cli(
         index_urls=repository.finder.index_urls,
         trusted_hosts=repository.finder.trusted_hosts,
         format_control=repository.finder.format_control,
+        linesep=linesep,
         allow_unsafe=allow_unsafe,
         find_links=repository.finder.find_links,
         emit_find_links=emit_find_links,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -515,7 +515,7 @@ def cli(
         "native": os.linesep,
         "LF": "\n",
         "CRLF": "\r\n",
-        "preserve": os.linesep,
+        "preserve": "\n",
     }[newline]
 
     ##

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -499,14 +499,18 @@ def cli(
 
     log.debug("")
 
+    # Determine linesep for OutputWriter to use
     if newline == "preserve":
-        if os.path.exists(output_file.name):
-            with open(output_file.name, "rb") as existing_target:
-                existing_txt = existing_target.read().decode()
-            if "\r\n" in existing_txt:
-                newline = "CRLF"
-            elif "\n" in existing_txt:
-                newline = "LF"
+        for fname in (output_file.name, *src_files):
+            if os.path.exists(fname):
+                with open(fname, "rb") as existing_file:
+                    existing_text = existing_file.read().decode()
+                if "\r\n" in existing_text:
+                    newline = "CRLF"
+                    break
+                elif "\n" in existing_text:
+                    newline = "LF"
+                    break
     linesep = {
         "native": os.linesep,
         "LF": "\n",

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -98,6 +98,7 @@ class OutputWriter:
         index_urls: Iterable[str],
         trusted_hosts: Iterable[str],
         format_control: FormatControl,
+        linesep: str,
         allow_unsafe: bool,
         find_links: List[str],
         emit_find_links: bool,
@@ -117,6 +118,7 @@ class OutputWriter:
         self.index_urls = index_urls
         self.trusted_hosts = trusted_hosts
         self.format_control = format_control
+        self.linesep = linesep
         self.allow_unsafe = allow_unsafe
         self.find_links = find_links
         self.emit_find_links = emit_find_links
@@ -215,7 +217,7 @@ class OutputWriter:
         if packages:
             for ireq in sorted(packages, key=self._sort_key):
                 if has_hashes and not hashes.get(ireq):
-                    yield MESSAGE_UNHASHED_PACKAGE
+                    yield self.linesep.join(MESSAGE_UNHASHED_PACKAGE.splitlines())
                     warn_uninstallable = True
                 line = self._format_requirement(
                     ireq, markers.get(key_from_ireq(ireq)), hashes=hashes
@@ -227,10 +229,10 @@ class OutputWriter:
             yield ""
             yielded = True
             if has_hashes and not self.allow_unsafe:
-                yield MESSAGE_UNSAFE_PACKAGES_UNPINNED
+                yield self.linesep.join(MESSAGE_UNSAFE_PACKAGES_UNPINNED.splitlines())
                 warn_uninstallable = True
             else:
-                yield MESSAGE_UNSAFE_PACKAGES
+                yield self.linesep.join(MESSAGE_UNSAFE_PACKAGES.splitlines())
 
             for ireq in sorted(unsafe_requirements, key=self._sort_key):
                 ireq_key = key_from_ireq(ireq)
@@ -264,7 +266,7 @@ class OutputWriter:
             else:
                 log.info(line)
                 self.dst_file.write(unstyle(line).encode())
-                self.dst_file.write(os.linesep.encode())
+                self.dst_file.write(self.linesep.encode())
 
     def _format_requirement(
         self,
@@ -279,7 +281,7 @@ class OutputWriter:
             line = strip_extras(line)
 
         if not self.annotate:
-            return line
+            return self.linesep.join(line.splitlines())
 
         # Annotate what packages or reqs-ins this package is required by
         required_by = set()
@@ -308,6 +310,6 @@ class OutputWriter:
                 annotation = strip_extras(annotation)
             # 24 is one reasonable column size to use here, that we've used in the past
             lines = f"{line:24}{sep}{comment(annotation)}".splitlines()
-            line = "\n".join(ln.rstrip() for ln in lines)
+            line = self.linesep.join(ln.rstrip() for ln in lines)
 
         return line

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -868,7 +868,7 @@ def test_generate_hashes_with_editable(pip_conf, runner):
     small_fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_with_deps")
     small_fake_package_url = path_to_url(small_fake_package_dir)
     with open("requirements.in", "w") as fp:
-        fp.write(f"-e {small_fake_package_url}\n")
+        fp.write(f"-e {small_fake_package_url}")
     out = runner.invoke(cli, ["--no-annotate", "--generate-hashes"])
     expected = (
         "-e {}\n"
@@ -888,7 +888,7 @@ def test_generate_hashes_with_url(runner):
     with open("requirements.in", "w") as fp:
         fp.write(
             "https://github.com/jazzband/pip-tools/archive/"
-            "7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip#egg=pip-tools\n"
+            "7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3.zip#egg=pip-tools"
         )
     out = runner.invoke(cli, ["--no-annotate", "--generate-hashes"])
     expected = (
@@ -1028,7 +1028,9 @@ def test_generate_hashes_with_split_style_annotations(runner):
         fp.write("pytz==2020.4\n")
         fp.write("sqlparse==0.3.1\n")
 
-    out = runner.invoke(cli, ["--generate-hashes", "--annotation-style", "split"])
+    out = runner.invoke(
+        cli, ["--generate-hashes", "--annotation-style", "split", "--newline=LF"]
+    )
     assert out.stderr == dedent(
         f"""\
         #
@@ -1036,7 +1038,7 @@ def test_generate_hashes_with_split_style_annotations(runner):
 {sys.version_info.major}.{sys.version_info.minor}
         # To update, run:
         #
-        #    pip-compile --generate-hashes
+        #    pip-compile --generate-hashes --newline=LF
         #
         django==1.11.29 \\
             --hash=sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f \\
@@ -1084,7 +1086,9 @@ def test_generate_hashes_with_line_style_annotations(runner):
         fp.write("pytz==2020.4\n")
         fp.write("sqlparse==0.3.1\n")
 
-    out = runner.invoke(cli, ["--generate-hashes", "--annotation-style", "line"])
+    out = runner.invoke(
+        cli, ["--generate-hashes", "--annotation-style", "line", "--newline=LF"]
+    )
     assert out.stderr == dedent(
         f"""\
         #
@@ -1092,7 +1096,7 @@ def test_generate_hashes_with_line_style_annotations(runner):
 {sys.version_info.major}.{sys.version_info.minor}
         # To update, run:
         #
-        #    pip-compile --annotation-style=line --generate-hashes
+        #    pip-compile --annotation-style=line --generate-hashes --newline=LF
         #
         django==1.11.29 \\
             --hash=sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f \\
@@ -1276,7 +1280,7 @@ def test_multiple_input_files_without_output_file(runner):
 {sys.version_info.major}.{sys.version_info.minor}
             # To update, run:
             #
-            #    pip-compile --no-emit-find-links
+            #    pip-compile --newline=LF --no-emit-find-links
             #
             small-fake-a==0.1
                 # via
@@ -1296,7 +1300,7 @@ def test_multiple_input_files_without_output_file(runner):
 {sys.version_info.major}.{sys.version_info.minor}
             # To update, run:
             #
-            #    pip-compile --annotation-style=line --no-emit-find-links
+            #    pip-compile --annotation-style=line --newline=LF --no-emit-find-links
             #
             small-fake-a==0.1         # via -c constraints.txt, small-fake-with-deps
             small-fake-with-deps==0.1  # via -r requirements.in
@@ -1312,7 +1316,7 @@ def test_multiple_input_files_without_output_file(runner):
 {sys.version_info.major}.{sys.version_info.minor}
             # To update, run:
             #
-            #    pip-compile --no-annotate --no-emit-find-links
+            #    pip-compile --newline=LF --no-annotate --no-emit-find-links
             #
             small-fake-a==0.1
             small-fake-with-deps==0.1
@@ -1332,7 +1336,7 @@ def test_annotate_option(pip_conf, runner, options, expected):
         req_in.write("-c constraints.txt\n")
         req_in.write("small_fake_with_deps")
 
-    out = runner.invoke(cli, [*options, "-n", "--no-emit-find-links"])
+    out = runner.invoke(cli, [*options, "-n", "--no-emit-find-links", "--newline=LF"])
 
     assert out.exit_code == 0, out
     assert out.stderr == dedent(expected)
@@ -2012,7 +2016,14 @@ def test_combine_different_extras_of_the_same_package(
         )
 
     out = runner.invoke(
-        cli, ["--find-links", str(dists_dir), "--no-header", "--no-emit-options"]
+        cli,
+        [
+            "--find-links",
+            str(dists_dir),
+            "--no-header",
+            "--no-emit-options",
+            "--newline=LF",
+        ],
     )
     assert out.exit_code == 0
     assert (

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -957,9 +957,6 @@ def test_generate_hashes_with_annotations(runner):
             {"\n": "\r\n", "\r\n": "\n"}[os.linesep],
             id="native",
         ),
-        pytest.param(
-            (), os.linesep, {"\n": "\r\n", "\r\n": "\n"}[os.linesep], id="default"
-        ),
     ),
 )
 def test_override_newline(
@@ -998,6 +995,26 @@ def test_override_newline(
 
     if must_exclude in must_include:
         txt = txt.replace(must_include, "")
+    assert must_exclude not in txt
+
+
+@pytest.mark.network
+@pytest.mark.parametrize(
+    ("linesep", "must_exclude"),
+    (pytest.param("\n", "\r\n", id="LF"), pytest.param("\r\n", "\n", id="CRLF")),
+)
+def test_preserve_newline_from_input(runner, linesep, must_exclude):
+    with open("requirements.in", "wb") as req_in:
+        req_in.write(f"six{linesep}".encode())
+
+    runner.invoke(cli, ["--newline=preserve", "requirements.in"])
+    with open("requirements.txt", "rb") as req_txt:
+        txt = req_txt.read().decode()
+
+    assert linesep in txt
+
+    if must_exclude in linesep:
+        txt = txt.replace(linesep, "")
     assert must_exclude not in txt
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -42,6 +42,7 @@ def writer(tmpdir_cwd):
             index_urls=[],
             trusted_hosts=[],
             format_control=FormatControl(set(), set()),
+            linesep="\n",
             allow_unsafe=False,
             find_links=[],
             emit_find_links=True,


### PR DESCRIPTION
`pip-compile` gains an option with ~two~ ~three~ **four** valid choices: `--newline=[LF|CRLF|native|preserve]`,
which can be used to override the guessed newline character used in the output file. The default is ~`native`~ **`preserve`**, which ~uses `os.linesep`~ tries to be consistent with an existing output file, or input file, or ~FALLBACK_VALUE (`native`, or `LF`? TBD)~ **falls back to `LF`**, in that order.

This aims to address #1448.

~Note: [poll for fallback value](https://github.com/jazzband/pip-tools/pull/1491#issuecomment-929417008)~

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
