### PR TITLE
Improve clarity of help text for options supporting multiple

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -75,13 +75,13 @@ def _get_default_option(option_name: str) -> Any:
     "--extra",
     "extras",
     multiple=True,
-    help="Names of extras_require to install",
+    help="Name of an extras_require group to install; may be used more than once",
 )
 @click.option(
     "-f",
     "--find-links",
     multiple=True,
-    help="Look for archives in this directory or on this HTML page",
+    help="Look for archives in this directory or on this HTML page; may be used more than once",
 )
 @click.option(
     "-i",
@@ -91,7 +91,9 @@ def _get_default_option(option_name: str) -> Any:
     ),
 )
 @click.option(
-    "--extra-index-url", multiple=True, help="Add additional index URL to search"
+    "--extra-index-url",
+    multiple=True,
+    help="Add another index URL to search; may be used more than once",
 )
 @click.option("--cert", help="Path to alternate CA bundle.")
 @click.option(
@@ -103,7 +105,7 @@ def _get_default_option(option_name: str) -> Any:
     "--trusted-host",
     multiple=True,
     help="Mark this host as trusted, even though it does not have "
-    "valid or any HTTPS.",
+    "valid or any HTTPS; may be used more than once",
 )
 @click.option(
     "--header/--no-header",
@@ -142,7 +144,7 @@ def _get_default_option(option_name: str) -> Any:
     "upgrade_packages",
     nargs=1,
     multiple=True,
-    help="Specify particular packages to upgrade.",
+    help="Specify a particular package to upgrade; may be used more than once",
 )
 @click.option(
     "-o",

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -48,16 +48,21 @@ version_option_kwargs = {"package_name": "pip-tools"} if IS_CLICK_VER_8_PLUS els
     "-f",
     "--find-links",
     multiple=True,
-    help="Look for archives in this directory or on this HTML page",
+    help="Look for archives in this directory or on this HTML page; may be used more than once",
 )
 @click.option("-i", "--index-url", help="Change index URL (defaults to PyPI)")
 @click.option(
-    "--extra-index-url", multiple=True, help="Add additional index URL to search"
+    "--extra-index-url",
+    multiple=True,
+    help="Add another index URL to search; may be used more than once",
 )
 @click.option(
     "--trusted-host",
     multiple=True,
-    help="Mark this host as trusted, even though it does not have valid or any HTTPS.",
+    help=(
+        "Mark this host as trusted, even though it does not have valid or any HTTPS"
+        "; may be used more than once"
+    ),
 )
 @click.option(
     "--no-index",


### PR DESCRIPTION
In each relevant option's help text, ensure we use singular language, and note that the option can be passed multiple times.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Fixes: #1430