### PR TITLE
Allow comma-separated arguments for --extra

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import shlex
 import sys
@@ -419,6 +420,8 @@ def cli(
                     options=repository.options,
                 )
             )
+
+    extras = tuple(itertools.chain.from_iterable(ex.split(",") for ex in extras))
 
     if extras and not setup_file_found:
         msg = "--extra has effect only with setup.py and PEP-517 input formats"

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1933,9 +1933,16 @@ def test_one_extra(fake_dists, runner, make_module, fname, content):
 
 
 @pytest.mark.network
+@pytest.mark.parametrize(
+    "extra_opts",
+    (
+        pytest.param(("--extra", "dev", "--extra", "test"), id="singular"),
+        pytest.param(("--extra", "dev,test"), id="comma-separated"),
+    ),
+)
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 @pytest.mark.xfail(is_pypy, reason="https://github.com/jazzband/pip-tools/issues/1375")
-def test_multiple_extras(fake_dists, runner, make_module, fname, content):
+def test_multiple_extras(fake_dists, runner, make_module, fname, content, extra_opts):
     """
     Test passing multiple `--extra` params.
     """
@@ -1944,10 +1951,7 @@ def test_multiple_extras(fake_dists, runner, make_module, fname, content):
         cli,
         [
             "-n",
-            "--extra",
-            "dev",
-            "--extra",
-            "test",
+            *extra_opts,
             "--find-links",
             fake_dists,
             meta_path,


### PR DESCRIPTION
Usually the form is `--extra ONE --extra TWO --extra THREE`. With this change, `--extra ONE,TWO --extra THREE` will be parsed to achieve the same result.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Fixes: #1430