### PR TITLE
Prevent loss of deep dependencies of local requirements [Fixes #1505]

### DIFF
--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -47,6 +47,17 @@ class BaseRepository(metaclass=ABCMeta):
         Monkey patches pip.Wheel to allow wheels from all platforms and Python versions.
         """
 
+    @abstractmethod
+    def copy_ireq_dependencies(
+        self, source: InstallRequirement, dest: InstallRequirement
+    ) -> None:
+        """
+        Notifies the repository that `dest` is a copy of `source`, and so it
+        has the same dependencies. Otherwise, once we prepare an ireq to assign
+        it its name, we would lose track of those dependencies on combining
+        that ireq with others.
+        """
+
     @property
     @abstractmethod
     def options(self) -> optparse.Values:

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -95,3 +95,8 @@ class LocalRequirementsRepository(BaseRepository):
     def allow_all_wheels(self) -> Iterator[None]:
         with self.repository.allow_all_wheels():
             yield
+
+    def copy_ireq_dependencies(
+        self, source: InstallRequirement, dest: InstallRequirement
+    ) -> None:
+        self.repository.copy_ireq_dependencies(source, dest)

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -239,6 +239,15 @@ class PyPIRepository(BaseRepository):
 
         return self._dependencies_cache[ireq]
 
+    def copy_ireq_dependencies(
+        self, source: InstallRequirement, dest: InstallRequirement
+    ) -> None:
+        try:
+            self._dependencies_cache[dest] = self._dependencies_cache[source]
+        except KeyError:
+            # `source` may not be in cache yet.
+            pass
+
     def _get_project(self, ireq: InstallRequirement) -> Any:
         """
         Return a dict of a project info from PyPI JSON API for a given

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -72,6 +72,7 @@ def combine_install_requirements(
 
     # deepcopy the accumulator so as to not modify the inputs
     combined_ireq = copy.deepcopy(source_ireqs[0])
+    repository.copy_ireq_dependencies(source_ireqs[0], combined_ireq)
 
     for ireq in source_ireqs[1:]:
         # NOTE we may be losing some info on dropped reqs here

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,10 @@ class FakeRepository(BaseRepository):
         # No need to do an actual pip.Wheel mock here.
         yield
 
+    def copy_ireq_dependencies(self, source, dest):
+        # No state to update.
+        pass
+
     @property
     def options(self) -> optparse.Values:
         """Not used"""


### PR DESCRIPTION
I've just restored the minimum use of `copy_ireq_dependencies`, which we removed as part of #1486 for some important fixes.

@richafrank Please have a look, as I don't know what any negative consequences or better alternatives might be.

TODO:
- [ ] sanity check
- [ ] add test

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
