### PR TITLE
Ensure an empty pip conf is used by default for all unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def tmpdir_cwd(tmpdir):
 
 @pytest.fixture
 def make_pip_conf(tmpdir, monkeypatch):
-    created_paths = []
+    created_paths = set()
 
     def _make_pip_conf(content):
         pip_conf_file = "pip.conf" if os.name != "nt" else "pip.ini"
@@ -198,7 +198,7 @@ def make_pip_conf(tmpdir, monkeypatch):
 
         monkeypatch.setenv("PIP_CONFIG_FILE", path)
 
-        created_paths.append(path)
+        created_paths.add(path)
         return path
 
     try:
@@ -232,6 +232,11 @@ def pip_with_index_conf(make_pip_conf):
             """
         )
     )
+
+
+@pytest.fixture(autouse=True)
+def pip_with_empty_conf(make_pip_conf):
+    return make_pip_conf("")
 
 
 @pytest.fixture

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from contextlib import contextmanager
-from shutil import rmtree
 from tempfile import NamedTemporaryFile
 
 import pytest

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -116,6 +116,3 @@ def test_reverse_dependencies(from_line, tmpdir):
         "bottom": {"middle", "top"},
         "bonus": {"top"},
     }
-
-    # Clean up our temp directory
-    rmtree(tmpdir)


### PR DESCRIPTION
I started working on my first small task for pip tools. When I tried to run unit tests with my changes a lot of tests failed so I then tried to run them in master. I discovered that the current mocking on master is insufficient. My local environment has a ~/.pip/pip.conf. Many of the unit tests use that pip.conf and end up failing. Some unit tests already do mock pip.conf but many did not (mostly in test_cli_compile) so I got 35 errors on master. Most of the errors (maybe all) were caused by my local pip.conf having it's own extra-index-url which changed the output of pip-compile being compared against.

This fixes all those tests by adding a default pip.conf to every test. The default pip.conf added is just an empty file. For tests that have their own custom pip.conf they will continue to use their own. What happens is their pip.conf fixture will run second and overwrite the default empty one. I've tested that running all tests now passes even when user already has custom pip.conf.

The small change to test_cache is because deleting tmpdir there is unnecessary as tmpdir is always deleted at the end of fixture and deleting it there caused a conflict from trying to delete pip.conf twice (once  in make_pip_conf and once from rmtree).

I'm unsure why we delete pip.confs in make_pip_conf as even if we forgot to delete, tmpdir should already delete it at the same. When you hit finally in make_pip_conf right after that tmpdir is deleted including pip.conf. I can simplify that logic if desired. The current change was minimal one to make unit tests work well for me.

The swap to a set for created_paths is to deal with case a test has both default empty pip.conf and it's own pip.conf like pip_with_index_conf as they overwrite each other with last one winning.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
