### PR TITLE
Fix use of FakeRepository in tests that change current dir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,16 +32,16 @@ from piptools.utils import (
     make_install_requirement,
 )
 
-from .constants import MINIMAL_WHEELS_PATH
+from .constants import MINIMAL_WHEELS_PATH, TEST_DATA_PATH
 from .utils import looks_like_ci
 
 
 class FakeRepository(BaseRepository):
     def __init__(self):
-        with open("tests/test_data/fake-index.json") as f:
+        with open(os.path.join(TEST_DATA_PATH, "fake-index.json")) as f:
             self.index = json.load(f)
 
-        with open("tests/test_data/fake-editables.json") as f:
+        with open(os.path.join(TEST_DATA_PATH, "fake-editables.json")) as f:
             self.editables = json.load(f)
 
     def get_hashes(self, ireq):


### PR DESCRIPTION
outside of the repo root, e.g. via `tmpdir_cwd`,
or when running any test from a different working dir.

Uses the absolute path instead of relative.

I encountered this on a branch (not ready yet) where I was starting to use both fixtures in a single test:
```
test setup failed
@pytest.fixture
    def repository():
>       return FakeRepository()

.../pip-tools/tests/conftest.py:136: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.conftest.FakeRepository object at 0x103893460>

    def __init__(self):
>       with open("tests/test_data/fake-index.json") as f:
E       FileNotFoundError: [Errno 2] No such file or directory: 'tests/test_data/fake-index.json'

.../pip-tools/tests/conftest.py:41: FileNotFoundError
```

##### Contributor checklist

- [x] Provided the tests for the changes. (Existing tests still pass.)
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
