### PR TITLE
Include extras when formatting a url direct reference

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -152,7 +152,10 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
 
     # If we get here then we have a requirement that supports direct reference.
     # We need to remove the egg if it exists and keep the rest of the fragments.
-    direct_reference = f"{ireq.name.lower()} @ {ireq.link.url_without_fragment}"
+    formatted_extras = f"[{','.join(sorted(ireq.extras))}]" if ireq.extras else ""
+    direct_reference = (
+        f"{ireq.name.lower()}{formatted_extras} @ {ireq.link.url_without_fragment}"
+    )
     fragments = []
 
     # Check if there is any fragment to add to the URI.

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -659,7 +659,10 @@ def test_direct_reference_with_extras(runner):
         )
     out = runner.invoke(cli, ["-n", "--rebuild"])
     assert out.exit_code == 0
-    assert "pip-tools @ git+https://github.com/jazzband/pip-tools@6.2.0" in out.stderr
+    assert (
+        "pip-tools[coverage,testing] @ git+https://github.com/jazzband/pip-tools@6.2.0"
+        in out.stderr
+    )
     assert "pytest==" in out.stderr
     assert "pytest-cov==" in out.stderr
 


### PR DESCRIPTION
As specified by the grammar in https://www.python.org/dev/peps/pep-0508/ :

```
url_req       = name wsp* extras? wsp* urlspec wsp+ quoted_marker?
urlspec       = '@' wsp* <URI_reference>
extras        = '[' wsp* extras_list? wsp* ']'
```

For https://github.com/jazzband/pip-tools/issues/1518 , if folks agree with the change.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
