### PR TITLE
Update `git://` to `https://` since GitHub disabled support for this protocol

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -477,7 +477,7 @@ def test_editable_package_in_constraints(pip_conf, runner, req_editable):
 @pytest.mark.network
 def test_editable_package_vcs(runner):
     vcs_package = (
-        "git+git://github.com/jazzband/pip-tools@"
+        "git+https://github.com/jazzband/pip-tools@"
         "f97e62ecb0d9b70965c8eff952c001d8e2722e94"
         "#egg=pip-tools"
     )
@@ -525,7 +525,7 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
             id="Zip URL",
         ),
         pytest.param(
-            "git+git://github.com/jazzband/pip-tools@"
+            "git+https://github.com/jazzband/pip-tools@"
             "7d86c8d3ecd1faa6be11c7ddc6b29a30ffd1dae3",
             "\nclick==",
             id="VCS URL",
@@ -538,10 +538,10 @@ def test_locally_available_editable_package_is_not_archived_in_cache_dir(
             id="Wheel URL",
         ),
         pytest.param(
-            "pytest-django @ git+git://github.com/pytest-dev/pytest-django"
+            "pytest-django @ git+https://github.com/pytest-dev/pytest-django"
             "@21492afc88a19d4ca01cd0ac392a5325b14f95c7"
             "#egg=pytest-django",
-            "pytest-django @ git+git://github.com/pytest-dev/pytest-django"
+            "pytest-django @ git+https://github.com/pytest-dev/pytest-django"
             "@21492afc88a19d4ca01cd0ac392a5325b14f95c7",
             id="VCS with direct reference and egg",
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -274,7 +274,7 @@ def test_is_pinned_requirement_editable(from_editable):
         ("file:///example.zip", True),
         ("https://example.com/example.zip", True),
         ("https://example.com/example.zip#egg=example", True),
-        ("git+git://github.com/jazzband/pip-tools@master", True),
+        ("git+https://github.com/jazzband/pip-tools@master", True),
     ),
 )
 def test_is_url_requirement(caplog, from_line, line, expected):


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
and https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting

Fixes https://github.com/jazzband/pip-tools/issues/1522

##### Contributor checklist

- [x] Provided the tests for the changes. (These are all changes to tests.)
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
