### PR TITLE
Disregard existing pins in the output which can't be found by pip, rather than failing to compile

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1971,6 +1971,12 @@ def test_ignore_compiled_unavailable_version(pip_conf, runner):
     assert "small-fake-a==" in out.stderr
     assert "small-fake-a==9999" not in out.stderr.splitlines()
 
+    assert (
+        "Discarding small-fake-a==9999 "
+        "(from -r requirements.txt (line 1)) "
+        "to proceed the resolution"
+    ) in out.stderr
+
 
 def test_prefer_binary_dist(
     pip_conf, make_package, make_sdist, make_wheel, tmpdir, runner

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1958,6 +1958,21 @@ def test_preserve_compiled_prerelease_version(pip_conf, runner):
     assert "small-fake-a==0.3b1" in out.stderr.splitlines()
 
 
+@pytest.mark.xfail
+def test_ignore_compiled_unavailable_version(pip_conf, runner):
+    with open("requirements.in", "w") as req_in:
+        req_in.write("small-fake-a")
+
+    with open("requirements.txt", "w") as req_txt:
+        req_txt.write("small-fake-a==9999")
+
+    out = runner.invoke(cli, ["--no-annotate", "--no-header"])
+
+    assert out.exit_code == 0, out
+    assert "small-fake-a==" in out.stderr
+    assert "small-fake-a==9999" not in out.stderr.splitlines()
+
+
 def test_prefer_binary_dist(
     pip_conf, make_package, make_sdist, make_wheel, tmpdir, runner
 ):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1958,7 +1958,6 @@ def test_preserve_compiled_prerelease_version(pip_conf, runner):
     assert "small-fake-a==0.3b1" in out.stderr.splitlines()
 
 
-@pytest.mark.xfail
 def test_ignore_compiled_unavailable_version(pip_conf, runner):
     with open("requirements.in", "w") as req_in:
         req_in.write("small-fake-a")


### PR DESCRIPTION
Before running `pip-compile`, the output file may contain a pinned requirement which can't be found in PyPI or whichever repo (e.g. a revoked release). This change aims to disregard these un-find-able pins, rather than cause the compile operation to fail.

Fixes #1530

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
