### PR TITLE
CI: Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -75,7 +75,7 @@ jobs:
           - MacOS
           - Windows
         python-version:
-          - pypy3
+          - pypy-3.8
         pip-version:
           - latest
     env:


### PR DESCRIPTION
pypy3 is deprecated and is not available in newer images:
https://github.com/actions/setup-python/issues/244#issuecomment-925966022

Instead explicitly specify the version:
https://github.com/actions/setup-python#specifying-a-pypy-version

Committed via https://github.com/asottile/all-repos