### PR TITLE
Add support for pip's 2020 dependency resolver

### DIFF
--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -3,6 +3,7 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from typing import Iterator, Optional, Set
 
+from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.index import PyPI
 from pip._internal.network.session import PipSession
@@ -61,3 +62,8 @@ class BaseRepository(metaclass=ABCMeta):
     @abstractmethod
     def finder(self) -> PackageFinder:
         """Returns a package finder to interact with simple repository API (PEP 503)"""
+
+    @property
+    @abstractmethod
+    def command(self) -> InstallCommand:
+        """Return an install command."""

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -2,6 +2,7 @@ import optparse
 from contextlib import contextmanager
 from typing import Iterator, Mapping, Optional, Set, cast
 
+from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.req import InstallRequirement
@@ -60,6 +61,11 @@ class LocalRequirementsRepository(BaseRepository):
     @property
     def session(self) -> Session:
         return self.repository.session
+
+    @property
+    def command(self) -> InstallCommand:
+        """Return an install command instance."""
+        return self.repository.command
 
     def clear_caches(self) -> None:
         self.repository.clear_caches()

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -139,24 +139,14 @@ def combine_install_requirements(
             key=lambda x: (len(str(x)), str(x)),
         )
 
-    combined_ireq = InstallRequirement(
+    combined_ireq = copy_install_requirement(
+        template=source_ireqs[0],
         req=req,
         comes_from=comes_from,
-        editable=source_ireqs[0].editable,
-        link=link_attrs["link"],
-        markers=source_ireqs[0].markers,
-        use_pep517=source_ireqs[0].use_pep517,
-        isolated=source_ireqs[0].isolated,
-        install_options=source_ireqs[0].install_options,
-        global_options=source_ireqs[0].global_options,
-        hash_options=source_ireqs[0].hash_options,
         constraint=constraint,
         extras=extras,
-        user_supplied=source_ireqs[0].user_supplied,
+        **link_attrs,
     )
-    # e.g. If the original_link was None, keep it so. Passing `link` as an
-    # argument to `InstallRequirement` sets it as the original_link:
-    combined_ireq.original_link = link_attrs["original_link"]
     combined_ireq._source_ireqs = source_ireqs
 
     return combined_ireq

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -46,7 +46,7 @@ from .utils import (
     is_url_requirement,
     key_from_ireq,
     key_from_req,
-    remove_value,
+    omit_list_value,
     strip_extras,
 )
 
@@ -236,7 +236,7 @@ class LegacyResolver(BaseResolver):
             raise PipToolsError("Legacy resolver deprecated feature must be enabled.")
 
         # Make sure there is no enabled 2020-resolver
-        options.features_enabled = remove_value(
+        options.features_enabled = omit_list_value(
             options.features_enabled, "2020-resolver"
         )
 
@@ -534,7 +534,7 @@ class BacktrackingResolver(BaseResolver):
         self._constraints_map = {key_from_ireq(ireq): ireq for ireq in constraints}
 
         # Make sure there is no enabled legacy resolver
-        options.deprecated_features_enabled = remove_value(
+        options.deprecated_features_enabled = omit_list_value(
             options.deprecated_features_enabled, "legacy-resolver"
         )
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -3,6 +3,7 @@ import copy
 import itertools
 import json
 import os
+import re
 import shlex
 import typing
 from typing import (
@@ -441,3 +442,43 @@ def get_sys_path_for_python_executable(python_executable: str) -> List[str]:
     assert isinstance(paths, list)
     assert all(isinstance(i, str) for i in paths)
     return [os.path.abspath(path) for path in paths]
+
+
+def remove_value(lst: List[_T], value: _T) -> List[_T]:
+    """
+    Returns new list without a given value.
+    """
+    return [item for item in lst if item != value]
+
+
+_strip_extras_re = re.compile(r"\[.+?\]")
+
+
+def strip_extras(name: str) -> str:
+    """Strip extras from package name, e.g. pytest[testing] -> pytest."""
+    return re.sub(_strip_extras_re, "", name)
+
+
+def copy_install_requirement(template: InstallRequirement) -> InstallRequirement:
+    """Make a copy of an ``InstallRequirement``."""
+    ireq = InstallRequirement(
+        req=copy.deepcopy(template.req),
+        comes_from=template.comes_from,
+        editable=template.editable,
+        link=template.link,
+        markers=template.markers,
+        use_pep517=template.use_pep517,
+        isolated=template.isolated,
+        install_options=template.install_options,
+        global_options=template.global_options,
+        hash_options=template.hash_options,
+        constraint=template.constraint,
+        extras=template.extras,
+        user_supplied=template.user_supplied,
+    )
+
+    # If the original_link was None, keep it so. Passing `link` as an
+    # argument to `InstallRequirement` sets it as the original_link:
+    ireq.original_link = template.original_link
+
+    return ireq

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -444,10 +444,8 @@ def get_sys_path_for_python_executable(python_executable: str) -> List[str]:
     return [os.path.abspath(path) for path in paths]
 
 
-def remove_value(lst: List[_T], value: _T) -> List[_T]:
-    """
-    Returns new list without a given value.
-    """
+def omit_list_value(lst: List[_T], value: _T) -> List[_T]:
+    """Produce a new list with a given value skipped."""
     return [item for item in lst if item != value]
 
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -293,9 +293,7 @@ class OutputWriter:
         if ireq.comes_from:
             required_by.add(_comes_from_as_string(ireq.comes_from))
 
-        if hasattr(ireq, "_required_by"):
-            for name in ireq._required_by:
-                required_by.add(name)
+        required_by |= set(getattr(ireq, "_required_by", set()))
 
         if required_by:
             if self.annotation_style == "split":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,16 @@
 import json
-import optparse
 import os
 import subprocess
 import sys
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from functools import partial
 from textwrap import dedent
+from typing import List, Optional
 
 import pytest
 from click.testing import CliRunner
+from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.network.session import PipSession
@@ -24,7 +26,7 @@ from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
 from piptools.repositories import PyPIRepository
 from piptools.repositories.base import BaseRepository
-from piptools.resolver import Resolver
+from piptools.resolver import BacktrackingResolver, LegacyResolver
 from piptools.utils import (
     as_tuple,
     is_url_requirement,
@@ -37,8 +39,17 @@ from .constants import MINIMAL_WHEELS_PATH, TEST_DATA_PATH
 from .utils import looks_like_ci
 
 
+@dataclass
+class FakeOptions:
+    features_enabled: List[str] = field(default_factory=list)
+    deprecated_features_enabled: List[str] = field(default_factory=list)
+    target_dir: Optional[str] = None
+
+
 class FakeRepository(BaseRepository):
-    def __init__(self):
+    def __init__(self, options: FakeOptions):
+        self._options = options
+
         with open(os.path.join(TEST_DATA_PATH, "fake-index.json")) as f:
             self.index = json.load(f)
 
@@ -91,8 +102,8 @@ class FakeRepository(BaseRepository):
         yield
 
     @property
-    def options(self) -> optparse.Values:
-        """Not used"""
+    def options(self):
+        return self._options
 
     @property
     def session(self) -> PipSession:
@@ -100,6 +111,10 @@ class FakeRepository(BaseRepository):
 
     @property
     def finder(self) -> PackageFinder:
+        """Not used"""
+
+    @property
+    def command(self) -> InstallCommand:
         """Not used"""
 
 
@@ -145,13 +160,20 @@ def fake_dist():
 
 @pytest.fixture
 def repository():
-    return FakeRepository()
+    return FakeRepository(
+        options=FakeOptions(deprecated_features_enabled=["legacy-resolver"])
+    )
 
 
 @pytest.fixture
 def pypi_repository(tmpdir):
     return PyPIRepository(
-        ["--index-url", PyPIRepository.DEFAULT_INDEX_URL],
+        [
+            "--index-url",
+            PyPIRepository.DEFAULT_INDEX_URL,
+            "--use-deprecated",
+            "legacy-resolver",
+        ],
         cache_dir=(tmpdir / "pypi-repo"),
     )
 
@@ -166,12 +188,27 @@ def resolver(depcache, repository):
     # TODO: It'd be nicer if Resolver instance could be set up and then
     #       use .resolve(...) on the specset, instead of passing it to
     #       the constructor like this (it's not reusable)
-    return partial(Resolver, repository=repository, cache=depcache)
+    return partial(
+        LegacyResolver, repository=repository, cache=depcache, existing_constraints={}
+    )
+
+
+@pytest.fixture
+def backtracking_resolver(depcache):
+    # TODO: It'd be nicer if Resolver instance could be set up and then
+    #       use .resolve(...) on the specset, instead of passing it to
+    #       the constructor like this (it's not reusable)
+    return partial(
+        BacktrackingResolver,
+        repository=FakeRepository(options=FakeOptions()),
+        cache=depcache,
+        existing_constraints={},
+    )
 
 
 @pytest.fixture
 def base_resolver(depcache):
-    return partial(Resolver, cache=depcache)
+    return partial(LegacyResolver, cache=depcache, existing_constraints={})
 
 
 @pytest.fixture

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -706,10 +706,10 @@ def test_ignore_incompatible_existing_pins(pip_conf, runner):
     """
     Successfully compile when existing output pins conflict with input.
     """
+    with open("requirements.txt", "w") as req_txt:
+        req_txt.write("small-fake-a==0.2\nsmall-fake-b==0.2")
     with open("requirements.in", "w") as req_in:
-        req_in.write("small-fake-b>0.1")
-    with open("requirements.txt", "w") as req_in:
-        req_in.write("small-fake-b==0.1")
+        req_in.write("small-fake-with-deps\nsmall-fake-b<0.2")
 
     out = runner.invoke(cli, [])
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -702,6 +702,20 @@ def test_input_file_without_extension(pip_conf, runner):
     assert os.path.exists("requirements.txt")
 
 
+def test_ignore_incompatible_existing_pins(pip_conf, runner):
+    """
+    Successfully compile when existing output pins conflict with input.
+    """
+    with open("requirements.in", "w") as req_in:
+        req_in.write("small-fake-b>0.1")
+    with open("requirements.txt", "w") as req_in:
+        req_in.write("small-fake-b==0.1")
+
+    out = runner.invoke(cli, [])
+
+    assert out.exit_code == 0
+
+
 def test_upgrade_packages_option(pip_conf, runner):
     """
     piptools respects --upgrade-package/-P inline list.

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -13,6 +13,12 @@ from piptools.utils import COMPILE_EXCLUDE_OPTIONS
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
 
+legacy_resolver_only = pytest.mark.parametrize(
+    "current_resolver",
+    ("legacy",),
+    indirect=("current_resolver",),
+)
+
 
 @pytest.fixture(
     autouse=True,
@@ -441,19 +447,12 @@ def test_editable_package_without_non_editable_duplicate(pip_conf, runner):
     assert "small-fake-a==" not in out.stderr
 
 
+@legacy_resolver_only
 def test_editable_package_constraint_without_non_editable_duplicate(pip_conf, runner):
     """
     piptools keeps editable constraint,
     without also adding a duplicate "non-editable" requirement variation
     """
-
-    if current_resolver != "legacy":
-        pytest.skip(
-            "This test is actual only for legacy resolver. "
-            "Constraints refactored in 2020 resolver. "
-            "See https://github.com/pypa/pip/issues/9020 for details."
-        )
-
     fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_a")
     fake_package_dir = path_to_url(fake_package_dir)
     with open("constraints.txt", "w") as constraints:
@@ -473,19 +472,13 @@ def test_editable_package_constraint_without_non_editable_duplicate(pip_conf, ru
     assert "small-fake-a==" not in out.stderr
 
 
+@legacy_resolver_only
 @pytest.mark.parametrize("req_editable", ((True,), (False,)))
 def test_editable_package_in_constraints(pip_conf, runner, req_editable):
     """
     piptools can compile an editable that appears in both primary requirements
     and constraints
     """
-    if current_resolver != "legacy":
-        pytest.skip(
-            "This test is actual only for legacy resolver. "
-            "Constraints refactored in 2020 resolver. "
-            "See https://github.com/pypa/pip/issues/9020 for details."
-        )
-
     fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_with_deps")
     fake_package_dir = path_to_url(fake_package_dir)
 
@@ -518,15 +511,13 @@ def test_editable_package_vcs(runner):
     assert "click" in out.stderr  # dependency of pip-tools
 
 
+@legacy_resolver_only
 def test_locally_available_editable_package_is_not_archived_in_cache_dir(
     pip_conf, tmpdir, runner
 ):
     """
     piptools will not create an archive for a locally available editable requirement
     """
-    if current_resolver != "legacy":
-        pytest.skip("Test relevant to legacy resolver.")
-
     cache_dir = tmpdir.mkdir("cache_dir")
 
     fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_with_deps")
@@ -1059,10 +1050,8 @@ def test_bad_setup_file(runner):
     assert f"Failed to parse {os.path.abspath('setup.py')}" in out.stderr
 
 
+@legacy_resolver_only
 def test_no_candidates(pip_conf, runner):
-    if current_resolver != "legacy":
-        pytest.skip("Only legacy resolver throws this errors.")
-
     with open("requirements", "w") as req_in:
         req_in.write("small-fake-a>0.3b1,<0.3b2")
 
@@ -1072,10 +1061,8 @@ def test_no_candidates(pip_conf, runner):
     assert "Skipped pre-versions:" in out.stderr
 
 
+@legacy_resolver_only
 def test_no_candidates_pre(pip_conf, runner):
-    if current_resolver != "legacy":
-        pytest.skip("Only legacy resolver throws this errors.")
-
     with open("requirements", "w") as req_in:
         req_in.write("small-fake-a>0.3b1,<0.3b1")
 
@@ -1574,13 +1561,11 @@ def test_options_in_requirements_file(runner, options):
         ),
     ),
 )
+@legacy_resolver_only
 def test_unreachable_index_urls(runner, cli_options, expected_message):
     """
     Test pip-compile raises an error if index URLs are not reachable.
     """
-    if current_resolver != "legacy":
-        pytest.skip("Only legacy resolver throws this errors.")
-
     with open("requirements.in", "w") as reqs_in:
         reqs_in.write("some-package")
 


### PR DESCRIPTION
### What's new?

Added new option `--resolver [backtracking|legacy]` to `pip-compile` (default is `legacy`). 

### How to use?

To enable [2020 dependency resolver](https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020) run `pip-compile --resolver=backtracking`.

### Backtracking resolver example

```bash
$ echo "oslo.utils==1.4.0" | pip-compile - --resolver=backtracking --allow-unsafe --annotation-style=line -qo-
#
# This file is autogenerated by pip-compile with python 3.8
# To update, run:
#
#    pip-compile --allow-unsafe --annotation-style=line --output-file=- --resolver=backtracking -
#
babel==2.10.3             # via oslo-i18n, oslo-utils
iso8601==1.0.2            # via oslo-utils
netaddr==0.8.0            # via oslo-utils
netifaces==0.11.0         # via oslo-utils
oslo-i18n==2.1.0          # via oslo-utils
oslo-utils==1.4.0         # via -r -
pbr==0.11.1               # via oslo-i18n, oslo-utils
pytz==2022.1              # via babel
six==1.16.0               # via oslo-i18n, oslo-utils

# The following packages are considered to be unsafe in a requirements file:
pip==22.1.2               # via pbr
```

### Legacy resolver example

```bash
$ echo "oslo.utils==1.4.0" | pip-compile - --resolver=legacy --allow-unsafe -qo-
Could not find a version that matches pbr!=0.7,!=2.1.0,<1.0,>=0.6,>=2.0.0 (from oslo.utils==1.4.0->-r -)
Tried: 0.5.2.5.g5b3e942, 0.5.0, 0.5.1, 0.5.2, 0.5.4, 0.5.5, 0.5.6, 0.5.7, 0.5.8, 0.5.10, 0.5.11, 0.5.12, 0.5.13, 0.5.14, 0.5.15, 0.5.16, 0.5.17, 0.5.18, 0.5.19, 0.5.20, 0.5.21, 0.5.22, 0.5.23, 0.6, 0.7.0, 0.8.0, 0.8.1, 0.8.2, 0.9.0, 0.9.0, 0.10.0, 0.10.0, 0.10.1, 0.10.1, 0.10.2, 0.10.2, 0.10.3, 0.10.3, 0.10.4, 0.10.4, 0.10.5, 0.10.5, 0.10.6, 0.10.6, 0.10.7, 0.10.7, 0.10.8, 0.10.8, 0.11.0, 0.11.0, 0.11.1, 0.11.1, 1.0.0, 1.0.0, 1.0.1, 1.0.1, 1.1.0, 1.1.0, 1.1.1, 1.1.1, 1.2.0, 1.2.0, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 1.5.0, 1.5.0, 1.6.0, 1.6.0, 1.7.0, 1.7.0, 1.8.0, 1.8.0, 1.8.1, 1.8.1, 1.9.0, 1.9.0, 1.9.1, 1.9.1, 1.10.0, 1.10.0, 2.0.0, 2.0.0, 2.1.0, 2.1.0, 3.0.0, 3.0.0, 3.0.1, 3.0.1, 3.1.0, 3.1.0, 3.1.1, 3.1.1, 4.0.0, 4.0.0, 4.0.1, 4.0.1, 4.0.2, 4.0.2, 4.0.3, 4.0.3, 4.0.4, 4.0.4, 4.1.0, 4.1.0, 4.1.1, 4.1.1, 4.2.0, 4.2.0, 4.3.0, 4.3.0, 5.0.0, 5.0.0, 5.1.0, 5.1.0, 5.1.1, 5.1.1, 5.1.2, 5.1.2, 5.1.3, 5.1.3, 5.2.0, 5.2.0, 5.2.1, 5.2.1, 5.3.0, 5.3.0, 5.3.1, 5.3.1, 5.4.0, 5.4.0, 5.4.1, 5.4.1, 5.4.2, 5.4.2, 5.4.3, 5.4.3, 5.4.4, 5.4.4, 5.4.5, 5.4.5, 5.5.0, 5.5.0, 5.5.1, 5.5.1, 5.6.0, 5.6.0, 5.7.0, 5.7.0, 5.8.0, 5.8.0
There are incompatible versions in the resolved dependencies:
  pbr!=0.7,<1.0,>=0.6 (from oslo.utils==1.4.0->-r -)
  pbr!=2.1.0,>=2.0.0 (from oslo.i18n==5.1.0->oslo.utils==1.4.0->-r -)
```
 
##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
