### PR TITLE
Fix --generate-hashes when hashes are computed from files

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -431,6 +431,10 @@ class PyPIRepository(BaseRepository):
         Wheel.support_index_min = _wheel_support_index_min
         self._available_candidates_cache = {}
 
+        # If we don't clear this cache then it can contain results from an
+        # earlier call when allow_all_wheels wasn't active. See GH-1532
+        self.finder.find_all_candidates.cache_clear()
+
         try:
             yield
         finally:

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -15,9 +15,16 @@ def test_generate_hashes_all_platforms(capsys, pip_conf, from_line, pypi_reposit
         "sha256:8d4d131cd05338e09f461ad784297efea3652e542c5fabe04a62358429a6175e",
         "sha256:ad05e1371eb99f257ca00f791b755deb22e752393eb8e75bc01d651715b02ea9",
         "sha256:24afa5b317b302f356fd3fc3b1cfb0aad114d509cf635ea9566052424191b944",
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     }
 
     ireq = from_line("small-fake-multi-arch==0.1")
+
+    # pip caches the candidates for the current system, which means
+    # allow_all_wheels won't have the desired effect unless the cache is
+    # cleared. See GH-1532
+    assert pypi_repository.get_hashes(ireq) < expected
+
     with pypi_repository.allow_all_wheels():
         assert pypi_repository.get_hashes(ireq) == expected
     captured = capsys.readouterr()


### PR DESCRIPTION
Fixes #1532

This issue only shows up for PyPI servers where we can't get hashes from
a JSON API. When pip-compile runs, `find_all_candidates` first gets
called outside of an `allow_all_wheels()` context, and pip caches the
list of candidates. Later, while pip-compile computes hashes from the
files, the effects of `allow_all_wheels()` are not seen because the
cached candidates are returned.

In order for the test to pass I've added a blank sdist for
small-fake-multi-arch so that there's always at least one candidate
when pypi_repository.get_hashes is called outside of allow_all_wheels

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
