### PR TITLE
Compute hashes from all index servers

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -11,6 +11,7 @@ from typing import (
     ContextManager,
     Dict,
     Iterator,
+    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -239,6 +240,37 @@ class PyPIRepository(BaseRepository):
 
         return self._dependencies_cache[ireq]
 
+    def _get_json_from_index(self, link: Link):
+        url = f"{link.url}/json"
+        try:
+            response = self.session.get(url)
+        except RequestException as e:
+            log.debug(f"Fetch package info from PyPI failed: {url}: {e}")
+            return
+
+        # Skip this PyPI server, because there is no package
+        # or JSON API might be not supported
+        if response.status_code == 404:
+            return
+
+        try:
+            return response.json()
+        except ValueError as e:
+            log.debug(f"Cannot parse JSON response from PyPI: {url}: {e}")
+
+
+    def _get_all_package_links(self, ireq: InstallRequirement):
+        package_indexes = (
+            PackageIndex(url=index_url, file_storage_domain="")
+            for index_url in self.finder.search_scope.index_urls
+        )
+        package_links = (
+            Link(f"{package_index.pypi_url}/{ireq.name}", comes_from=package_index.simple_url)
+            for package_index in package_indexes
+        )
+        return package_links
+
+
     def _get_project(self, ireq: InstallRequirement) -> Any:
         """
         Return a dict of a project info from PyPI JSON API for a given
@@ -247,29 +279,10 @@ class PyPIRepository(BaseRepository):
 
         API reference: https://warehouse.readthedocs.io/api-reference/json/
         """
-        package_indexes = (
-            PackageIndex(url=index_url, file_storage_domain="")
-            for index_url in self.finder.search_scope.index_urls
-        )
-        for package_index in package_indexes:
-            url = f"{package_index.pypi_url}/{ireq.name}/json"
-            try:
-                response = self.session.get(url)
-            except RequestException as e:
-                log.debug(f"Fetch package info from PyPI failed: {url}: {e}")
-                continue
-
-            # Skip this PyPI server, because there is no package
-            # or JSON API might be not supported
-            if response.status_code == 404:
-                continue
-
-            try:
-                data = response.json()
-            except ValueError as e:
-                log.debug(f"Cannot parse JSON response from PyPI: {url}: {e}")
-                continue
-            return data
+        for _,link in self._get_all_package_links(ireq):
+            data = self._get_json_from_index(link)
+            if data is not None:
+                return data
         return None
 
     def _get_download_path(self, ireq: InstallRequirement) -> str:
@@ -320,26 +333,37 @@ class PyPIRepository(BaseRepository):
         log.debug(ireq.name)
 
         with log.indentation():
-            hashes = self._get_hashes_from_pypi(ireq)
-            if hashes is None:
-                log.debug("Couldn't get hashes from PyPI, fallback to hashing files")
-                return self._get_hashes_from_files(ireq)
+            # get pypi hashes using the json API, once per server
+            pypi_hashes = self._get_hashes_from_pypi(ireq)
+            # Compute hashes for ALL candidate installation links, using hashes from json APIs if available
+            hashes = self._get_hashes_from_files(ireq, pypi_hashes)
 
         return hashes
 
-    def _get_hashes_from_pypi(self, ireq: InstallRequirement) -> Optional[Set[str]]:
+    def _get_hashes_from_pypi(self, ireq: InstallRequirement):
+        # package links help us construct a json query URL for index servers.
+        # Note the same type but different usage from installation candidates because we only care about one per server.
+        all_package_links = self._get_all_package_links(ireq)
+
+        # Get json from each index server
+        pypi_json = {link.comes_from: self._get_json_from_index(link) for link in all_package_links}
+        pypi_hashes = {
+            url: self._get_hash_from_json(json_resp, ireq)
+            for url, json_resp in pypi_json.items() if json_resp
+        }
+
+        # remove duplicates and empty json responses
+        return {url: hashes for url, hashes in pypi_hashes.items() if hashes is not None}
+
+    def _get_hash_from_json(self, pypi_json: object, ireq: InstallRequirement) -> Optional[Set[str]]:
         """
         Return a set of hashes from PyPI JSON API for a given InstallRequirement.
         Return None if fetching data is failed or missing digests.
         """
-        project = self._get_project(ireq)
-        if project is None:
-            return None
-
         _, version, _ = as_tuple(ireq)
 
         try:
-            release_files = project["releases"][version]
+            release_files = pypi_json["releases"][version]
         except KeyError:
             log.debug("Missing release files on PyPI")
             return None
@@ -356,7 +380,7 @@ class PyPIRepository(BaseRepository):
 
         return hashes
 
-    def _get_hashes_from_files(self, ireq: InstallRequirement) -> Set[str]:
+    def _get_hashes_from_files(self, ireq: InstallRequirement, pypi_hashes=None) -> Set[str]:
         """
         Return a set of hashes for all release files of a given InstallRequirement.
         """
@@ -371,10 +395,18 @@ class PyPIRepository(BaseRepository):
         matching_candidates = candidates_by_version[matching_versions[0]]
 
         return {
-            self._get_file_hash(candidate.link) for candidate in matching_candidates
+            self._get_file_hash(candidate.link, pypi_hashes) for candidate in matching_candidates
         }
 
-    def _get_file_hash(self, link: Link) -> str:
+    def _get_file_hash(self, link: Link, pypi_hashes=None) -> str:
+        if link.has_hash:
+            return f"{link.hash_name}:{link.hash}"
+
+        # This conditional feels too peculiar to tolerate future maintenance.
+        # But figuring out how the Link is constructed in find_all_candidates smells like it isn't a guaranteed API
+        if pypi_hashes and link.comes_from in pypi_hashes:
+            return pypi_hashes[link.url]
+
         log.debug(f"Hashing {link.show_url}")
         h = hashlib.new(FAVORITE_HASH)
         with open_local_or_remote_file(link, self.session) as f:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -11,7 +11,6 @@ from typing import (
     ContextManager,
     Dict,
     Iterator,
-    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -258,18 +257,19 @@ class PyPIRepository(BaseRepository):
         except ValueError as e:
             log.debug(f"Cannot parse JSON response from PyPI: {url}: {e}")
 
-
     def _get_all_package_links(self, ireq: InstallRequirement):
         package_indexes = (
             PackageIndex(url=index_url, file_storage_domain="")
             for index_url in self.finder.search_scope.index_urls
         )
         package_links = (
-            Link(f"{package_index.pypi_url}/{ireq.name}", comes_from=package_index.simple_url)
+            Link(
+                f"{package_index.pypi_url}/{ireq.name}",
+                comes_from=package_index.simple_url,
+            )
             for package_index in package_indexes
         )
         return package_links
-
 
     def _get_project(self, ireq: InstallRequirement) -> Any:
         """
@@ -346,10 +346,14 @@ class PyPIRepository(BaseRepository):
         all_package_links = self._get_all_package_links(ireq)
 
         # Get json from each index server
-        pypi_json = {link.comes_from: self._get_json_from_index(link) for link in all_package_links}
+        pypi_json = {
+            link.comes_from: self._get_json_from_index(link)
+            for link in all_package_links
+        }
         pypi_hashes = {
             url: self._get_hash_from_json(json_resp, ireq)
-            for url, json_resp in pypi_json.items() if json_resp
+            for url, json_resp in pypi_json.items()
+            if json_resp
         }
 
         # remove duplicates and empty json responses
@@ -358,7 +362,9 @@ class PyPIRepository(BaseRepository):
         }
         return hashes_by_index or None
 
-    def _get_hash_from_json(self, pypi_json: object, ireq: InstallRequirement) -> Optional[Set[str]]:
+    def _get_hash_from_json(
+        self, pypi_json: object, ireq: InstallRequirement
+    ) -> Optional[Set[str]]:
         """
         Return a set of hashes from PyPI JSON API for a given InstallRequirement.
         Return None if fetching data is failed or missing digests.
@@ -383,7 +389,9 @@ class PyPIRepository(BaseRepository):
 
         return hashes
 
-    def _get_hashes_from_files(self, ireq: InstallRequirement, pypi_hashes=None) -> Set[str]:
+    def _get_hashes_from_files(
+        self, ireq: InstallRequirement, pypi_hashes=None
+    ) -> Set[str]:
         """
         Return a set of hashes for all release files of a given InstallRequirement.
         """
@@ -398,7 +406,8 @@ class PyPIRepository(BaseRepository):
         matching_candidates = candidates_by_version[matching_versions[0]]
 
         return {
-            self._get_file_hash(candidate.link, pypi_hashes) for candidate in matching_candidates
+            self._get_file_hash(candidate.link, pypi_hashes)
+            for candidate in matching_candidates
         }
 
     def _get_file_hash(self, link: Link, pypi_hashes=None) -> str:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -279,7 +279,7 @@ class PyPIRepository(BaseRepository):
 
         API reference: https://warehouse.readthedocs.io/api-reference/json/
         """
-        for _,link in self._get_all_package_links(ireq):
+        for link in self._get_all_package_links(ireq):
             data = self._get_json_from_index(link)
             if data is not None:
                 return data
@@ -353,7 +353,10 @@ class PyPIRepository(BaseRepository):
         }
 
         # remove duplicates and empty json responses
-        return {url: hashes for url, hashes in pypi_hashes.items() if hashes is not None}
+        hashes_by_index = {
+            url: hashes for url, hashes in pypi_hashes.items() if hashes is not None
+        }
+        return hashes_by_index or None
 
     def _get_hash_from_json(self, pypi_json: object, ireq: InstallRequirement) -> Optional[Set[str]]:
         """

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -172,7 +172,7 @@ def test_pip_cache_dir_is_empty(from_line, tmpdir):
                     ]
                 }
             },
-            {"sha256:fake-hash"},
+            {'https://pypi.org/simple': {"sha256:fake-hash"}},
             id="return single hash",
         ),
         pytest.param(
@@ -190,7 +190,7 @@ def test_pip_cache_dir_is_empty(from_line, tmpdir):
                     ]
                 }
             },
-            {"sha256:fake-hash-number1", "sha256:fake-hash-number2"},
+            {'https://pypi.org/simple': {"sha256:fake-hash-number1", "sha256:fake-hash-number2"}},
             id="return multiple hashes",
         ),
         pytest.param(
@@ -212,7 +212,7 @@ def test_pip_cache_dir_is_empty(from_line, tmpdir):
                     ]
                 }
             },
-            {"sha256:fake-hash-number1", "sha256:fake-hash-number2"},
+            {'https://pypi.org/simple': {"sha256:fake-hash-number1", "sha256:fake-hash-number2"}},
             id="return only bdist_wheel and sdist hashes",
         ),
         pytest.param(None, None, id="not found project data"),
@@ -243,7 +243,7 @@ def test_get_hashes_from_pypi(from_line, tmpdir, project_data, expected_hashes):
     """
 
     class MockPyPIRepository(PyPIRepository):
-        def _get_project(self, ireq):
+        def _get_json_from_index(self, ireq):
             return project_data
 
     pypi_repository = MockPyPIRepository(


### PR DESCRIPTION
<!--- Describe the changes here. --->

When pip-compile encounters one index server which supports the json API it does not go on to compute hashes on files from "simple" index servers. This change fetches hashes from _all_ index servers, and computes hashes on all files that don't have one provided by a json API

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
