### PR TITLE
Update pypi.py

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -31,11 +31,7 @@ from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement, RequirementSet
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.hashes import FAVORITE_HASH
-from pip._internal.utils.logging import (
-    indent_log,
-    setup_logging,
-    RichPipStreamHandler,
-)
+from pip._internal.utils.logging import RichPipStreamHandler, indent_log, setup_logging
 from pip._internal.utils.misc import normalize_path
 from pip._internal.utils.temp_dir import TempDirectory, global_tempdir_manager
 from pip._internal.utils.urls import path_to_url, url_to_path

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -450,17 +450,17 @@ class PyPIRepository(BaseRepository):
 
         # Sync pip's console handler stream with LogContext.stream
         logger = logging.getLogger()
-        for handler in logger.handlers:
-            if handler.name == "console":  # pragma: no branch
-                assert isinstance(handler, logging.StreamHandler)
-                handler.stream = log.stream
-                break
-        else:  # pragma: no cover
+        logger_names = [x.name for x in logger.handles]
+        if 'console' not in logger_names: # pragma: no cover
             # There is always a console handler. This warning would be a signal that
             # this block should be removed/revisited, because of pip possibly
             # refactored-out logging config.
             log.warning("Couldn't find a 'console' logging handler")
-
+        else:
+            for handler in logger.handlers:
+                if isinstance(handler, logging.StreamHandler):
+                    handler.stream = log.stream
+                    break
         # Sync pip's progress bars stream with LogContext.stream
         for bar_cls in itertools.chain(*BAR_TYPES.values()):
             bar_cls.file = log.stream

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -451,7 +451,7 @@ class PyPIRepository(BaseRepository):
         # Sync pip's console handler stream with LogContext.stream
         logger = logging.getLogger()
         logger_names = [x.name for x in logger.handles]
-        if 'console' not in logger_names: # pragma: no cover
+        if "console" not in logger_names:  # pragma: no cover
             # There is always a console handler. This warning would be a signal that
             # this block should be removed/revisited, because of pip possibly
             # refactored-out logging config.

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -450,7 +450,7 @@ class PyPIRepository(BaseRepository):
 
         # Sync pip's console handler stream with LogContext.stream
         logger = logging.getLogger()
-        logger_names = [x.name for x in logger.handles]
+        logger_names = [x.name for x in logger.handlers]
         if "console" not in logger_names:  # pragma: no cover
             # There is always a console handler. This warning would be a signal that
             # this block should be removed/revisited, because of pip possibly

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     # direct dependencies
     click >= 7
     pep517
-    pip >= 21.2
+    pip >= 22.0.2
     # indirect dependencies
     setuptools  # typically needed when pip-tools invokes setup.py
     wheel  # pip plugin needed by pip-tools


### PR DESCRIPTION
Fixes AssertionError in Python>=V3.9.6 with Pip>=22.0.1 at Line 455

<!--- Describe the changes here. --->

Addresses AssertionError with Pip V>=22.0.1 on Python V>=3.9.6.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
