### PR TITLE
Daily cron: Test pip main on 3.10 but not 3.6

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -17,10 +17,10 @@ jobs:
           - Windows
           - MacOS
         python-version:
-          - 3.9
-          - 3.6
-          - 3.7
-          - 3.8
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
         pip-version:
           - main
     env:


### PR DESCRIPTION
<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).


---

pip main supports Python 3.7+.

The daily cron has been failing for three months in part due to this.

https://github.com/jazzband/pip-tools/actions/runs/1455236809

![image](https://user-images.githubusercontent.com/1324225/151752170-db640350-5024-42fe-ae4c-fa29cd117163.png)

https://github.com/jazzband/pip-tools/actions/workflows/cron.yml?page=4

![image](https://user-images.githubusercontent.com/1324225/151752221-d1bb9584-5ee7-4f7e-a13d-4adb33bd4570.png)
