### PR TITLE
With the release of pip 22.0, bump pipprevious to 21.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ extras =
     testing
     coverage: coverage
 deps =
-    pipprevious: pip==21.2.*
+    pipprevious: pip==21.3.*
     piplatest: pip
     pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
 setenv =


### PR DESCRIPTION
<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

---

pip 22.0 was released yesterday, so `pipprevious` should point to 21.3

https://pypi.org/project/pip/#history

![image](https://user-images.githubusercontent.com/1324225/151753573-77592f7e-10e7-4327-909a-61e223c4c910.png)
