### PR TITLE
Simplify CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,8 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python ${{ matrix.python-version }} from GitHub
-        if: "!endsWith(matrix.python-version, '-dev')"
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set up Python ${{ matrix.python-version }} from deadsnakes
-        if: endsWith(matrix.python-version, '-dev')
-        uses: deadsnakes/action@v2.0.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Log python version info (${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,32 +44,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            .pre-commit-config.yaml
+            setup.cfg
+            setup.py
+            tox.ini
       - name: Log python version info (${{ matrix.python-version }})
         run: python --version --version
-      - name: Pip cache
-        uses: actions/cache@v2
-        with:
-          path: >-
-            ${{
-              runner.os == 'Linux' &&
-              '~/.cache/pip'
-              || ''
-            }}${{
-              runner.os == 'macOS' &&
-              '~/Library/Caches/pip'
-              || ''
-            }}${{
-              runner.os == 'Windows' &&
-              '~\AppData\Local\pip\Cache'
-              || ''
-            }}
-          key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
       - name: Install test dependencies
         run: python -m pip install -U tox virtualenv
       - name: Prepare test environment
@@ -106,6 +88,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            .pre-commit-config.yaml
+            setup.cfg
+            setup.py
+            tox.ini
       - name: Install tox
         run: pip install tox
       - name: Prepare test environment

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,30 +33,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pip cache
-        uses: actions/cache@v2
-        with:
-          path: >-
-            ${{
-              runner.os == 'Linux' &&
-              '~/.cache/pip'
-              || ''
-            }}${{
-              runner.os == 'macOS' &&
-              '~/Library/Caches/pip'
-              || ''
-            }}${{
-              runner.os == 'Windows' &&
-              '~\AppData\Local\pip\Cache'
-              || ''
-            }}
-          key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          cache: pip
+          cache-dependency-path: |
+            .pre-commit-config.yaml
+            setup.cfg
+            setup.py
+            tox.ini
       - name: Install test dependencies
         run: python -m pip install -U tox virtualenv
       - name: Prepare test environment
@@ -88,30 +70,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pip cache
-        uses: actions/cache@v2
-        with:
-          path: >-
-            ${{
-              runner.os == 'Linux' &&
-              '~/.cache/pip'
-              || ''
-            }}${{
-              runner.os == 'macOS' &&
-              '~/Library/Caches/pip'
-              || ''
-            }}${{
-              runner.os == 'Windows' &&
-              '~\AppData\Local\pip\Cache'
-              || ''
-            }}
-          key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          cache: pip
+          cache-dependency-path: |
+            .pre-commit-config.yaml
+            setup.cfg
+            setup.py
+            tox.ini
       - name: Install tox
         run: pip install tox
       - name: Prepare test environment

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -30,30 +30,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pip cache
-        uses: actions/cache@v2
-        with:
-          path: >-
-            ${{
-              runner.os == 'Linux' &&
-              '~/.cache/pip'
-              || ''
-            }}${{
-              runner.os == 'macOS' &&
-              '~/Library/Caches/pip'
-              || ''
-            }}${{
-              runner.os == 'Windows' &&
-              '~\AppData\Local\pip\Cache'
-              || ''
-            }}
-          key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          cache: pip
+          cache-dependency-path: |
+            .pre-commit-config.yaml
+            setup.cfg
+            setup.py
+            tox.ini
       - name: Prepare cache key
         id: cache-key
         run: echo "::set-output name=sha-256::$(python -VV | sha256sum | cut -d' ' -f1)"


### PR DESCRIPTION
<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

---

Simplifies, replaces and closes https://github.com/jazzband/pip-tools/pull/1389.

Saves 70-odd lines of config compare to `master` and 108 compare to https://github.com/jazzband/pip-tools/pull/1389.

---

https://github.com/actions/setup-python now has pip caching built in, meaning we can remove a lot of https://github.com/actions/cache config.

* Docs: https://github.com/actions/setup-python#caching-packages-dependencies

---

https://github.com/actions/setup-python also now has `3.11-dev` so we can remove https://github.com/deadsnakes/action too. One difference here:

* `3.11-dev` on https://github.com/actions/setup-python is the latest alpha/beta/RC release
* `3.11-dev` on https://github.com/deadsnakes/action is a nightly build
