### PR TITLE
Ensure canonicalized requirement names are used as keys, to prevent unnecessary reinstallations during sync

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -69,9 +69,7 @@ def key_from_req(
     else:
         # from packaging, such as install requirements from requirements.txt
         key = req.name
-    assert isinstance(key, str)
-    key = key.replace("_", "-").lower()
-    return key
+    return str(canonicalize_name(key))
 
 
 def comment(text: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ from piptools.utils import (
     get_sys_path_for_python_executable,
     is_pinned_requirement,
     is_url_requirement,
+    key_from_ireq,
     lookup_table,
     lookup_table_from_tuples,
 )
@@ -264,6 +265,13 @@ def test_is_pinned_requirement(from_line, line, expected):
 def test_is_pinned_requirement_editable(from_editable):
     ireq = from_editable("git+git://fake.org/x/y.git#egg=y")
     assert not is_pinned_requirement(ireq)
+
+
+def test_key_from_ireq_normalization(from_line):
+    keys = set()
+    for line in ("zope.event", "zope-event", "zope_event", "ZOPE.event"):
+        keys.add(key_from_ireq(from_line(line)))
+    assert len(keys) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1570

`key_from_req` did a limited normalization that did not include replacing dots with dashes.

Now that we're using pip's `canonicalize_name` elsewhere, which does replace dots, this created a divergence in representations of the same package, which led during sync to extra uninstallation and reinstallation of some packages incorrectly identified as different.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
