### PR TITLE
`pip-compile`: Use the same newline string already found in relevant files (if impossible use LF), or override with `--force-lf-newlines`

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -49,6 +49,35 @@ def _get_default_option(option_name: str) -> Any:
     return getattr(default_values, option_name)
 
 
+def _determine_linesep(
+    strategy: str = "preserve", filenames: Tuple[str, ...] = ()
+) -> str:
+    """
+    Determine and return linesep string for OutputWriter to use.
+    Valid strategies: "LF", "CRLF", "native", "preserve"
+    When preserving, files are checked in order for existing newlines.
+    """
+    if strategy == "preserve":
+        for fname in filenames:
+            try:
+                with open(fname, "rb") as existing_file:
+                    existing_text = existing_file.read()
+            except FileNotFoundError:
+                continue
+            if b"\r\n" in existing_text:
+                strategy = "CRLF"
+                break
+            elif b"\n" in existing_text:
+                strategy = "LF"
+                break
+    return {
+        "native": os.linesep,
+        "LF": "\n",
+        "CRLF": "\r\n",
+        "preserve": "\n",
+    }[strategy]
+
+
 @click.command(context_settings={"help_option_names": ("-h", "--help")})
 @click.version_option(**version_option_kwargs)
 @click.pass_context
@@ -522,24 +551,9 @@ def cli(
 
     log.debug("")
 
-    # Determine linesep for OutputWriter to use
-    if newline == "preserve":
-        for fname in (output_file.name, *src_files):
-            if os.path.exists(fname):
-                with open(fname, "rb") as existing_file:
-                    existing_text = existing_file.read().decode()
-                if "\r\n" in existing_text:
-                    newline = "CRLF"
-                    break
-                elif "\n" in existing_text:
-                    newline = "LF"
-                    break
-    linesep = {
-        "native": os.linesep,
-        "LF": "\n",
-        "CRLF": "\r\n",
-        "preserve": "\n",
-    }[newline]
+    linesep = _determine_linesep(
+        strategy=newline, filenames=(output_file.name, *src_files)
+    )
 
     ##
     # Output

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -166,6 +166,12 @@ def _get_default_option(option_name: str) -> Any:
     ),
 )
 @click.option(
+    "--newline",
+    type=click.Choice(("LF", "CRLF", "native", "preserve"), case_sensitive=False),
+    default="preserve",
+    help="Override the newline control characters used",
+)
+@click.option(
     "--allow-unsafe/--no-allow-unsafe",
     is_flag=True,
     default=False,
@@ -279,6 +285,7 @@ def cli(
     upgrade: bool,
     upgrade_packages: Tuple[str, ...],
     output_file: Union[LazyFile, IO[Any], None],
+    newline: str,
     allow_unsafe: bool,
     strip_extras: bool,
     generate_hashes: bool,
@@ -515,6 +522,25 @@ def cli(
 
     log.debug("")
 
+    # Determine linesep for OutputWriter to use
+    if newline == "preserve":
+        for fname in (output_file.name, *src_files):
+            if os.path.exists(fname):
+                with open(fname, "rb") as existing_file:
+                    existing_text = existing_file.read().decode()
+                if "\r\n" in existing_text:
+                    newline = "CRLF"
+                    break
+                elif "\n" in existing_text:
+                    newline = "LF"
+                    break
+    linesep = {
+        "native": os.linesep,
+        "LF": "\n",
+        "CRLF": "\r\n",
+        "preserve": "\n",
+    }[newline]
+
     ##
     # Output
     ##
@@ -534,6 +560,7 @@ def cli(
         index_urls=repository.finder.index_urls,
         trusted_hosts=repository.finder.trusted_hosts,
         format_control=repository.finder.format_control,
+        linesep=linesep,
         allow_unsafe=allow_unsafe,
         find_links=repository.finder.find_links,
         emit_find_links=emit_find_links,

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -937,6 +937,88 @@ def test_generate_hashes_with_annotations(runner):
 
 
 @pytest.mark.network
+@pytest.mark.parametrize("gen_hashes", (True, False))
+@pytest.mark.parametrize(
+    "annotate_options",
+    (
+        ("--no-annotate",),
+        ("--annotation-style", "line"),
+        ("--annotation-style", "split"),
+    ),
+)
+@pytest.mark.parametrize(
+    ("nl_options", "must_include", "must_exclude"),
+    (
+        pytest.param(("--newline", "lf"), "\n", "\r\n", id="LF"),
+        pytest.param(("--newline", "crlf"), "\r\n", "\n", id="CRLF"),
+        pytest.param(
+            ("--newline", "native"),
+            os.linesep,
+            {"\n": "\r\n", "\r\n": "\n"}[os.linesep],
+            id="native",
+        ),
+    ),
+)
+def test_override_newline(
+    runner, gen_hashes, annotate_options, nl_options, must_include, must_exclude
+):
+    opts = annotate_options + nl_options
+    if gen_hashes:
+        opts += ("--generate-hashes",)
+
+    with open("requirements.in", "w") as req_in:
+        req_in.write("six==1.15.0\n")
+        req_in.write("setuptools\n")
+        req_in.write("pip-tools @ git+https://github.com/jazzband/pip-tools\n")
+
+    runner.invoke(cli, [*opts, "requirements.in"])
+    with open("requirements.txt", "rb") as req_txt:
+        txt = req_txt.read().decode()
+
+    assert must_include in txt
+
+    if must_exclude in must_include:
+        txt = txt.replace(must_include, "")
+    assert must_exclude not in txt
+
+    # Do it again, with --newline=preserve:
+
+    opts = annotate_options + ("--newline", "preserve")
+    if gen_hashes:
+        opts += ("--generate-hashes",)
+
+    runner.invoke(cli, [*opts, "requirements.in"])
+    with open("requirements.txt", "rb") as req_txt:
+        txt = req_txt.read().decode()
+
+    assert must_include in txt
+
+    if must_exclude in must_include:
+        txt = txt.replace(must_include, "")
+    assert must_exclude not in txt
+
+
+@pytest.mark.network
+@pytest.mark.parametrize(
+    ("linesep", "must_exclude"),
+    (pytest.param("\n", "\r\n", id="LF"), pytest.param("\r\n", "\n", id="CRLF")),
+)
+def test_preserve_newline_from_input(runner, linesep, must_exclude):
+    with open("requirements.in", "wb") as req_in:
+        req_in.write(f"six{linesep}".encode())
+
+    runner.invoke(cli, ["--newline=preserve", "requirements.in"])
+    with open("requirements.txt", "rb") as req_txt:
+        txt = req_txt.read().decode()
+
+    assert linesep in txt
+
+    if must_exclude in linesep:
+        txt = txt.replace(linesep, "")
+    assert must_exclude not in txt
+
+
+@pytest.mark.network
 def test_generate_hashes_with_split_style_annotations(runner):
     with open("requirements.in", "w") as fp:
         fp.write("Django==1.11.29\n")

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -42,6 +42,7 @@ def writer(tmpdir_cwd):
             index_urls=[],
             trusted_hosts=[],
             format_control=FormatControl(set(), set()),
+            linesep="\n",
             allow_unsafe=False,
             find_links=[],
             emit_find_links=True,


### PR DESCRIPTION
This changes `pip-compile`'s default behavior for writing newlines (1), and adds an overriding flag (2). 

### (1)

By default, `pip-compile` will determine a newline string to use based on a "preserve" strategy:

- if a pre-existing output file has a newline, use that
- otherwise, if an input file has a newline, use that
- otherwise, use LF (`\n`)

### (2)

`pip-compile` gains a flag: `--force-lf-newlines`, which ensures LF is used in the output file.

This aims to address https://github.com/jazzband/pip-tools/issues/1448.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
