### PR TITLE
Ensure `pip-compile --dry-run --quiet` still shows what would be done, while omitting the dry run message

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -245,8 +245,11 @@ class OutputWriter:
     ) -> None:
 
         for line in self._iter_lines(results, unsafe_requirements, markers, hashes):
-            log.info(line)
-            if not self.dry_run:
+            if self.dry_run:
+                # Bypass the log level to always print this during a dry run
+                log.log(line)
+            else:
+                log.info(line)
                 self.dst_file.write(unstyle(line).encode())
                 self.dst_file.write(os.linesep.encode())
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -801,8 +801,9 @@ def test_upgrade_packages_version_option_and_upgrade_no_existing_file(pip_conf, 
 def test_quiet_option(runner):
     with open("requirements", "w"):
         pass
-    out = runner.invoke(cli, ["--quiet", "-n", "requirements"])
-    # Pinned requirements result has not been written to output.
+    out = runner.invoke(cli, ["--quiet", "requirements"])
+    # Pinned requirements result has not been written to stdout or stderr:
+    assert not out.stdout_bytes
     assert not out.stderr_bytes
 
 
@@ -818,8 +819,12 @@ def test_dry_run_quiet_option(runner):
     with open("requirements", "w"):
         pass
     out = runner.invoke(cli, ["--dry-run", "--quiet", "requirements"])
-    # Dry-run message has not been written to output.
-    assert not out.stderr_bytes
+    # Neither dry-run message nor pinned requirements written to output:
+    assert not out.stdout_bytes
+    # Dry-run message has not been written to stderr:
+    assert "dry-run" not in out.stderr.lower()
+    # Pinned requirements (just the header in this case) *are* written to stderr:
+    assert "# " in out.stderr
 
 
 def test_generate_hashes_with_editable(pip_conf, runner):


### PR DESCRIPTION
Fixes #845

Original title: "Ensure `pip-compile --dry-run --quiet` logs the result (without the dry run message) to stderr"

As the purpose of `--dry-run` according to our `--help` docs is to "...show what would happen...", that bit of logging should not be silenced by `--quiet`, so we herein bypass the log level filtering by using `log.log` rather than `log.info` for the output during dry runs.

The corresponding dry+quiet test has been updated accordingly.

I also changed our basic testing of `--quiet` by removing the `--dry-run` option and additionally checking that stdout is empty. 

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
