### PR TITLE
Fix docs around prod/dev requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -332,13 +332,13 @@ To install requirements in production stage use:
 
 .. code-block:: bash
 
-    $ pip-sync
+    $ pip-sync requirements.txt
 
 You can install requirements in development stage by:
 
 .. code-block:: bash
 
-    $ pip-sync requirements.txt dev-requirements.txt
+    $ pip-sync dev-requirements.txt
 
 
 Version control integration


### PR DESCRIPTION
The docs for installing the requirements in the production example look to be missing the requirements file, and for the dev requirements, installing the `requirements.txt` is unnecessary with `dev-requirements.txt`.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
