### PR TITLE
Support env marker format strings w/ --output-file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -479,6 +479,15 @@ dependencies, making any newly generated ``requirements.txt`` environment-depend
 As a general rule, it's advised that users should still always execute ``pip-compile``
 on each targeted Python environment to avoid issues.
 
+``pip-compile`` supports a flexible mechanism for auto-embedding environment markers
+derived from the current environment in the generated output file names:
+
+.. code-block:: bash
+
+    $ pip-compile --output-file {platform_system}-{implementation_name_short}{python_version}-requirements.txt
+
+The format string fields corresponds directly to the PEP 508 marker names.
+
 .. _PEP 508 environment markers: https://www.python.org/dev/peps/pep-0508/#environment-markers
 
 Other useful tools


### PR DESCRIPTION
Overview
--------

This commit allows users to pass a format string to `--output-file`. The
supported fields in the output string correspond to [environment
marker](https://peps.python.org/pep-0508/#environment-markers) names.

Usage:

```
pip-compile --output-file {platform_system}-{implementation_name_short}{python_version}-requirements.txt

--> linux-cp3.10-requirements.txt
```

The motivation for this new feature is to provide an easy, flexible way
for users to use `pip-compile` with multi-environment projects. That is,
users can choose to embed environment markers in their pinned
requirements file names -- in as granular a fashion as needed.

Supported markers
-----------------

All PEP508 markers are supported with the exception of
`platform_version` which is too verbose to use in conjunction with a
filename.

In addition to the standard names, this commit also adds special fields
for "short hand" environment markers:

`platform_python_implementation_short`:
- This is the short version of `platform_python_implementation` and
  follows PEP 425 naming.
`implementation_name_short`:
- This is the short version of `implementation_name` and follows PEP 425
  naming.

DCO
---

Signed-off-by: Michael Mead <mmead.developer@gmail.com>

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
