### PR TITLE
Make setup.py example equivalent to setup.cfg in test_cli_compile

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1858,13 +1858,13 @@ METADATA_TEST_CASES = (
     pytest.param(
         "setup.py",
         """
-            from setuptools import setup, find
+            from setuptools import setup, find_packages
 
             setup(
                 name="sample_lib",
                 version=0.1,
                 install_requires=["small-fake-a==0.1", "small-fake-b==0.2"],
-                packages=find(),
+                packages=find_packages(),
                 extras_require={
                     "dev": ["small-fake-c==0.3", "small-fake-d==0.4"],
                     "test": ["small-fake-e==0.5", "small-fake-f==0.6"],

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1858,12 +1858,13 @@ METADATA_TEST_CASES = (
     pytest.param(
         "setup.py",
         """
-            from setuptools import setup
+            from setuptools import setup, find
 
             setup(
                 name="sample_lib",
                 version=0.1,
                 install_requires=["small-fake-a==0.1", "small-fake-b==0.2"],
+                packages=find(),
                 extras_require={
                     "dev": ["small-fake-c==0.3", "small-fake-d==0.4"],
                     "test": ["small-fake-e==0.5", "small-fake-f==0.6"],


### PR DESCRIPTION
This is an internal/maintenance change to the test suite.

As pointed out in https://github.com/pypa/setuptools/issues/3198#issuecomment-1082581233, the tests in:

[test_cli_compile.py::test_input_formats[setup.py]](https://github.com/jazzband/pip-tools/blob/master/tests/test_cli_compile.py#L1927)
[test_cli_compile.py::test_multiple_extras[setup.py-singular]](https://github.com/jazzband/pip-tools/blob/master/tests/test_cli_compile.py#L1967)
[test_cli_compile.py::test_one_extra[setup.py]](https://github.com/jazzband/pip-tools/blob/master/tests/test_cli_compile.py#L1946)
[test_cli_compile.py::test_multiple_extras[setup.py-comma-separated]](https://github.com/jazzband/pip-tools/blob/master/tests/test_cli_compile.py#L1967)

are currently failing.

After checking the code, it seems that the `setup.py` file does not match exactly its `setup.cfg` counterpart and is actually trying to create an empty package. (See https://github.com/pypa/setuptools/issues/3198#issuecomment-1083130213).

The changes introduced here make the `setup.py` mirror exactly its `setup.cfg` counterpart.
If instead the intention is to create purposefully empty packages, then [`setuptools v61` asks the users to explicitly set](https://setuptools.pypa.io/en/latest/history.html#v61-0-0):
```python
setup(
    ...,
    packages=[]
)
```

P.S.: I think this change can probably be a #skip-changelog. Please feel free to rename the PR.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
