### PR TITLE
Add support for pip==22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,23 +29,17 @@ jobs:
         pip-version:
           - "latest"
           - "previous"
-        continue-on-error: [false]
         include:
           - os: Ubuntu
             python-version: 3.11-dev
             pip-version: latest
-            continue-on-error: false
           - os: Ubuntu
             python-version: 3.7
             pip-version: main
-            continue-on-error: true
     env:
       PY_COLORS: 1
       TOXENV: pip${{ matrix.pip-version }}-coverage
       TOX_PARALLEL_NO_SPINNER: 1
-    # TODO: should be allow-failure: true or something similar
-    #       see https://github.com/actions/toolkit/issues/399
-    continue-on-error: ${{ matrix.continue-on-error }}
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.python-version }} from GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       PY_COLORS: 1
       TOXENV: pip${{ matrix.pip-version }}-coverage
       TOX_PARALLEL_NO_SPINNER: 1
+    # TODO: should be allow-failure: true or something similar
+    #       see https://github.com/actions/toolkit/issues/399
     continue-on-error: ${{ matrix.pip-version == 'main' }}
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,23 @@ jobs:
         pip-version:
           - "latest"
           - "previous"
+        continue-on-error: [false]
         include:
           - os: Ubuntu
             python-version: 3.11-dev
             pip-version: latest
+            continue-on-error: false
           - os: Ubuntu
             python-version: 3.7
             pip-version: main
-
+            continue-on-error: true
     env:
       PY_COLORS: 1
       TOXENV: pip${{ matrix.pip-version }}-coverage
       TOX_PARALLEL_NO_SPINNER: 1
     # TODO: should be allow-failure: true or something similar
     #       see https://github.com/actions/toolkit/issues/399
-    continue-on-error: ${{ matrix.pip-version == 'main' }}
+    continue-on-error: ${{ matrix.continue-on-error }}
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.python-version }} from GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,15 @@ jobs:
           - os: Ubuntu
             python-version: 3.11-dev
             pip-version: latest
+          - os: Ubuntu
+            python-version: 3.7
+            pip-version: main
 
     env:
       PY_COLORS: 1
       TOXENV: pip${{ matrix.pip-version }}-coverage
       TOX_PARALLEL_NO_SPINNER: 1
+    continue-on-error: ${{ matrix.pip-version == 'main' }}
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.python-version }} from GitHub

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -32,7 +32,7 @@ def parse_requirements(
         yield install_req_from_parsed_requirement(parsed_req, isolated=isolated)
 
 
-if PIP_VERSION <= (22, 0):
+if PIP_VERSION[:2] <= (22, 0):
     from pip._internal.req.req_tracker import (
         get_requirement_tracker as get_build_tracker,
     )

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -42,5 +42,3 @@ else:
         get_build_tracker,
         update_env_context_manager,
     )
-
-    raise Exception(1)

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -42,3 +42,5 @@ else:
         get_build_tracker,
         update_env_context_manager,
     )
+
+    raise Exception(1)

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -12,6 +12,12 @@ from pip._vendor.packaging.version import parse as parse_version
 PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split(".")))
 
 
+__all__ = [
+    "get_build_tracker",
+    "update_env_context_manager",
+]
+
+
 def parse_requirements(
     filename: str,
     session: PipSession,
@@ -24,3 +30,15 @@ def parse_requirements(
         filename, session, finder=finder, options=options, constraint=constraint
     ):
         yield install_req_from_parsed_requirement(parsed_req, isolated=isolated)
+
+
+if PIP_VERSION <= (22, 0):
+    from pip._internal.req.req_tracker import (
+        get_requirement_tracker as get_build_tracker,
+    )
+    from pip._internal.req.req_tracker import update_env_context_manager
+else:
+    from pip._internal.operations.build.build_tracker import (
+        get_build_tracker,
+        update_env_context_manager,
+    )

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -30,7 +30,6 @@ from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement, RequirementSet
-from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.hashes import FAVORITE_HASH
 from pip._internal.utils.logging import indent_log, setup_logging
 from pip._internal.utils.misc import normalize_path
@@ -41,6 +40,7 @@ from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.requests import RequestException, Session
 
 from .._compat import PIP_VERSION
+from .._compat.pip_compat import get_build_tracker
 from ..exceptions import NoCandidateFound
 from ..logging import log
 from ..utils import (
@@ -169,18 +169,23 @@ class PyPIRepository(BaseRepository):
         ireq: InstallRequirement,
         wheel_cache: WheelCache,
     ) -> Set[InstallationCandidate]:
-        with get_requirement_tracker() as req_tracker, TempDirectory(
+        with get_build_tracker() as build_tracker, TempDirectory(
             kind="resolver"
         ) as temp_dir, indent_log():
             preparer_kwargs = {
                 "temp_build_dir": temp_dir,
                 "options": self.options,
-                "req_tracker": req_tracker,
                 "session": self.session,
                 "finder": self.finder,
                 "use_user_site": False,
                 "download_dir": download_dir,
             }
+
+            if PIP_VERSION <= (22, 0):
+                preparer_kwargs["req_tracker"] = build_tracker
+            else:
+                preparer_kwargs["build_tracker"] = build_tracker
+
             preparer = self.command.make_requirement_preparer(**preparer_kwargs)
 
             reqset = RequirementSet()

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -181,7 +181,7 @@ class PyPIRepository(BaseRepository):
                 "download_dir": download_dir,
             }
 
-            if PIP_VERSION <= (22, 0):
+            if PIP_VERSION[:2] <= (22, 0):
                 preparer_kwargs["req_tracker"] = build_tracker
             else:
                 preparer_kwargs["build_tracker"] = build_tracker

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -6,11 +6,11 @@ from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple
 import click
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
-from pip._internal.req.req_tracker import update_env_context_manager
 
 from piptools.cache import DependencyCache
 from piptools.repositories.base import BaseRepository
 
+from ._compat.pip_compat import update_env_context_manager
 from .logging import log
 from .utils import (
     UNSAFE_PACKAGES,

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ extras =
 deps =
     pipprevious: pip==21.3.*
     piplatest: pip
-    piplatest: -e git+https://github.com/pypa/pip.git@main#egg=pip
     pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
 commands_pre =
-    piplatest: python -m pip install -U pip
+    piplatest: python -m pip install -U pip --ignore-installed
     pip --version
 commands = pytest {posargs}
 passenv = CI GITHUB_ACTIONS

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ extras =
     testing
     coverage: coverage
 deps =
-    pipprevious: pip==22.0.*
-    # TODO: change to `pip` after pip-22.1 being released
+    pipprevious: pip==21.3.*
+    piplatest: pip
     piplatest: -e git+https://github.com/pypa/pip.git@main#egg=pip
     pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,9 @@ extras =
     testing
     coverage: coverage
 deps =
-    pipprevious: pip==21.3.*
-    piplatest: pip
+    pipprevious: pip==22.0.*
+    # TODO: change to `pip` after pip-22.1 being released
+    piplatest: -e git+https://github.com/pypa/pip.git@main#egg=pip
     pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
 setenv =
     coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
 commands_pre =
-    piplatest: python -m pip install -U pip --ignore-installed
+    piplatest: python -m pip install -U pip
     pip --version
 commands = pytest {posargs}
 passenv = CI GITHUB_ACTIONS


### PR DESCRIPTION
- Prepare pip-tools for the upcoming `pip-22.1` release, see https://github.com/pypa/pip/issues/10991.
- Add `main` to the matrix so that we could see the changes pass tests. There is [fail-fast: false](https://github.com/jazzband/pip-tools/blob/ba022e8a6aed95abdf991fac24cd954bd85ac4c6/.github/workflows/ci.yml#L18) on CI so the workflow shouldn't be failed if `main` fails. It would be nice to have some kind of `allow-failure`, but it's not yet implemented, see: https://github.com/actions/toolkit/issues/399.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
