### PR TITLE
Remove extras from compiled file

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 import itertools
 import json
 import os
@@ -123,9 +122,9 @@ def format_requirement(
     else:
         # Canonicalize the requirement name
         # https://packaging.pypa.io/en/latest/utils.html#packaging.utils.canonicalize_name
-        req = copy.copy(ireq.req)
-        req.name = canonicalize_name(req.name)
-        line = str(req)
+        line = canonicalize_name(ireq.req.name)
+        if ireq.req.specifier:
+            line += str(ireq.req.specifier)
 
     if marker:
         line = f"{line} ; {marker}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,9 +28,23 @@ from piptools.utils import (
 )
 
 
-def test_format_requirement(from_line):
-    ireq = from_line("test==1.2")
-    assert format_requirement(ireq) == "test==1.2"
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    (
+        pytest.param("test==1.2", "test==1.2", id="with specifier"),
+        pytest.param("test[extra]==1.2", "test==1.2", id="with extra"),
+        pytest.param("test[extra1,extra2]==1.2", "test==1.2", id="with extra"),
+        pytest.param("test", "test", id="without specifier"),
+        pytest.param(
+            "test[extra1,extra2]==1.2;python_version=='2.7'",
+            'test==1.2 ; python_version == "2.7"',
+            id="with marker",
+        ),
+    ),
+)
+def test_format_requirement(from_line, line, expected):
+    ireq = from_line(line)
+    assert format_requirement(ireq, ireq.markers) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR removes the extras from the compiled files.

Please note that this is a proposal that needs discussion.

Here's a comparative table of other tools:

| Tool       | Result                  |
|------------|-------------------------|
| pipenv lock -r  | Includes extras         |
| pip freeze | Does not include extras |
| poetry export  | Does not include extras |

In my opinion the compiled files should not include extras.

Let's take an example:

Given a `requirements.in` containing [typer with all extras](https://github.com/tiangolo/typer/blob/master/pyproject.toml#L59):

```
typer[all]
```

When doing `pip-sync`, the compiled file is:

```
#
# This file is autogenerated by pip-compile with python 3.9
# To update, run:
#
#    pip-compile
#
click==8.1.2
    # via typer
colorama==0.4.4
    # via typer
shellingham==1.4.0
    # via typer
typer[all]==0.4.1
    # via -r requirements.in
```

Then `pip freeze` shows:

```
click==8.1.2
colorama==0.4.4
pep517==0.12.0
pip-tools==6.5.1
shellingham==1.4.0
tomli==2.0.1
typer==0.4.1
```

Now imagine that `typer[all]` did not contain `colorama` (which is an extra dependency) at the time we ran `pip-compile`.
The compiled file would look like that:

```
#
# This file is autogenerated by pip-compile with python 3.9
# To update, run:
#
#    pip-compile
#
click==8.1.2
    # via typer
shellingham==1.4.0
    # via typer
typer[all]==0.4.1
    # via -r requirements.in
```

Let's save the change in the compiled file and remove all installed packages in the venv.
Then let's do `pip-sync` and` pip freeze` again. Here's the output:

```
click==8.1.2
colorama==0.4.4
pep517==0.12.0
pip-tools==6.5.1
shellingham==1.4.0
tomli==2.0.1
typer==0.4.1
```

As you can see, while `colorama` was not explicitly defined in the compiled files, it has been installed because of the extra specified in the compiled file.

I do not know if it's possible to replace a package in PyPI with the same version.
If it is, then an attacker could inject an extra dependency and users would install it without realizing it. Personally, when my list of installed packages is huge, I don't check one by one all of them, I trust `pip` or `pip-sync` to install what's defined in the compiled file and nothing else. That's why I think this change makes sense.

## Links mentioning this change

- https://github.com/jazzband/pip-tools/pull/1582#issuecomment-1046176759
- https://github.com/jazzband/pip-tools/pull/1453#discussion_r671595549

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
