### PR TITLE
Fix support for pip>=22.1

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -20,7 +20,6 @@ from typing import (
 
 from click import progressbar
 from pip._internal.cache import WheelCache
-from pip._internal.cli.progress_bars import BAR_TYPES
 from pip._internal.commands import create_command
 from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
@@ -472,6 +471,9 @@ class PyPIRepository(BaseRepository):
             # this block should be removed/revisited, because of pip possibly
             # refactored-out logging config.
             log.warning("Couldn't find a 'console' logging handler")
+
+        # This import will fail with pip 22.1, but here we're pip<22.0
+        from pip._internal.cli.progress_bars import BAR_TYPES
 
         # Sync pip's progress bars stream with LogContext.stream
         for bar_cls in itertools.chain(*BAR_TYPES.values()):


### PR DESCRIPTION
Since #1607, which originally added 22.1 support, pip changed under the hood before release.

This PR fixes #1617, by moving an import inside the one function that needed it, which only ran under pip<22 anyway.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
