### PR TITLE
[Documentation] Use double quotes instead of single when running piptools with `--pip-args` flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,7 +227,7 @@ Any valid ``pip`` flags or arguments may be passed on with ``pip-compile``'s
 
 .. code-block:: bash
 
-    $ pip-compile requirements.in --pip-args '--retries 10 --timeout 30'
+    $ pip-compile requirements.in --pip-args "--retries 10 --timeout 30"
 
 Configuration
 -------------
@@ -439,7 +439,7 @@ Any valid ``pip install`` flags or arguments may be passed with ``pip-sync``'s
 
 .. code-block:: bash
 
-    $ pip-sync requirements.txt --pip-args '--no-cache-dir --no-deps'
+    $ pip-sync requirements.txt --pip-args "--no-cache-dir --no-deps"
 
 **Note**: ``pip-sync`` will not upgrade or uninstall packaging tools like
 ``setuptools``, ``pip``, or ``pip-tools`` itself. Use ``python -m pip install --upgrade``


### PR DESCRIPTION
<!--- Describe the changes here. --->

Linked issue is #1621 .

This PR replaces single quotes by double quotes in commands using the `--pip-args` flag to be compatible with more shells.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
