### PR TITLE
Update PyPIRepository::resolve_reqs() for pip>=22.1.1

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -191,7 +191,7 @@ class PyPIRepository(BaseRepository):
             ireq.user_supplied = True
             if PIP_VERSION[:3] < (22, 1, 1):
                 reqset.add_requirement(ireq)
-            elif getattr(ireq, 'name', None):
+            elif getattr(ireq, "name", None):
                 reqset.add_named_requirement(ireq)
             else:
                 reqset.add_unnamed_requirement(ireq)

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -189,7 +189,12 @@ class PyPIRepository(BaseRepository):
 
             reqset = RequirementSet()
             ireq.user_supplied = True
-            reqset.add_requirement(ireq)
+            if PIP_VERSION[:3] < (22, 1, 1):
+                reqset.add_requirement(ireq)
+            elif getattr(ireq, 'name', None):
+                reqset.add_named_requirement(ireq)
+            else:
+                reqset.add_unnamed_requirement(ireq)
 
             resolver = self.command.make_resolver(
                 preparer=preparer,


### PR DESCRIPTION
pip 22.1.1 splits RequirementSet::add_requirement() to RequirementSet::add_named_requirement() and RequirementSet::add_unnamed_requirement(). Here, we update PyPIRepository::resolve_reqs() to call the right method.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [X] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).


Fixes #1623