### PR TITLE
Support for the importlib.metadata metadata implementation

### DIFF
--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -1,5 +1,5 @@
 import optparse
-from typing import Iterator, Optional
+from typing import Callable, Iterator, Optional, cast
 
 import pip
 from pip._internal.index.package_finder import PackageFinder
@@ -8,6 +8,7 @@ from pip._internal.req import InstallRequirement
 from pip._internal.req import parse_requirements as _parse_requirements
 from pip._internal.req.constructors import install_req_from_parsed_requirement
 from pip._vendor.packaging.version import parse as parse_version
+from pip._vendor.pkg_resources import Requirement
 
 PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split(".")))
 
@@ -15,6 +16,9 @@ PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split("
 __all__ = [
     "get_build_tracker",
     "update_env_context_manager",
+    "dist_requires",
+    "uses_pkg_resources",
+    "Distribution",
 ]
 
 
@@ -42,3 +46,39 @@ else:
         get_build_tracker,
         update_env_context_manager,
     )
+
+
+# The Distribution interface has changed between pkg_resources and
+# importlib.metadata, so this compat layer allows for a consistent access
+# pattern. In pip 22.1, importlib.metdata became the default on Python 3.11
+# (and later), but is overrideable. `select_backend` returns what's being used.
+
+
+def _uses_pkg_resources() -> bool:
+
+    if PIP_VERSION[:2] < (22, 1):
+        return True
+    else:
+        from pip._internal.metadata import select_backend
+        from pip._internal.metadata.pkg_resources import Distribution as _Dist
+
+        return select_backend().Distribution is _Dist
+
+
+uses_pkg_resources = _uses_pkg_resources()
+
+if uses_pkg_resources:
+    from operator import methodcaller
+
+    from pip._vendor.pkg_resources import Distribution
+
+    dist_requires = cast(
+        Callable[[Distribution], Iterator[Requirement]], methodcaller("requires")
+    )
+else:
+    from pip._internal.metadata import select_backend
+
+    Distribution = select_backend().Distribution
+
+    def dist_requires(dist: "Distribution") -> Iterator[Requirement]:
+        return map(Requirement, dist.requires or ())

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -10,10 +10,10 @@ from pip._internal.commands import create_command
 from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_environment
-from pip._vendor.pkg_resources import Distribution
 
 from .. import sync
 from .._compat import IS_CLICK_VER_8_PLUS, parse_requirements
+from .._compat.pip_compat import Distribution
 from ..exceptions import PipToolsError
 from ..logging import log
 from ..repositories import PyPIRepository
@@ -275,7 +275,6 @@ def _get_installed_distributions(
     paths: Optional[List[str]] = None,
 ) -> List[Distribution]:
     """Return a list of installed Distribution objects."""
-    from pip._internal.metadata.pkg_resources import Distribution as _Dist
 
     env = get_environment(paths)
     dists = env.iter_installed_distributions(
@@ -283,4 +282,4 @@ def _get_installed_distributions(
         user_only=user_only,
         skip=[],
     )
-    return [cast(_Dist, dist)._dist for dist in dists]
+    return [cast(Distribution, dist)._dist for dist in dists]

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -19,8 +19,8 @@ import click
 from pip._internal.commands.freeze import DEV_PKGS
 from pip._internal.req import InstallRequirement
 from pip._internal.utils.compat import stdlib_pkgs
-from pip._vendor.pkg_resources import Distribution
 
+from ._compat.pip_compat import Distribution, dist_requires
 from .exceptions import IncompatibleRequirements
 from .logging import log
 from .utils import (
@@ -69,7 +69,7 @@ def dependency_tree(
 
         dependencies.add(key)
 
-        for dep_specifier in v.requires():
+        for dep_specifier in dist_requires(v):
             dep_name = key_from_req(dep_specifier)
             if dep_name in installed_keys:
                 dep = installed_keys[dep_name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from pip._internal.req.constructors import (
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
 
+from piptools._compat.pip_compat import uses_pkg_resources
 from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
 from piptools.repositories import PyPIRepository
@@ -106,6 +107,7 @@ class FakeInstalledDistribution:
     def __init__(self, line, deps=None):
         if deps is None:
             deps = []
+        self.dep_strs = deps
         self.deps = [Requirement.parse(d) for d in deps]
 
         self.req = Requirement.parse(line)
@@ -115,8 +117,18 @@ class FakeInstalledDistribution:
 
         self.version = line.split("==")[1]
 
-    def requires(self):
-        return self.deps
+    # The Distribution interface has changed between pkg_resources and
+    # importlib.metadata.
+    if uses_pkg_resources:
+
+        def requires(self):
+            return self.deps
+
+    else:
+
+        @property
+        def requires(self):
+            return self.dep_strs
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
enabled by pip 22.1 by default on Python 3.11 (or later)

See https://pip.pypa.io/en/stable/news/#v22-1

To fix the failing `CI / Ubuntu / 3.11-dev / latest (push)` row of the test matrix.

Thoughts on adding a row to the test matrix for 3.11 with `_PIP_USE_IMPORTLIB_METADATA = 0` to ensure that that flag is picked up? In theory that's an implementation detail of pip itself.

xref https://github.com/jazzband/pip-tools/pull/1607

##### Contributor checklist

- [x] Provided the tests for the changes. (Existing tests already fail.)
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
