### PR TITLE
Remove duplicate PyPIRepository().finder.find_all_candidates cache

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -428,7 +428,7 @@ class PyPIRepository(BaseRepository):
 
         original_wheel_supported = Wheel.supported
         original_support_index_min = Wheel.support_index_min
-        original_candidates_cache = self.finder.find_all_candidates
+        original_candidates_cache = vars(self.finder).get("find_all_candidates")
 
         Wheel.supported = _wheel_supported
         Wheel.support_index_min = _wheel_support_index_min
@@ -450,7 +450,10 @@ class PyPIRepository(BaseRepository):
         finally:
             Wheel.supported = original_wheel_supported
             Wheel.support_index_min = original_support_index_min
-            self.finder.find_all_candidates = original_candidates_cache
+            if original_candidates_cache is not None:
+                self.finder.find_all_candidates = original_candidates_cache
+            else:
+                del self.finder.find_all_candidates
 
 
 @contextmanager

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -287,7 +287,7 @@ def test_get_hashes_from_pypi(from_line, tmpdir, project_data, expected_hashes):
     assert actual_hashes == expected_hashes
 
 
-def test_get_hashes_from_mixed(pip_conf, from_line, tmpdir):
+def test_get_hashes_from_mixed(pip_conf, from_line, tmpdir, monkeypatch):
     """
     Test PyPIRepository.get_hashes() returns hashes from both PyPi and extra indexes/links
     """
@@ -327,14 +327,17 @@ def test_get_hashes_from_mixed(pip_conf, from_line, tmpdir):
                 }
             }
 
-        def find_all_candidates(self, req_name):
-            return all_candidates
-
         def _get_file_hash(self, link):
             return file_hashes[link]
 
+    def mock_find_all_candidates(project_name):
+        return all_candidates
+
     pypi_repository = MockPyPIRepository(
         ["--no-cache-dir"], cache_dir=(tmpdir / "pypi-repo-cache")
+    )
+    monkeypatch.setattr(
+        pypi_repository.finder, "find_all_candidates", mock_find_all_candidates
     )
 
     ireq = from_line(f"{package_name}=={package_version}")


### PR DESCRIPTION
Hi! I believe that `PyPIRepository()._available_candidates_cache` is redundant, as `PackageFinder().find_all_candidates` has been `lru_cache`d since Pip 20.3 (https://github.com/pypa/pip/commit/1dd6d562789b06dc1508212505e32f36bd71d310).

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
