### PR TITLE
Support relative paths and regularize path handling and formatting

### DIFF
--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -53,7 +53,7 @@ def parse_requirements(
                 # This can happen when the url is a relpath with a fragment,
                 # so we try again with the fragment stripped
                 preq_without_fragment = ParsedRequirement(
-                    requirement=re.sub(r"#[^#]+=.+$", "", parsed_req.requirement),
+                    requirement=re.sub(r"#[^#]+$", "", parsed_req.requirement),
                     is_editable=parsed_req.is_editable,
                     comes_from=parsed_req.comes_from,
                     constraint=parsed_req.constraint,
@@ -75,7 +75,7 @@ def parse_requirements(
             fragment = Link(parsed_req.requirement)._parsed_url.fragment
             if fragment:
                 link_with_fragment = Link(
-                    url=f"{ireq.link.url}#{fragment}",
+                    url=f"{ireq.link.url_without_fragment}#{fragment}",
                     comes_from=ireq.link.comes_from,
                     requires_python=ireq.link.requires_python,
                     yanked_reason=ireq.link.yanked_reason,
@@ -87,7 +87,9 @@ def parse_requirements(
 
         # To account for the second, we guess if the path was initially relative and
         # set _was_relative ourselves:
-        bare_path = file_url_schemes_re.sub("", parsed_req.requirement)
+        bare_path = file_url_schemes_re.sub(
+            "", parsed_req.requirement.split(" @ ", 1)[-1]
+        )
         is_win = platform.system() == "Windows"
         if is_win:
             bare_path = bare_path.lstrip("/")

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -1,4 +1,6 @@
 import optparse
+import platform
+import re
 from typing import Callable, Iterable, Iterator, Optional, cast
 
 import pip
@@ -10,8 +12,11 @@ from pip._internal.req.constructors import install_req_from_parsed_requirement
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import Requirement
 
+from ..utils import abs_ireq, working_dir
+
 PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split(".")))
 
+file_url_schemes_re = re.compile(r"^((git|hg|svn|bzr)\+)?file:")
 
 __all__ = [
     "get_build_tracker",
@@ -29,11 +34,36 @@ def parse_requirements(
     options: Optional[optparse.Values] = None,
     constraint: bool = False,
     isolated: bool = False,
+    from_dir: Optional[str] = None,
 ) -> Iterator[InstallRequirement]:
     for parsed_req in _parse_requirements(
         filename, session, finder=finder, options=options, constraint=constraint
     ):
-        yield install_req_from_parsed_requirement(parsed_req, isolated=isolated)
+        # This context manager helps pip locate relative paths specified
+        # with non-URI (non file:) syntax, e.g. '-e ..'
+        with working_dir(from_dir):
+            ireq = install_req_from_parsed_requirement(parsed_req, isolated=isolated)
+
+        # But the resulting ireq is absolute (ahead of schedule),
+        # so abs_ireq will not apply the _was_relative attribute,
+        # which is needed for the writer to use the relpath.
+        a_ireq = abs_ireq(ireq, from_dir)
+
+        # To account for that, we guess if the path was initially relative and
+        # set _was_relative ourselves:
+        bare_path = file_url_schemes_re.sub("", parsed_req.requirement)
+        is_win = platform.system() == "Windows"
+        if is_win:
+            bare_path = bare_path.lstrip("/")
+        if (
+            a_ireq.link is not None
+            and a_ireq.link.scheme.endswith("file")
+            and not bare_path.startswith("/")
+        ):
+            if not (is_win and re.match(r"[a-zA-Z]:", bare_path)):
+                a_ireq._was_relative = True
+
+        yield a_ireq
 
 
 if PIP_VERSION[:2] <= (22, 0):

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -778,4 +778,13 @@ class BacktrackingResolver(BaseResolver):
         if source_ireq is not None and ireq_key not in self.existing_constraints:
             pinned_ireq._source_ireqs = [source_ireq]
 
+        # Preserve _was_relative attribute of local path requirements
+        if pinned_ireq.link.is_file:
+            # Install requirement keys may not match
+            for c in self.constraints:
+                if pinned_ireq.link == c.link:
+                    if hasattr(c, "_was_relative"):
+                        pinned_ireq._was_relative = True
+                    break
+
         return pinned_ireq

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -705,8 +705,8 @@ class BacktrackingResolver(BaseResolver):
         for extras_candidate in extras_candidates:
             project_name = canonicalize_name(extras_candidate.project_name)
             ireq = result_ireqs[project_name]
-            ireq.extras |= extras_candidate.extras
-            ireq.req.extras |= extras_candidate.extras
+            ireq.extras = set(ireq.extras) | set(extras_candidate.extras)
+            ireq.req.extras = set(ireq.req.extras) | set(extras_candidate.extras)
 
         return set(result_ireqs.values())
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -160,6 +160,15 @@ def _get_default_option(option_name: str) -> Any:
     ),
 )
 @click.option(
+    "--write-relative-to-output",
+    is_flag=True,
+    default=False,
+    help=(
+        "Construct relative paths as relative to the output file's parent. "
+        "Will be written as relative to the current folder otherwise."
+    ),
+)
+@click.option(
     "--allow-unsafe/--no-allow-unsafe",
     is_flag=True,
     default=False,
@@ -272,6 +281,7 @@ def cli(
     upgrade: bool,
     upgrade_packages: Tuple[str, ...],
     output_file: Union[LazyFile, IO[Any], None],
+    write_relative_to_output: bool,
     allow_unsafe: bool,
     strip_extras: bool,
     generate_hashes: bool,
@@ -385,6 +395,11 @@ def cli(
             finder=tmp_repository.finder,
             session=tmp_repository.session,
             options=tmp_repository.options,
+            from_dir=(
+                os.path.dirname(os.path.abspath(output_file.name))
+                if write_relative_to_output
+                else None
+            ),
         )
 
         for ireq in filter(is_pinned_requirement, ireqs):
@@ -526,6 +541,7 @@ def cli(
         find_links=repository.finder.find_links,
         emit_find_links=emit_find_links,
         emit_options=emit_options,
+        write_relative_to_output=write_relative_to_output,
     )
     writer.write(
         results=results,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -322,15 +322,15 @@ def cli(
         # An output file must be provided for stdin
         if src_files == ("-",):
             raise click.BadParameter("--output-file is required if input is from stdin")
-        # Use default requirements output file if there is a setup.py the source file
-        elif os.path.basename(src_files[0]) in METADATA_FILENAMES:
-            file_name = os.path.join(
-                os.path.dirname(src_files[0]), DEFAULT_REQUIREMENTS_OUTPUT_FILE
-            )
         # An output file must be provided if there are multiple source files
         elif len(src_files) > 1:
             raise click.BadParameter(
                 "--output-file is required if two or more input files are given."
+            )
+        # Use default requirements output file if there is only a setup.py source file
+        elif os.path.basename(src_files[0]) in METADATA_FILENAMES:
+            file_name = os.path.join(
+                os.path.dirname(src_files[0]), DEFAULT_REQUIREMENTS_OUTPUT_FILE
             )
         # Otherwise derive the output file from the source file
         else:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -316,6 +316,8 @@ def cli(
                 ).format(DEFAULT_REQUIREMENTS_FILE)
             )
 
+    src_files = tuple(src if src == "-" else os.path.abspath(src) for src in src_files)
+
     if not output_file:
         # An output file must be provided for stdin
         if src_files == ("-",):
@@ -332,8 +334,9 @@ def cli(
             )
         # Otherwise derive the output file from the source file
         else:
-            base_name = src_files[0].rsplit(".", 1)[0]
-            file_name = base_name + ".txt"
+            file_name = os.path.splitext(src_files[0])[0] + ".txt"
+            if file_name == src_files[0]:
+                file_name += ".txt"
 
         output_file = click.open_file(file_name, "w+b", atomic=True, lazy=True)
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -28,6 +28,7 @@ from ..utils import (
     drop_extras,
     is_pinned_requirement,
     key_from_ireq,
+    working_dir,
 )
 from ..writer import OutputWriter
 
@@ -169,6 +170,15 @@ def _get_default_option(option_name: str) -> Any:
     ),
 )
 @click.option(
+    "--read-relative-to-input",
+    is_flag=True,
+    default=False,
+    help=(
+        "Resolve relative paths as relative to the input file's parent. "
+        "Will be resolved as relative to the current folder otherwise."
+    ),
+)
+@click.option(
     "--allow-unsafe/--no-allow-unsafe",
     is_flag=True,
     default=False,
@@ -282,6 +292,7 @@ def cli(
     upgrade_packages: Tuple[str, ...],
     output_file: Union[LazyFile, IO[Any], None],
     write_relative_to_output: bool,
+    read_relative_to_input: bool,
     allow_unsafe: bool,
     strip_extras: bool,
     generate_hashes: bool,
@@ -426,8 +437,7 @@ def cli(
         if src_file == "-":
             # pip requires filenames and not files. Since we want to support
             # piping from stdin, we need to briefly save the input from stdin
-            # to a temporary file and have pip read that.  also used for
-            # reading requirements from install_requires in setup.py.
+            # to a temporary file and have pip read that.
             tmpfile = tempfile.NamedTemporaryFile(mode="wt", delete=False)
             tmpfile.write(sys.stdin.read())
             comes_from = "-r -"
@@ -453,13 +463,19 @@ def cli(
                 log.error(str(e))
                 log.error(f"Failed to parse {os.path.abspath(src_file)}")
                 sys.exit(2)
-            comes_from = f"{metadata.get_all('Name')[0]} ({src_file})"
-            constraints.extend(
-                [
-                    install_req_from_line(req, comes_from=comes_from)
-                    for req in metadata.get_all("Requires-Dist") or []
-                ]
-            )
+            with working_dir(os.path.dirname(os.path.abspath(output_file.name))):
+                comes_from = (
+                    f"{metadata.get_all('Name')[0]} ({os.path.relpath(src_file)})"
+                )
+            with working_dir(
+                os.path.dirname(src_file) if read_relative_to_input else None
+            ):
+                constraints.extend(
+                    [
+                        install_req_from_line(req, comes_from=comes_from)
+                        for req in metadata.get_all("Requires-Dist") or []
+                    ]
+                )
         else:
             constraints.extend(
                 parse_requirements(
@@ -467,6 +483,9 @@ def cli(
                     finder=repository.finder,
                     session=repository.session,
                     options=repository.options,
+                    from_dir=(
+                        os.path.dirname(src_file) if read_relative_to_input else None
+                    ),
                 )
             )
 

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -71,6 +71,15 @@ version_option_kwargs = {"package_name": "pip-tools"} if IS_CLICK_VER_8_PLUS els
     help="Ignore package index (only looking at --find-links URLs instead)",
 )
 @click.option(
+    "--read-relative-to-input",
+    is_flag=True,
+    default=False,
+    help=(
+        "Resolve relative paths as relative to the input file's parent. "
+        "Will be resolved as relative to the current folder otherwise."
+    ),
+)
+@click.option(
     "--python-executable",
     help="Custom python executable path if targeting an environment other than current.",
 )
@@ -96,6 +105,7 @@ def cli(
     extra_index_url: Tuple[str, ...],
     trusted_host: Tuple[str, ...],
     no_index: bool,
+    read_relative_to_input: bool,
     python_executable: Optional[str],
     verbose: int,
     quiet: int,
@@ -139,7 +149,17 @@ def cli(
     # Parse requirements file. Note, all options inside requirements file
     # will be collected by the finder.
     requirements = flat_map(
-        lambda src: parse_requirements(src, finder=finder, session=session), src_files
+        lambda src: parse_requirements(
+            src,
+            finder=finder,
+            session=session,
+            from_dir=(
+                os.path.dirname(os.path.abspath(src))
+                if read_relative_to_input
+                else os.getcwd()
+            ),
+        ),
+        src_files,
     )
 
     try:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -203,7 +203,8 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
     # We need to remove the egg if it exists and keep the rest of the fragments.
     extras = f"[{','.join(sorted(ireq.extras))}]" if ireq.extras else ""
     return (
-        f"{ireq.name.lower()}{extras} @ {ireq.link.url_without_fragment}"
+        f"{canonicalize_name(ireq.name)}{extras} @ "
+        f"{ireq.link.url_without_fragment}"
         f"{fragment_string(ireq, omit_egg=True)}"
     )
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 import shlex
-import typing
+from contextlib import contextmanager
 from typing import (
     Any,
     Callable,
@@ -62,9 +62,7 @@ def key_from_ireq(ireq: InstallRequirement) -> str:
         return key_from_req(ireq.req)
 
 
-def key_from_req(
-    req: typing.Union[InstallRequirement, Distribution, Requirement]
-) -> str:
+def key_from_req(req: Union[InstallRequirement, Distribution, Requirement]) -> str:
     """Get an all-lowercase version of the requirement's name."""
     if hasattr(req, "key"):
         # from pkg_resources, such as installed dists for pip-sync
@@ -349,6 +347,24 @@ def get_hashes_from_ireq(ireq: InstallRequirement) -> Set[str]:
         for hash_ in hexdigests:
             result.add(f"{algorithm}:{hash_}")
     return result
+
+
+@contextmanager
+def working_dir(folder: Optional[str]) -> Iterator[None]:
+    """Change the current directory within the context, then change it back."""
+    if folder is None:
+        yield
+    else:
+        try:
+            original_dir = os.getcwd()
+            # The os and pathlib modules are incapable of returning an absolute path to the
+            # current directory without also resolving symlinks, so this is the realpath.
+            # This can be avoided on some systems with, e.g. os.environ["PWD"], but we'll
+            # not go there if we don't have to.
+            os.chdir(os.path.abspath(folder))
+            yield
+        finally:
+            os.chdir(original_dir)
 
 
 def get_compile_command(click_ctx: click.Context) -> str:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -581,6 +581,19 @@ def copy_install_requirement(
     if "req" not in kwargs:
         kwargs["req"] = copy.deepcopy(template.req)
 
+    # Copy extras from a new link if appropriate.
+    if (
+        not kwargs["extras"]
+        and kwargs["link"]
+        and kwargs["link"]._parsed_url.fragment.endswith("]")
+    ):
+        kwargs["extras"] = tuple(
+            map(
+                str.strip,
+                kwargs["link"]._parsed_url.fragment.rsplit("[", 1)[-1][:-1].split(","),
+            )
+        )
+
     ireq = InstallRequirement(**kwargs)
 
     # If the original_link was None, keep it so. Passing `link` as an

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -110,9 +110,7 @@ def is_url_requirement(ireq: InstallRequirement) -> bool:
     return bool(ireq.original_link)
 
 
-def fragment_string(
-    ireq: InstallRequirement, omit_egg: bool = False, omit_extras: bool = True
-) -> str:
+def fragment_string(ireq: InstallRequirement, omit_egg: bool = False) -> str:
     """
     Return a string like "#egg=pkgname&subdirectory=folder", or "".
     """
@@ -123,10 +121,9 @@ def fragment_string(
         fragment = re.sub(r"[#&]egg=[^#&]+", "", fragment).lstrip("#&")
         if fragment:
             fragment = f"#{fragment}"
-    if omit_extras:
-        fragment = re.sub(r"\[[^\]]+\]$", "", fragment).lstrip("#")
-        if fragment:
-            fragment = f"#{fragment}"
+    fragment = re.sub(r"\[[^\]]+\]$", "", fragment).lstrip("#")
+    if fragment:
+        fragment = f"#{fragment}"
     return fragment
 
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -194,21 +194,10 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
 
     # If we get here then we have a requirement that supports direct reference.
     # We need to remove the egg if it exists and keep the rest of the fragments.
-    direct_reference = f"{ireq.name.lower()} @ {ireq.link.url_without_fragment}"
-    fragments = []
-
-    # Check if there is any fragment to add to the URI.
-    if ireq.link.subdirectory_fragment:
-        fragments.append(f"subdirectory={ireq.link.subdirectory_fragment}")
-
-    if ireq.link.has_hash:
-        fragments.append(f"{ireq.link.hash_name}={ireq.link.hash}")
-
-    # Then add the fragments into the URI, if any.
-    if fragments:
-        direct_reference += f"#{'&'.join(fragments)}"
-
-    return direct_reference
+    return (
+        f"{ireq.name.lower()} @ {ireq.link.url_without_fragment}"
+        f"{fragment_string(ireq, omit_egg=True)}"
+    )
 
 
 def format_specifier(ireq: InstallRequirement) -> str:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -26,6 +26,7 @@ from click.utils import LazyFile
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
+from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import is_url
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.specifiers import SpecifierSet
@@ -109,25 +110,64 @@ def is_url_requirement(ireq: InstallRequirement) -> bool:
     return bool(ireq.original_link)
 
 
+def fragment_string(ireq: InstallRequirement, omit_egg: bool = False) -> str:
+    """
+    Return a string like "#egg=pkgname&subdirectory=folder", or "".
+    """
+    if ireq.link is None or not ireq.link._parsed_url.fragment:
+        return ""
+    fragment = f"#{ireq.link._parsed_url.fragment.replace(os.path.sep, '/')}"
+    if omit_egg:
+        fragment = re.sub(r"[#&]egg=[^#&]+", "", fragment).lstrip("#&")
+        if fragment:
+            fragment = f"#{fragment}"
+    return fragment
+
+
 def format_requirement(
     ireq: InstallRequirement,
     marker: Optional[Marker] = None,
     hashes: Optional[Set[str]] = None,
+    from_dir: Optional[str] = None,
 ) -> str:
     """
     Generic formatter for pretty printing InstallRequirements to the terminal
     in a less verbose way than using its `__str__` method.
     """
-    if ireq.editable:
-        line = f"-e {ireq.link.url}"
-    elif is_url_requirement(ireq):
-        line = _build_direct_reference_best_efforts(ireq)
-    else:
+    if not is_url_requirement(ireq):
         # Canonicalize the requirement name
         # https://packaging.pypa.io/en/latest/utils.html#packaging.utils.canonicalize_name
         req = copy.copy(ireq.req)
         req.name = canonicalize_name(req.name)
         line = str(req)
+    elif not ireq.link.is_file:
+        line = (
+            f"-e {ireq.link.url}"
+            if ireq.editable
+            else _build_direct_reference_best_efforts(ireq)
+        )
+        # pip doesn't support relative paths in git+file scheme urls,
+        # for which ireq.link.is_file == False
+    elif not from_dir:
+        line = (
+            f"-e {path_to_url(ireq.local_file_path)}"
+            if ireq.editable
+            else _build_direct_reference_best_efforts(ireq)
+        )
+    else:
+        try:
+            path_url = "file:" + os.path.relpath(
+                ireq.local_file_path, from_dir
+            ).replace(os.path.sep, "/")
+        except ValueError:
+            # On Windows, a relative path is not always possible (no common ancestor)
+            line = (
+                f"-e {path_to_url(ireq.local_file_path)}"
+                if ireq.editable
+                else _build_direct_reference_best_efforts(ireq)
+            )
+        else:
+            line = f"{'-e ' if ireq.editable else ''}{path_url}{fragment_string(ireq)}"
 
     if marker:
         line = f"{line} ; {marker}"

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -3,6 +3,7 @@ import copy
 import itertools
 import json
 import os
+import platform
 import re
 import shlex
 from contextlib import contextmanager
@@ -23,10 +24,11 @@ from typing import (
 
 import click
 from click.utils import LazyFile
+from pip._internal.models.link import Link
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
-from pip._internal.utils.urls import path_to_url
+from pip._internal.utils.urls import path_to_url, url_to_path
 from pip._internal.vcs import is_url
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.specifiers import SpecifierSet
@@ -367,6 +369,52 @@ def working_dir(folder: Optional[str]) -> Iterator[None]:
             os.chdir(original_dir)
 
 
+def abs_ireq(
+    ireq: InstallRequirement, from_dir: Optional[str] = None
+) -> InstallRequirement:
+    """
+    Return the given InstallRequirement if its source isn't a relative path;
+    Otherwise, return a new one with the relative path rewritten as absolute.
+
+    In this case, an extra attribute is added: _was_relative,
+    which is always True when present at all.
+    """
+    # We check ireq.link.scheme rather than ireq.link.is_file,
+    # to also match <vcs>+file schemes
+    if ireq.link is None or not ireq.link.scheme.endswith("file"):
+        return ireq
+
+    naive_path = ireq.local_file_path or ireq.link.path
+    if platform.system() == "Windows":
+        naive_path = naive_path.lstrip("/")
+
+    with working_dir(from_dir):
+        url = path_to_url(naive_path).replace("%40", "@")
+
+    if (
+        os.path.normpath(naive_path).lower()
+        == os.path.normpath(url_to_path(url)).lower()
+    ):
+        return ireq
+
+    abs_url = f"{url}{fragment_string(ireq)}"
+    if "+" in ireq.link.scheme:
+        abs_url = f"{ireq.link.scheme.split('+')[0]}+{abs_url}"
+
+    abs_link = Link(
+        url=abs_url,
+        comes_from=ireq.link.comes_from,
+        requires_python=ireq.link.requires_python,
+        yanked_reason=ireq.link.yanked_reason,
+        cache_link_parsing=ireq.link.cache_link_parsing,
+    )
+
+    a_ireq = copy_install_requirement(ireq, link=abs_link)
+    a_ireq._was_relative = True
+
+    return a_ireq
+
+
 def get_compile_command(click_ctx: click.Context) -> str:
     """
     Returns a normalized compile command depending on cli context.
@@ -539,5 +587,9 @@ def copy_install_requirement(
     ireq.original_link = (
         template.original_link if original_link is None else original_link
     )
+
+    for custom_attr in ("_source_ireqs", "_was_relative"):
+        if hasattr(template, custom_attr):
+            setattr(ireq, custom_attr, getattr(template, custom_attr))
 
     return ireq

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -154,7 +154,14 @@ def format_requirement(
     else:
         fragment = fragment_string(ireq)
         extras = f"[{','.join(sorted(ireq.extras))}]" if ireq.extras else ""
-        delimiter = "#" if extras and not fragment else ""
+        # pip install needs different relpath formats, depending on extras and fragments:
+        # https://github.com/jazzband/pip-tools/pull/1329#issuecomment-1056409415
+        if fragment or not extras:
+            prefix = "file:"
+            delimiter = ""
+        else:
+            prefix = ""
+            delimiter = "#"
         if not from_dir:
             line = (
                 f"-e {path_to_url(ireq.local_file_path)}{fragment}{delimiter}{extras}"
@@ -163,9 +170,9 @@ def format_requirement(
             )
         else:
             try:
-                path_url = "file:" + os.path.relpath(
-                    ireq.local_file_path, from_dir
-                ).replace(os.path.sep, "/")
+                relpath = os.path.relpath(ireq.local_file_path, from_dir).replace(
+                    os.path.sep, "/"
+                )
             except ValueError:
                 # On Windows, a relative path is not always possible (no common ancestor)
                 line = (
@@ -174,7 +181,9 @@ def format_requirement(
                     else _build_direct_reference_best_efforts(ireq)
                 )
             else:
-                line = f"{'-e ' if ireq.editable else ''}{path_url}{fragment}{delimiter}{extras}"
+                if not prefix and not relpath.startswith("."):
+                    prefix = "./"
+                line = f"{'-e ' if ireq.editable else ''}{prefix}{relpath}{fragment}{extras}"
 
     if marker:
         line = f"{line} ; {marker}"

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -194,8 +194,9 @@ def _build_direct_reference_best_efforts(ireq: InstallRequirement) -> str:
 
     # If we get here then we have a requirement that supports direct reference.
     # We need to remove the egg if it exists and keep the rest of the fragments.
+    extras = f"[{','.join(sorted(ireq.extras))}]" if ireq.extras else ""
     return (
-        f"{ireq.name.lower()} @ {ireq.link.url_without_fragment}"
+        f"{ireq.name.lower()}{extras} @ {ireq.link.url_without_fragment}"
         f"{fragment_string(ireq, omit_egg=True)}"
     )
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+from contextlib import suppress
 from itertools import chain
 from typing import (
     BinaryIO,
@@ -31,6 +32,7 @@ from .utils import (
     get_compile_command,
     key_from_ireq,
     strip_extras,
+    working_dir,
 )
 
 MESSAGE_UNHASHED_PACKAGE = comment(
@@ -55,13 +57,38 @@ MESSAGE_UNINSTALLABLE = (
 )
 
 
-strip_comes_from_line_re = re.compile(r" \(line \d+\)$")
+comes_from_line_re = re.compile(
+    r"^(?P<opts>-[rc]) (?P<path>.+)(?P<line_num> \(line \d+\))$"
+)
+
+comes_from_line_project_re = re.compile(
+    r"^(?P<name>.+) \((?P<path>.+(/|\\)(?P<filename>setup\.(py|cfg)|pyproject\.toml))\)$"
+)
 
 
-def _comes_from_as_string(comes_from: Union[str, InstallRequirement]) -> str:
-    if isinstance(comes_from, str):
-        return strip_comes_from_line_re.sub("", comes_from)
-    return cast(str, canonicalize_name(key_from_ireq(comes_from)))
+def _comes_from_as_string(
+    comes_from: Union[str, InstallRequirement], from_dir: Optional[str] = None
+) -> str:
+    if not isinstance(comes_from, str):
+        return cast(str, canonicalize_name(key_from_ireq(comes_from)))
+
+    match = comes_from_line_re.search(comes_from)
+    if match:
+        with working_dir(from_dir):
+            with suppress(ValueError):
+                return f"{match['opts']} {os.path.relpath(match['path'])}"
+            # ValueError: it's impossible to construct the relative path
+        return f"{match['opts']} {match['path']}"
+
+    match = comes_from_line_project_re.search(comes_from)
+    if match:
+        with working_dir(from_dir):
+            with suppress(ValueError):
+                return f"{match['name']} ({os.path.relpath(match['path'])})"
+            # ValueError: it's impossible to construct the relative path
+        return f"{match['name']} ({match['path']})"
+
+    return comes_from
 
 
 def annotation_style_split(required_by: Set[str]) -> str:

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -300,8 +300,12 @@ class OutputWriter:
         hashes: Optional[Dict[InstallRequirement, Set[str]]] = None,
     ) -> str:
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
-
-        line = format_requirement(ireq, marker=marker, hashes=ireq_hashes)
+        line = format_requirement(
+            ireq,
+            marker=marker,
+            hashes=ireq_hashes,
+            from_dir=(os.getcwd() if hasattr(ireq, "_was_relative") else None),
+        )
         if self.strip_extras:
             line = strip_extras(line)
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -302,11 +302,12 @@ class OutputWriter:
         hashes: Optional[Dict[InstallRequirement, Set[str]]] = None,
     ) -> str:
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
-        from_dir = (
+        out_dir = (
             os.getcwd()
-            if not self.write_relative_to_output or self.dst_file.name == "-"
+            if self.dst_file.name == "-"
             else os.path.dirname(os.path.abspath(self.dst_file.name))
         )
+        from_dir = out_dir if self.write_relative_to_output else os.getcwd()
         line = format_requirement(
             ireq,
             marker=marker,
@@ -323,13 +324,13 @@ class OutputWriter:
         required_by = set()
         if hasattr(ireq, "_source_ireqs"):
             required_by |= {
-                _comes_from_as_string(src_ireq.comes_from, from_dir=from_dir)
+                _comes_from_as_string(src_ireq.comes_from, from_dir=out_dir)
                 for src_ireq in ireq._source_ireqs
                 if src_ireq.comes_from
             }
 
         if ireq.comes_from:
-            required_by.add(_comes_from_as_string(ireq.comes_from, from_dir=from_dir))
+            required_by.add(_comes_from_as_string(ireq.comes_from, from_dir=out_dir))
 
         required_by |= set(getattr(ireq, "_required_by", set()))
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1412,6 +1412,58 @@ def test_annotate_option(pip_conf, runner, options, expected):
     assert out.stderr == dedent(expected)
 
 
+@pytest.mark.network
+@pytest.mark.parametrize("to_stdout", (True, False))
+@pytest.mark.parametrize(
+    "flags",
+    (
+        (),
+        ("--write-relative-to-output",),
+        ("--read-relative-to-input",),
+        ("--write-relative-to-output", "--read-relative-to-input"),
+    ),
+)
+@pytest.mark.parametrize(
+    ("input_filename", "input_content", "expected"),
+    (
+        ("requirements.in", "small-fake-a==0.1", " # via -r {}"),
+        (
+            "setup.py",
+            (
+                "from setuptools import setup\n"
+                "setup(name='fake-setuptools-a', install_requires=['small-fake-a==0.1'])"
+            ),
+            " # via fake-setuptools-a ({})",
+        ),
+    ),
+    ids=("requirements.in", "setup.py"),
+)
+def test_annotation_relative_paths(
+    runner, tmp_path, input_filename, input_content, expected, flags, to_stdout
+):
+    """
+    Annotations referencing files use paths relative to the output file.
+    """
+    run_dir = tmp_path
+
+    in_path = tmp_path / input_filename
+    in_path.write_text(input_content)
+
+    txt_path = tmp_path / "deeper" / "requirements.txt"
+    txt_path.parent.mkdir(parents=True, exist_ok=True)
+
+    output = "-" if to_stdout else str(txt_path)
+
+    with working_dir(run_dir):
+        out = runner.invoke(
+            cli,
+            ["--find-links", MINIMAL_WHEELS_PATH, "-o", output, *flags, str(in_path)],
+        )
+        assert out.exit_code == 0
+        with working_dir(None if to_stdout else txt_path.parent):
+            assert expected.format(os.path.relpath(in_path)) in out.stderr
+
+
 @pytest.mark.parametrize(
     ("option", "expected"),
     (

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -739,7 +739,10 @@ def test_direct_reference_with_extras(runner):
         )
     out = runner.invoke(cli, ["-n", "--rebuild"])
     assert out.exit_code == 0
-    assert "pip-tools @ git+https://github.com/jazzband/pip-tools@6.2.0" in out.stderr
+    assert (
+        "pip-tools[coverage,testing] @ git+https://github.com/jazzband/pip-tools@6.2.0"
+        in out.stderr
+    )
     assert "pytest==" in out.stderr
     assert "pytest-cov==" in out.stderr
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -661,6 +661,64 @@ def test_local_file_uri_package(
     assert dependency in out.stderr
 
 
+@pytest.mark.parametrize(
+    ("line", "rewritten_line"),
+    (
+        pytest.param(
+            "./small_fake_a",
+            "file:small_fake_a",
+            id="relative path",
+        ),
+        pytest.param(
+            "./small_fake_with_extras[dev,test]",
+            "file:small_fake_with_extras#[dev,test]",
+            id="relative path with extras",
+        ),
+        pytest.param(
+            "./small_fake_a#egg=name",
+            "file:small_fake_a#egg=name",
+            id="relative path with egg",
+        ),
+        pytest.param(
+            "./small_fake_with_extras#egg=name[dev,test]",
+            "file:small_fake_with_extras#egg=name[dev,test]",
+            id="relative path with egg and extras",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_a",
+            f"small-fake-a @ {path_to_url(PACKAGES_PATH)}/small_fake_a",
+            id="absolute path",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_with_extras[dev,test]",
+            (
+                "small-fake-with-extras[dev,test] @ "
+                f"{path_to_url(PACKAGES_PATH)}/small_fake_with_extras"
+            ),
+            id="absolute path with extras",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_a#egg=test",
+            f"small-fake-a @ {path_to_url(PACKAGES_PATH)}/small_fake_a",
+            id="absolute path with egg",
+        ),
+        pytest.param(
+            f"{PACKAGES_PATH}/small_fake_with_extras#egg=name[dev,test]",
+            (
+                "small-fake-with-extras[dev,test] @ "
+                f"{path_to_url(PACKAGES_PATH)}/small_fake_with_extras"
+            ),
+            id="absolute path with egg and extras",
+        ),
+    ),
+)
+def test_local_file_path_package(pip_conf, runner, line, rewritten_line):
+    with working_dir(PACKAGES_PATH):
+        out = runner.invoke(cli, ["--output-file", "-", "-"], input=line)
+    assert out.exit_code == 0
+    assert rewritten_line in out.stderr
+
+
 def test_relative_file_uri_package(pip_conf, runner):
     # Copy wheel into temp dir
     shutil.copy(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -747,6 +747,21 @@ def test_direct_reference_with_extras(runner):
     assert "pytest-cov==" in out.stderr
 
 
+def test_url_package_with_extras(runner):
+    with open("requirements.in", "w") as req_in:
+        req_in.write(
+            "git+https://github.com/jazzband/pip-tools@6.2.0#[testing,coverage]"
+        )
+    out = runner.invoke(cli, ["-n", "--rebuild"])
+    assert out.exit_code == 0
+    assert (
+        "pip-tools[coverage,testing] @ git+https://github.com/jazzband/pip-tools@6.2.0"
+        in out.stderr
+    )
+    assert "pytest==" in out.stderr
+    assert "pytest-cov==" in out.stderr
+
+
 @pytest.mark.parametrize("flags", (("--write-relative-to-output",), ()))
 def test_local_editable_vcs_package(runner, tmp_path, make_package, flags):
     """

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -812,6 +812,43 @@ def test_input_file_without_extension(pip_conf, runner):
     assert os.path.exists("requirements.txt")
 
 
+def test_input_file_with_txt_extension(pip_conf, runner, tmp_path):
+    """
+    Compile an input file ending in .txt to a separate output file (*.txt.txt),
+    without overwriting the input file.
+    """
+    in_file = tmp_path / "requirements.txt"
+    content = "small-fake-a==0.1"
+
+    in_file.write_text(content)
+
+    out = runner.invoke(cli, [str(in_file)])
+
+    assert out.exit_code == 0
+    assert in_file.read_text().strip() == content
+    assert os.path.exists(f"{in_file}.txt")
+
+
+def test_input_file_without_extension_and_dotted_path(pip_conf, runner, tmp_path):
+    """
+    Compile a file without an extension, in a subdir with a dot,
+    into an input-adjacent file with .txt as the extension.
+    """
+    dotted_dir = tmp_path / "some.folder"
+    in_path = tmp_path / dotted_dir / "reqs"
+    txt_path = tmp_path / dotted_dir / "reqs.txt"
+
+    dotted_dir.mkdir(parents=True, exist_ok=True)
+
+    in_path.write_text("small-fake-a==0.1\n")
+
+    out = runner.invoke(cli, [str(in_path)])
+
+    assert out.exit_code == 0
+    assert "small-fake-a==0.1" in out.stderr
+    assert txt_path.exists()
+
+
 def test_ignore_incompatible_existing_pins(pip_conf, runner):
     """
     Successfully compile when existing output pins conflict with input.

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2473,3 +2473,16 @@ def test_resolver_reaches_max_rounds(runner):
     out = runner.invoke(cli, ["--max-rounds", 0])
 
     assert out.exit_code != 0, out
+
+
+@pytest.mark.parametrize("extras", (("dev",), ("test",), ("dev", "test")))
+def test_local_file_uri_with_extras(pip_conf, runner, extras):
+    """
+    Test [extras] notation is included output.
+    """
+    uri = path_to_url(os.path.join(PACKAGES_PATH, "small_fake_with_extras"))
+    out = runner.invoke(
+        cli, ["--output-file", "-", "-"], input=f"{uri}#[{','.join(extras)}]"
+    )
+    assert out.exit_code == 0
+    assert f"small-fake-with-extras[{','.join(sorted(extras))}] @ " in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import sys
+from contextlib import suppress
 from textwrap import dedent
 from unittest import mock
 
@@ -732,6 +733,68 @@ def test_direct_reference_with_extras(runner):
     assert "pip-tools @ git+https://github.com/jazzband/pip-tools@6.2.0" in out.stderr
     assert "pytest==" in out.stderr
     assert "pytest-cov==" in out.stderr
+
+
+@pytest.mark.parametrize("flags", (("--write-relative-to-output",), ()))
+def test_local_editable_vcs_package(runner, tmp_path, make_package, flags):
+    """
+    git+file urls are resolved to use absolute paths, and otherwise remain intact.
+    """
+    name = "fake-git-a"
+    version = "0.1"
+
+    run_dir = tmp_path / "working"
+    in_path = tmp_path / "requirements.in"
+    txt_path = tmp_path / "deep" / "requirements.txt"
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    txt_path.parent.mkdir(parents=True, exist_ok=True)
+
+    pkg_dir = make_package(name=name, version=version)
+    repo_dir = pkg_dir.parents[1]
+
+    with working_dir(repo_dir):
+        fragment = f"#egg={name}&subdirectory={os.path.relpath(pkg_dir)}"
+        for cmd in (
+            ["git", "init", "-q"],
+            ["git", "config", "user.name", "pip-tools"],
+            ["git", "config", "user.email", "pip-tools@example.com"],
+            ["git", "add", "-A"],
+            ["git", "commit", "-q", "-m", version],
+            ["git", "tag", version],
+        ):
+            subprocess.run(cmd, check=True)
+
+    line_abs = f"-e git+{path_to_url(repo_dir)}@{version}{fragment}".replace(
+        os.path.sep, "/"
+    )
+
+    with working_dir(run_dir):
+        line_rel = (
+            f"-e git+file:{os.path.relpath(repo_dir)}@{version}{fragment}".replace(
+                os.path.sep, "/"
+            )
+        )
+
+        in_path.write_text(line_abs)
+
+        out = runner.invoke(
+            cli, ["-o", os.path.relpath(txt_path), *flags, os.path.relpath(in_path)]
+        )
+
+        assert out.exit_code == 0
+        assert line_abs in out.stderr
+
+        in_path.write_text(line_rel)
+
+        with suppress(FileNotFoundError):
+            txt_path.unlink()
+        out = runner.invoke(
+            cli, ["-o", os.path.relpath(txt_path), *flags, os.path.relpath(in_path)]
+        )
+
+        assert out.exit_code == 0
+        assert line_abs in out.stderr
 
 
 def test_input_file_without_extension(pip_conf, runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -671,7 +671,7 @@ def test_local_file_uri_package(
         ),
         pytest.param(
             "./small_fake_with_extras[dev,test]",
-            "file:small_fake_with_extras#[dev,test]",
+            "./small_fake_with_extras[dev,test]",
             id="relative path with extras",
         ),
         pytest.param(

--- a/tests/test_data/packages/small_fake_with_extras/setup.py
+++ b/tests/test_data/packages/small_fake_with_extras/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name="small_fake_with_extras",
+    version=0.1,
+    install_requires=["small-fake-a", "small-fake-b"],
+    extras_require={
+        "dev": ["small-fake-a"],
+        "test": ["small-fake-b"],
+    },
+)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import logging
 import operator
 import os
 import platform
+import re
 import shlex
 import sys
 
@@ -144,7 +145,9 @@ def test_format_requirement_editable_vcs_with_password(from_editable):
 
 def test_format_requirement_editable_local_path(from_editable):
     ireq = from_editable("file:///home/user/package")
-    assert format_requirement(ireq) == "-e file:///home/user/package"
+    assert re.match(
+        r"-e file:///([a-zA-Z]:/)?home/user/package$", format_requirement(ireq)
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ from piptools.utils import (
     key_from_ireq,
     lookup_table,
     lookup_table_from_tuples,
+    working_dir,
 )
 
 
@@ -540,3 +541,22 @@ def test_get_sys_path_for_python_executable():
     # not testing for equality, because pytest adds extra paths into current sys.path
     for path in result:
         assert path in sys.path
+
+
+@pytest.mark.parametrize(
+    ("folder_name", "use_abspath"),
+    (("subfolder", True), ("subfolder", False), (None, False)),
+)
+def test_working_dir(tmpdir_cwd, folder_name, use_abspath):
+    if folder_name is not None:
+        os.mkdir(folder_name)
+        expected_within = os.path.abspath(folder_name)
+    else:
+        expected_within = tmpdir_cwd
+    if use_abspath:
+        folder_name = expected_within
+
+    with working_dir(folder_name):
+        assert os.getcwd() == expected_within
+
+    assert os.getcwd() == tmpdir_cwd

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -47,6 +47,7 @@ def writer(tmpdir_cwd):
             emit_find_links=True,
             strip_extras=False,
             emit_options=True,
+            write_relative_to_output=False,
         )
         yield writer
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -68,6 +68,20 @@ def test_format_requirement_annotation(from_line, writer):
     assert writer._format_requirement(ireq) == "test==1.2\n    " + comment("# via xyz")
 
 
+def test_format_requirement_annotation_source_ireqs(from_line, writer):
+    "Annotations credit an ireq's source_ireq's comes_from attribute."
+    ireq = from_line("test==1.2")
+    ireq.comes_from = "xyz"
+
+    ireq2 = from_line("testwithsrc==3.0")
+    ireq2._source_ireqs = [ireq]
+
+    assert (
+        writer._format_requirement(ireq2)
+        == f"testwithsrc==3.0\n    {comment('# via xyz')}"
+    )
+
+
 def test_format_requirement_annotation_lower_case(from_line, writer):
     ireq = from_line("Test==1.2")
     ireq.comes_from = "xyz"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -69,6 +69,23 @@ def test_format_requirement_annotation(from_line, writer):
     assert writer._format_requirement(ireq) == "test==1.2\n    " + comment("# via xyz")
 
 
+@pytest.mark.parametrize(
+    ("comes_from", "expected"),
+    (
+        ("xyz (z:/pyproject.toml)", "# via xyz (z:/pyproject.toml)"),
+        ("-r z:/pyproject.toml (line 1)", "# via -r z:/pyproject.toml"),
+    ),
+)
+def test_format_requirement_annotation_impossible_relative_path(
+    from_line, writer, comes_from, expected
+):
+    "A relative path can't be constructed across drives on a Windows filesystem."
+    ireq = from_line("test==1.2")
+    ireq.comes_from = comes_from
+
+    assert writer._format_requirement(ireq) == "test==1.2\n    " + comment(expected)
+
+
 def test_format_requirement_annotation_source_ireqs(from_line, writer):
     "Annotations credit an ireq's source_ireq's comes_from attribute."
     ireq = from_line("test==1.2")


### PR DESCRIPTION
This replaces #1329, rebased with care on top of pip-tools 6.8.0.

**Changelog-friendly one-liners**:
- Support relative paths in input files, as long as they lead with `file:`, `<vcs>+file:`, or `.`.
- Relative paths in input files become relative paths in output files.
- `pip-compile` will interpret relative paths in an input file as relative to that input file, rather than the current folder, if `--read-relative-to-input` is passed.
- `pip-compile` will reconstruct relative req paths as relative to the output file, rather than the current folder, if `--write-relative-to-output` is passed.
- `pip-sync` will interpret relative paths in an input file as relative to that input file, rather than the current folder, if `--read-relative-to-input` is passed.
- Annotation paths are now relative to the output file.
- Don't overwrite an input file ending in '.txt' when deriving the output file path.
- Don't confuse dots in folder names with file extensions when deriving the output file path.
- Include extras more reliably in output lines, like `pkg[extra1,extra2]`.

---

- Fixes:
  - #204
  - #1107
  - #1165
- Related: 
  - #453 (Not addressed in this PR)
  - #673 
  - #702
  - #1067
  - pypa/pip#1289
  - pypa/pip#6112
  - pypa/pip#6247
  - pypa/pip#6276
  - pypa/pip#6658
  - pypa/pip#6905
  - pypa/pip#7650
  - pypa/pip#8035
  - pypa/pip#8765
  - pypa/pip#8828
  - pypa/packaging#264

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
