### PR TITLE
docs: Fix a few typos

### DIFF
--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -50,8 +50,8 @@ else:
 
 # The Distribution interface has changed between pkg_resources and
 # importlib.metadata, so this compat layer allows for a consistent access
-# pattern. In pip 22.1, importlib.metdata became the default on Python 3.11
-# (and later), but is overrideable. `select_backend` returns what's being used.
+# pattern. In pip 22.1, importlib.metadata became the default on Python 3.11
+# (and later), but is overridable. `select_backend` returns what's being used.
 
 
 def _uses_pkg_resources() -> bool:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1603,7 +1603,7 @@ def test_upgrade_packages_option_subdependency(
     pip_conf, runner, current_package, upgraded_package
 ):
     """
-    Test that pip-compile --upgrade-package/-P upgrades/dpwngrades subdependencies.
+    Test that pip-compile --upgrade-package/-P upgrades/downgrades subdependencies.
     """
 
     with open("requirements.in", "w") as reqs:


### PR DESCRIPTION
There are small typos in:
- piptools/_compat/pip_compat.py
- tests/test_cli_compile.py

Fixes:
- Should read `overridable` rather than `overrideable`.
- Should read `metadata` rather than `metdata`.
- Should read `downgrades` rather than `dpwngrades`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md