### PR TITLE
Address deprecated pytest `--strict` option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     piplatest: pip
     pipmain: -e git+https://github.com/pypa/pip.git@main#egg=pip
 setenv =
-    coverage: PYTEST_ADDOPTS=--strict --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
+    coverage: PYTEST_ADDOPTS=--strict-markers --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
 commands_pre =
     piplatest: python -m pip install -U pip
     pip --version


### PR DESCRIPTION
https://docs.pytest.org/en/7.1.x/deprecations.html?highlight=strict#the-strict-command-line-option

```
PytestRemovedIn8Warning: The --strict option is deprecated, use --strict-markers instead.
```

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
