### PR TITLE
Add regression test for GH-1647

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import subprocess
 import sys
 from contextlib import contextmanager
@@ -423,3 +424,13 @@ def fake_dists(tmpdir, make_package, make_wheel):
     for pkg in pkgs:
         make_wheel(pkg, dists_path)
     return dists_path
+
+
+@pytest.fixture
+def venv(tmp_path):
+    """Create a temporary venv and get the path of its directory of executables."""
+    subprocess.run(
+        [sys.executable, "-m", "venv", os.fspath(tmp_path)],
+        check=True,
+    )
+    return tmp_path / ("Scripts" if platform.system() == "Windows" else "bin")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -511,6 +511,50 @@ def test_editable_package_vcs(runner):
     assert "click" in out.stderr  # dependency of pip-tools
 
 
+@pytest.mark.network
+def test_compile_cached_vcs_package(runner, venv):
+    """
+    Test pip-compile doesn't write local paths for cached wheels of VCS packages.
+
+    Regression test for issue GH-1647.
+    """
+    vcs_package = (
+        "typing-extensions @ git+https://github.com/python/typing_extensions@"
+        "9c0759a260fe126210a1e2026720000a3c40a919"
+    )
+    vcs_wheel_prefix = "typing_extensions-4.3.0-py3"
+
+    # Install and cache VCS package.
+    subprocess.run(
+        [os.fspath(venv / "python"), "-m" "pip", "install", vcs_package],
+        check=True,
+    )
+    assert (
+        vcs_wheel_prefix
+        in subprocess.run(
+            [
+                sys.executable,
+                "-m" "pip",
+                "cache",
+                "list",
+                "--format=abspath",
+                vcs_wheel_prefix,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+
+    with open("requirements.in", "w") as req_in:
+        req_in.write(vcs_package)
+
+    out = runner.invoke(cli, ["--no-header", "--no-emit-options", "--no-annotate"])
+
+    assert out.exit_code == 0, out
+    assert vcs_package == out.stderr.strip()
+
+
 @legacy_resolver_only
 def test_locally_available_editable_package_is_not_archived_in_cache_dir(
     pip_conf, tmpdir, runner


### PR DESCRIPTION
Closes #1686.

This asserts that the package is cached to avoid the problem with the prior test (where it passed when it should have failed—see https://github.com/jazzband/pip-tools/pull/1649#discussion_r939591090).

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
