### PR TITLE
Update pip-tools version in the README's pre-commit examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -417,7 +417,7 @@ Sample ``.pre-commit-config.yaml``:
 
     repos:
       - repo: https://github.com/jazzband/pip-tools
-        rev: 6.3.0
+        rev: 6.9.0
         hooks:
           - id: pip-compile
 
@@ -427,7 +427,7 @@ You might want to customize ``pip-compile`` args by configuring ``args`` and/or 
 
     repos:
       - repo: https://github.com/jazzband/pip-tools
-        rev: 6.3.0
+        rev: 6.9.0
         hooks:
           - id: pip-compile
             files: ^requirements/production\.(in|txt)$
@@ -439,7 +439,7 @@ If you have multiple requirement files make sure you create a hook for each file
 
     repos:
       - repo: https://github.com/jazzband/pip-tools
-        rev: 5.3.1
+        rev: 6.9.0
         hooks:
           - id: pip-compile
             name: pip-compile setup.py


### PR DESCRIPTION
The version mentioned there causes an error on the pre-commit, which is fixed on the current version. 👀 

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
