### PR TITLE
Add support for Python 3.11 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           - Windows
           - macOS
         python-version:
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
@@ -50,9 +51,6 @@ jobs:
           - "latest"
           - "previous"
         include:
-          - os: Ubuntu
-            python-version: 3.11-dev
-            pip-version: latest
           - os: Ubuntu
             python-version: 3.7
             pip-version: main

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: System :: Systems Administration


### PR DESCRIPTION
<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Add the Trove classifier.

For what version range should 3.11 be added in this table?

https://github.com/jazzband/pip-tools#versions-and-compatibility