### PR TITLE
Prompt user to use the backtracking resolver on errors

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -548,7 +548,9 @@ def cli(
     except NoCandidateFound as e:
         if resolver_cls == LegacyResolver:
             log.error(
-                "Using legacy resolver.  Consider using backtracking resolver with --resolver=backtracking"
+                "Using legacy resolver. "
+                "Consider using backtracking resolver with "
+                "`--resolver=backtracking`."
             )
 
         log.error(str(e))

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -16,7 +16,7 @@ from pip._internal.utils.misc import redact_auth_from_url
 
 from .._compat import IS_CLICK_VER_8_PLUS, parse_requirements
 from ..cache import DependencyCache
-from ..exceptions import PipToolsError
+from ..exceptions import PipToolsError, NoCandidateFound
 from ..locations import CACHE_DIR
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
@@ -545,6 +545,12 @@ def cli(
         )
         results = resolver.resolve(max_rounds=max_rounds)
         hashes = resolver.resolve_hashes(results) if generate_hashes else None
+    except NoCandidateFound as e:
+        if resolver_cls == LegacyResolver:
+            log.error("Using legacy resolver.  Consider using backtracking resolver with --resolver=backtracking")
+
+        log.error(str(e))
+        sys.exit(2)
     except PipToolsError as e:
         log.error(str(e))
         sys.exit(2)

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -6,13 +6,14 @@ import tempfile
 from typing import IO, Any, BinaryIO, List, Optional, Tuple, Union, cast
 
 import click
-from build import BuildBackendException
 from build.util import project_wheel_metadata
 from click.utils import LazyFile, safecall
 from pip._internal.commands import create_command
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
+
+from build import BuildBackendException
 
 from .._compat import IS_CLICK_VER_8_PLUS, parse_requirements
 from ..cache import DependencyCache
@@ -546,7 +547,7 @@ def cli(
         results = resolver.resolve(max_rounds=max_rounds)
         hashes = resolver.resolve_hashes(results) if generate_hashes else None
     except NoCandidateFound as e:
-        if resolver_cls == LegacyResolver:
+        if resolver_cls == LegacyResolver:  # pragma: no branch
             log.error(
                 "Using legacy resolver. "
                 "Consider using backtracking resolver with "

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -16,7 +16,7 @@ from pip._internal.utils.misc import redact_auth_from_url
 
 from .._compat import IS_CLICK_VER_8_PLUS, parse_requirements
 from ..cache import DependencyCache
-from ..exceptions import PipToolsError, NoCandidateFound
+from ..exceptions import NoCandidateFound, PipToolsError
 from ..locations import CACHE_DIR
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
@@ -547,7 +547,9 @@ def cli(
         hashes = resolver.resolve_hashes(results) if generate_hashes else None
     except NoCandidateFound as e:
         if resolver_cls == LegacyResolver:
-            log.error("Using legacy resolver.  Consider using backtracking resolver with --resolver=backtracking")
+            log.error(
+                "Using legacy resolver.  Consider using backtracking resolver with --resolver=backtracking"
+            )
 
         log.error(str(e))
         sys.exit(2)

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -6,14 +6,13 @@ import tempfile
 from typing import IO, Any, BinaryIO, List, Optional, Tuple, Union, cast
 
 import click
+from build import BuildBackendException
 from build.util import project_wheel_metadata
 from click.utils import LazyFile, safecall
 from pip._internal.commands import create_command
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
-
-from build import BuildBackendException
 
 from .._compat import IS_CLICK_VER_8_PLUS, parse_requirements
 from ..cache import DependencyCache

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -648,7 +648,7 @@ def test_url_package(runner, line, dependency, generate_hashes):
         pytest.param(
             os.path.join(
                 MINIMAL_WHEELS_PATH, "small_fake_with_deps-0.1-py2.py3-none-any.whl"
-            ),
+           ),
             "\nsmall-fake-a==0.1",
             path_to_url(
                 os.path.join(
@@ -2487,3 +2487,85 @@ def test_preserve_via_requirements_constrained_dependencies_when_run_twice(
     for output in (first_out, second_out):
         assert output.exit_code == 0, output
         assert output.stderr == expected_output
+
+
+def test_failure_of_legacy_resolver_prompts_for_backtracking(
+        pip_conf, runner, tmpdir, make_package, make_wheel
+):
+    """ Test that pip-compile prompts to use the backtracking resolver """
+    pkgs = [
+        make_package(
+            "a",
+            version="0.1",
+            install_requires=["b==0.1"]
+        ),
+        make_package(
+            "a",
+            version="0.2",
+            install_requires=["b==0.2"]
+        ),
+        make_package(
+            "b",
+            version="0.1"
+        ),
+        make_package(
+            "b",
+            version="0.2"
+        ),
+        make_package(
+            "c",
+            version="1",
+            install_requires=["b==0.1", "a"]
+        )
+    ]
+
+    dists_dir = tmpdir / "dists"
+    for pkg in pkgs:
+        make_wheel(pkg, dists_dir)
+
+    with open("requirements.in", "w") as req_in:
+        req_in.writelines(["c"])
+
+    out = runner.invoke(cli, ["--resolver=legacy", "--find-links", str(dists_dir), "--pip-args='--no-index'"])
+    assert "Consider using backtracking resolver with" in out.stderr
+
+
+def test_success_of_legacy_resolver_doesnt_prompt_for_backtracking(
+        pip_conf, runner, tmpdir, make_package, make_wheel
+):
+    """ Test that pip-compile prompts to use the backtracking resolver """
+    pkgs = [
+        make_package(
+            "a",
+            version="0.1",
+            install_requires=["b==0.1"]
+        ),
+        make_package(
+            "a",
+            version="0.2",
+            install_requires=["b==0.2"]
+        ),
+        make_package(
+            "b",
+            version="0.1"
+        ),
+        make_package(
+            "b",
+            version="0.2"
+        ),
+        make_package(
+            "c",
+            version="1",
+            install_requires=["b==0.2", "a"]
+        )
+    ]
+
+    dists_dir = tmpdir / "dists"
+    for pkg in pkgs:
+        make_wheel(pkg, dists_dir)
+
+    with open("requirements.in", "w") as req_in:
+        req_in.writelines(["c"])
+
+    out = runner.invoke(cli, ["--resolver=legacy", "--find-links", str(dists_dir), "--pip-args='--no-index'"])
+    assert "Consider using backtracking resolver with" not in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -648,7 +648,7 @@ def test_url_package(runner, line, dependency, generate_hashes):
         pytest.param(
             os.path.join(
                 MINIMAL_WHEELS_PATH, "small_fake_with_deps-0.1-py2.py3-none-any.whl"
-           ),
+            ),
             "\nsmall-fake-a==0.1",
             path_to_url(
                 os.path.join(
@@ -2490,33 +2490,15 @@ def test_preserve_via_requirements_constrained_dependencies_when_run_twice(
 
 
 def test_failure_of_legacy_resolver_prompts_for_backtracking(
-        pip_conf, runner, tmpdir, make_package, make_wheel
+    pip_conf, runner, tmpdir, make_package, make_wheel
 ):
-    """ Test that pip-compile prompts to use the backtracking resolver """
+    """Test that pip-compile prompts to use the backtracking resolver"""
     pkgs = [
-        make_package(
-            "a",
-            version="0.1",
-            install_requires=["b==0.1"]
-        ),
-        make_package(
-            "a",
-            version="0.2",
-            install_requires=["b==0.2"]
-        ),
-        make_package(
-            "b",
-            version="0.1"
-        ),
-        make_package(
-            "b",
-            version="0.2"
-        ),
-        make_package(
-            "c",
-            version="1",
-            install_requires=["b==0.1", "a"]
-        )
+        make_package("a", version="0.1", install_requires=["b==0.1"]),
+        make_package("a", version="0.2", install_requires=["b==0.2"]),
+        make_package("b", version="0.1"),
+        make_package("b", version="0.2"),
+        make_package("c", version="1", install_requires=["b==0.1", "a"]),
     ]
 
     dists_dir = tmpdir / "dists"
@@ -2526,38 +2508,28 @@ def test_failure_of_legacy_resolver_prompts_for_backtracking(
     with open("requirements.in", "w") as req_in:
         req_in.writelines(["c"])
 
-    out = runner.invoke(cli, ["--resolver=legacy", "--find-links", str(dists_dir), "--pip-args='--no-index'"])
+    out = runner.invoke(
+        cli,
+        [
+            "--resolver=legacy",
+            "--find-links",
+            str(dists_dir),
+            "--pip-args='--no-index'",
+        ],
+    )
     assert "Consider using backtracking resolver with" in out.stderr
 
 
 def test_success_of_legacy_resolver_doesnt_prompt_for_backtracking(
-        pip_conf, runner, tmpdir, make_package, make_wheel
+    pip_conf, runner, tmpdir, make_package, make_wheel
 ):
-    """ Test that pip-compile prompts to use the backtracking resolver """
+    """Test that pip-compile prompts to use the backtracking resolver"""
     pkgs = [
-        make_package(
-            "a",
-            version="0.1",
-            install_requires=["b==0.1"]
-        ),
-        make_package(
-            "a",
-            version="0.2",
-            install_requires=["b==0.2"]
-        ),
-        make_package(
-            "b",
-            version="0.1"
-        ),
-        make_package(
-            "b",
-            version="0.2"
-        ),
-        make_package(
-            "c",
-            version="1",
-            install_requires=["b==0.2", "a"]
-        )
+        make_package("a", version="0.1", install_requires=["b==0.1"]),
+        make_package("a", version="0.2", install_requires=["b==0.2"]),
+        make_package("b", version="0.1"),
+        make_package("b", version="0.2"),
+        make_package("c", version="1", install_requires=["b==0.2", "a"]),
     ]
 
     dists_dir = tmpdir / "dists"
@@ -2567,5 +2539,13 @@ def test_success_of_legacy_resolver_doesnt_prompt_for_backtracking(
     with open("requirements.in", "w") as req_in:
         req_in.writelines(["c"])
 
-    out = runner.invoke(cli, ["--resolver=legacy", "--find-links", str(dists_dir), "--pip-args='--no-index'"])
+    out = runner.invoke(
+        cli,
+        [
+            "--resolver=legacy",
+            "--find-links",
+            str(dists_dir),
+            "--pip-args='--no-index'",
+        ],
+    )
     assert "Consider using backtracking resolver with" not in out.stderr


### PR DESCRIPTION
Prompt the user to use the backtracking resolver if the legacy resolver is in use and pip-tools is failing to resolve the dependencies.  This is as mentioned in #1717 and related to PR #1718.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
