### PR TITLE
Generate hashes for all available candidates

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -325,6 +325,10 @@ class PyPIRepository(BaseRepository):
             return self._get_req_hashes(ireq)
 
     def _get_req_hashes(self, ireq: InstallRequirement) -> set[str]:
+        """
+        Collects the hashes for all candidates satisfying the given InstallRequirement. Computes
+        the hashes for the candidates that don't have one reported by their index.
+        """
         matching_candidates = self._get_matching_candidates(ireq)
         pypi_hashes_by_link = self._get_hashes_from_pypi(ireq)
         pypi_hashes = {
@@ -341,8 +345,8 @@ class PyPIRepository(BaseRepository):
 
     def _get_hashes_from_pypi(self, ireq: InstallRequirement) -> dict[str, str]:
         """
-        Return a set of hashes from PyPI JSON API for a given InstallRequirement.
-        Return None if fetching data is failed or missing digests.
+        Builds a mapping from the release URLs to their hashes as reported by the PyPI JSON API
+        for a given InstallRequirement.
         """
         project = self._get_project(ireq)
         if project is None:
@@ -372,7 +376,7 @@ class PyPIRepository(BaseRepository):
         self, ireq: InstallRequirement
     ) -> set[InstallationCandidate]:
         """
-        Return a set of hashes for all release files of a given InstallRequirement.
+        Returns all candidates that satisfy the given InstallRequirement.
         """
         # We need to get all of the candidates that match our current version
         # pin, these will represent all of the files that could possibly
@@ -382,8 +386,7 @@ class PyPIRepository(BaseRepository):
         matching_versions = list(
             ireq.specifier.filter(candidate.version for candidate in all_candidates)
         )
-        matching_candidates = candidates_by_version[matching_versions[0]]
-        return matching_candidates
+        return candidates_by_version[matching_versions[0]]
 
     def _get_file_hash(self, link: Link) -> str:
         log.debug(f"Hashing {link.show_url}")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1250,7 +1250,7 @@ PYPI_PROJECT_SMALL_FAKE_A = {
 }
 
 
-def test_generate_hashes_with_mixed_sources(runner):
+def test_generate_hashes_with_mixed_sources_mocked(runner):
     with open("requirements.in", "w") as fp:
         fp.write("small_fake-a==0.1")
 
@@ -1308,6 +1308,46 @@ def test_generate_hashes_with_mixed_sources(runner):
 
     assert out.exit_code == 0, out
     assert out.stdout == expected
+
+
+@pytest.mark.network
+def test_generate_hashes_with_mixed_sources(runner):
+    with open("requirements.in", "w") as fp:
+        fp.write("torch-scatter==2.0.9\n")
+
+    out = runner.invoke(
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--quiet",
+            "--no-header",
+            "--generate-hashes",
+            "--find-links",
+            "https://data.pyg.org/whl/torch-1.13.0+cpu.html",
+        ],
+    )
+
+    assert out.stdout == dedent(
+        """\
+        --find-links https://data.pyg.org/whl/torch-1.13.0+cpu.html
+        
+        torch-scatter==2.0.9 \\
+            --hash=sha256:08f5511d64473badf0a71d156b36dc2b09b9c2f00a7cd373b935b490c477a7f1 \\
+            --hash=sha256:2003d31429c4efa30c12026a1662194fae8fae1c3f0e891d5563b9e73afb9a67 \\
+            --hash=sha256:4c6dc46112ed0f01ea532a6ad98ed5facae1bcd15e0a74bc3b0efebcfc1b33ed \\
+            --hash=sha256:5a85675da0fa668aef938e097f3c89940ed4d9cda9f186e604e73960b8be4bdc \\
+            --hash=sha256:610d87fdc72738d4b76a4599a1a0eb0c3ec9f164edf07aca2c7d9c649ad0c6b0 \\
+            --hash=sha256:6bcb2d26bc7934683a667d2e23e8c9cc52c4c81e41526733bc12de2698ce9679 \\
+            --hash=sha256:84e9f266c5ed3527ce1d475ceb32df9a61017e3a6db28b1ab53cfba7836c82ec \\
+            --hash=sha256:967432cde1b736a6cbce7a606ddc9abefd7d1a4cafe1dcbef289672fc9fe9fcf \\
+            --hash=sha256:a8ca5eafa302fc4779c18b6a8854a4b3f1a2b20893c1fddf5f1137630995fea2 \\
+            --hash=sha256:aa9005a5ec09265d6cfde266c0e3a40f16b0a732cfcca2304839f81694904b1e \\
+            --hash=sha256:d470bfe9de64c95ca69ef46c90dd9aaad11f538ced601ada131cbb7d52d74a39 \\
+            --hash=sha256:d53255b4e23701ddaf5dda173bcb02ca0f69604e5917169cb06bf31ec3587e49
+            # via -r requirements.in
+        """
+    )
 
 
 def test_filter_pip_markers(pip_conf, runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1298,7 +1298,7 @@ def test_generate_hashes_with_mixed_sources_mocked(runner):
     expected = dedent(
         f"""\
         --find-links {MINIMAL_WHEELS_PATH}
-        
+
         small-fake-a==0.1 \\
             --hash=sha256:{INDEX_HASH_SMALL_FAKE_A} \\
             --hash=sha256:5e6071ee6e4c59e0d0408d366fe9b66781d2cf01be9a6e19a2433bb3c5336330
@@ -1331,7 +1331,7 @@ def test_generate_hashes_with_mixed_sources(runner):
     assert out.stdout == dedent(
         """\
         --find-links https://data.pyg.org/whl/torch-1.13.0+cpu.html
-        
+
         torch-scatter==2.0.9 \\
             --hash=sha256:08f5511d64473badf0a71d156b36dc2b09b9c2f00a7cd373b935b490c477a7f1 \\
             --hash=sha256:2003d31429c4efa30c12026a1662194fae8fae1c3f0e891d5563b9e73afb9a67 \\

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import traceback
 from textwrap import dedent
 from unittest import mock
 
@@ -14,7 +15,6 @@ from piptools.scripts.compile import cli
 from piptools.utils import COMPILE_EXCLUDE_OPTIONS
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
-from .test_utils import MockRequests
 
 legacy_resolver_only = pytest.mark.parametrize(
     "current_resolver",
@@ -1213,103 +1213,6 @@ def test_generate_hashes_with_line_style_annotations(runner):
     )
 
 
-SMALL_FAKE_A_FILE_NAME = "small_fake_a-0.1-py2.py3-none-any.whl"
-INDEX_URL_SMALL_FAKE_A = (
-    "https://files.pythonhosted.org/packages/08/e3/"
-    "ad05e1371eb99f257ca00f791b755deb22e752393eb8e75bc01d651715b02ea9/"
-    + SMALL_FAKE_A_FILE_NAME
-)
-INDEX_HASH_SMALL_FAKE_A = (
-    "33e1acdca3b9162e002cedb0e58b350d731d1ed3f53a6b22e0a628bca7c7c6ed"
-)
-
-INDEX_SIMPLE_SMALL_FAKE_A = {
-    "files": [
-        {
-            "filename": SMALL_FAKE_A_FILE_NAME,
-            "hashes": {"sha256": INDEX_HASH_SMALL_FAKE_A},
-            "requires-python": "",
-            "url": INDEX_URL_SMALL_FAKE_A,
-            "yanked": False,
-        },
-    ]
-}
-
-PYPI_PROJECT_SMALL_FAKE_A = {
-    "releases": {
-        "0.1": [
-            {
-                "packagetype": "bdist_wheel",
-                "digests": {
-                    "sha256": INDEX_HASH_SMALL_FAKE_A,
-                },
-                "url": INDEX_URL_SMALL_FAKE_A,
-            },
-        ]
-    }
-}
-
-
-def test_generate_hashes_with_mixed_sources_mocked(runner):
-    with open("requirements.in", "w") as fp:
-        fp.write("small_fake-a==0.1")
-
-    with (
-        MockRequests()
-        .handle(
-            "https://pypi.org/simple/small-fake-a/",
-            MockRequests.response_json(
-                INDEX_SIMPLE_SMALL_FAKE_A,
-                content_type="application/vnd.pypi.simple.v1+json",
-            ),
-        )
-        .handle(
-            "https://pypi.org/pypi/small-fake-a/json",
-            MockRequests.response_json(PYPI_PROJECT_SMALL_FAKE_A),
-        )
-        .handle(
-            "https://pypi.org/pypi/small_fake-a/json",
-            MockRequests.response_json(PYPI_PROJECT_SMALL_FAKE_A),
-        )
-        .handle(
-            INDEX_URL_SMALL_FAKE_A,
-            MockRequests.response_file(
-                os.path.join(
-                    # Note the discrepancy in file names to cause a different hash to be generated
-                    MINIMAL_WHEELS_PATH,
-                    "small_fake_a-0.2-py2.py3-none-any.whl",
-                )
-            ),
-        )
-    ):
-        out = runner.invoke(
-            cli,
-            [
-                "--output-file",
-                "-",
-                "--quiet",
-                "--no-header",
-                "--generate-hashes",
-                "--find-links",
-                MINIMAL_WHEELS_PATH,
-            ],
-        )
-
-    expected = dedent(
-        f"""\
-        --find-links {MINIMAL_WHEELS_PATH}
-
-        small-fake-a==0.1 \\
-            --hash=sha256:{INDEX_HASH_SMALL_FAKE_A} \\
-            --hash=sha256:5e6071ee6e4c59e0d0408d366fe9b66781d2cf01be9a6e19a2433bb3c5336330
-            # via -r requirements.in
-        """
-    )
-
-    assert out.exit_code == 0, out
-    assert out.stdout == expected
-
-
 @pytest.mark.network
 def test_generate_hashes_with_mixed_sources(runner):
     with open("requirements.in", "w") as fp:
@@ -1328,6 +1231,8 @@ def test_generate_hashes_with_mixed_sources(runner):
         ],
     )
 
+    print(out.stderr)
+    traceback.print_exception(*out.exc_info)
     assert out.stdout == dedent(
         """\
         --find-links https://data.pyg.org/whl/torch-1.13.0+cpu.html

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import json
 import logging
 import operator
 import os
 import shlex
 import sys
+from codecs import encode
+from contextlib import AbstractContextManager
+from io import BytesIO
+from typing import Callable
+from unittest import mock
 
 import pip
 import pytest
 from pip._vendor.packaging.version import Version
+from pip._vendor.requests.models import Response
 
 from piptools.scripts.compile import cli as compile_cli
 from piptools.utils import (
@@ -542,3 +549,80 @@ def test_get_sys_path_for_python_executable():
     # not testing for equality, because pytest adds extra paths into current sys.path
     for path in result:
         assert path in sys.path
+
+
+class MockRequests(AbstractContextManager):
+    def __init__(self):
+        from pip._internal.network.session import PipSession
+
+        self.ctx = mock.patch.object(PipSession, "get", self._get)
+        self.responses = {}
+
+    def _get(self, url, **kwargs):
+        if url in self.responses:
+            response = self.responses[url]
+            return response(url)
+        else:
+            raise AssertionError(f"Missing handler for {url}")
+
+    def handle(self, url, response):
+        self.responses[url] = response
+        return self
+
+    def __enter__(self):
+        self.ctx.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return self.ctx.__exit__(exc_type, exc_val, exc_tb)
+
+    @classmethod
+    def response_html(
+        cls, body: str, status_code: int = 200
+    ) -> Callable[[str], Response]:
+        def response(url):
+            r = Response()
+            r.url = url
+            r.status_code = status_code
+            r.reason = "OK"
+            r.headers["Content-Type"] = "text/html"
+            r.raw = BytesIO(encode(body))
+            return r
+
+        return response
+
+    @classmethod
+    def response_json(
+        cls,
+        body: dict,
+        status_code: int = 200,
+        content_type: str = "application/json",
+    ) -> Callable[[str], Response]:
+        def response(url):
+            r = Response()
+            r.url = url
+            r.status_code = status_code
+            r.reason = "OK"
+            r.headers = {"Content-Type": content_type}
+            r.raw = BytesIO(encode(json.dumps(body)))
+            return r
+
+        return response
+
+    @classmethod
+    def response_file(
+        cls,
+        path: str,
+        status_code: int = 200,
+        content_type: str = "binary/octet-stream",
+    ) -> Callable[[str], Response]:
+        def response(url):
+            r = Response()
+            r.url = url
+            r.status_code = status_code
+            r.reason = "OK"
+            r.headers = {"Content-Type": content_type}
+            with open(path, "br") as f:
+                r.raw = BytesIO(f.read())
+            return r
+
+        return response

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import sys
 from codecs import encode
 from contextlib import AbstractContextManager
 from io import BytesIO
-from typing import Callable
+from typing import Callable, Any
 from unittest import mock
 
 import pip
@@ -551,7 +551,7 @@ def test_get_sys_path_for_python_executable():
         assert path in sys.path
 
 
-class MockRequests(AbstractContextManager):
+class MockRequests(AbstractContextManager[Any]):
     def __init__(self):
         from pip._internal.network.session import PipSession
 
@@ -593,7 +593,7 @@ class MockRequests(AbstractContextManager):
     @classmethod
     def response_json(
         cls,
-        body: dict,
+        body: dict[Any, Any],
         status_code: int = 200,
         content_type: str = "application/json",
     ) -> Callable[[str], Response]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import sys
 from codecs import encode
 from contextlib import AbstractContextManager
 from io import BytesIO
-from typing import Callable, Any
+from typing import Any, Callable
 from unittest import mock
 
 import pip


### PR DESCRIPTION
Generate hashes covering the PyPi index as well as additional candidates available through an extra index of find-links. Currently if PyPi index is available the hashes will be limited to those available in it.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Fixes #1662