### PR TITLE
Deprecate `pip-compile --resolver=legacy`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -571,6 +571,8 @@ This section lists ``pip-tools`` features that are currently deprecated.
   default. Use ``--no-allow-unsafe`` to keep the old behavior. It is
   recommended to pass the ``--allow-unsafe`` now to adapt to the upcoming
   change.
+- Legacy resolver is deprecated and will be removed in future versions.
+  Use ``--resolver=backtracking`` instead.
 
 A Note on Resolvers
 ===================

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -327,7 +327,7 @@ def cli(
     emit_find_links: bool,
     cache_dir: str,
     pip_args_str: str | None,
-    resolver_name: str | None,
+    resolver_name: str,
     emit_index_url: bool,
     emit_options: bool,
     unsafe_package: tuple[str, ...],

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -272,7 +272,7 @@ def _determine_linesep(
     "--resolver",
     "resolver_name",
     type=click.Choice(("legacy", "backtracking")),
-    default=None,
+    default="legacy",
     envvar="PIP_TOOLS_RESOLVER",
     help="Choose the dependency resolver.",
 )
@@ -378,12 +378,12 @@ def cli(
         if isinstance(output_file, LazyFile):  # pragma: no cover
             ctx.call_on_close(safecall(output_file.close_intelligently))
 
-    if resolver_name is None:
+    if resolver_name == "legacy":
         log.warning(
-            "WARNING: default resolver will be changed to 'backtracking' in 7.0.0 "
-            "version. Specify the --resolver option to silence this warning."
+            "WARNING: using legacy resolver is deprecated and will be removed in "
+            "future versions. The default resolver will be change to 'backtracking' "
+            "in 7.0.0 version. Specify --resolver=backtracking to silence this warning."
         )
-        resolver_name = "legacy"
 
     ###
     # Setup

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -8,14 +8,13 @@ import tempfile
 from typing import IO, Any, BinaryIO, cast
 
 import click
+from build import BuildBackendException
 from build.util import project_wheel_metadata
 from click.utils import LazyFile, safecall
 from pip._internal.commands import create_command
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
-
-from build import BuildBackendException
 
 from .._compat import IS_CLICK_VER_8_PLUS, parse_requirements
 from ..cache import DependencyCache

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -20,6 +20,11 @@ legacy_resolver_only = pytest.mark.parametrize(
     ("legacy",),
     indirect=("current_resolver",),
 )
+no_current_resolver = pytest.mark.parametrize(
+    "current_resolver",
+    ("",),
+    indirect=("current_resolver",),
+)
 
 
 @pytest.fixture(
@@ -2522,3 +2527,14 @@ def test_failure_of_legacy_resolver_prompts_for_backtracking(
         assert out.exit_code == 0, out
     else:  # pragma: no cover
         raise AssertionError("unreachable")
+
+
+@no_current_resolver
+def test_print_warning_if_resolver_not_specified(pip_conf, runner):
+    with open("requirements.in", "w"):
+        pass
+
+    out = runner.invoke(cli)
+
+    assert out.exit_code == 0, out
+    assert "WARNING: default resolver will be changed to 'backtracking'" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2530,11 +2530,11 @@ def test_failure_of_legacy_resolver_prompts_for_backtracking(
 
 
 @no_current_resolver
-def test_print_warning_if_resolver_not_specified(pip_conf, runner):
+def test_print_deprecation_warning_if_using_legacy_resolver(pip_conf, runner):
     with open("requirements.in", "w"):
         pass
 
     out = runner.invoke(cli)
 
     assert out.exit_code == 0, out
-    assert "WARNING: default resolver will be changed to 'backtracking'" in out.stderr
+    assert "WARNING: using legacy resolver is deprecated" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -20,11 +20,6 @@ legacy_resolver_only = pytest.mark.parametrize(
     ("legacy",),
     indirect=("current_resolver",),
 )
-no_current_resolver = pytest.mark.parametrize(
-    "current_resolver",
-    ("",),
-    indirect=("current_resolver",),
-)
 
 
 @pytest.fixture(
@@ -2553,12 +2548,15 @@ def test_failure_of_legacy_resolver_prompts_for_backtracking(
         raise AssertionError("unreachable")
 
 
-@no_current_resolver
-def test_print_deprecation_warning_if_using_legacy_resolver(pip_conf, runner):
+def test_print_deprecation_warning_if_using_legacy_resolver(runner, current_resolver):
     with open("requirements.in", "w"):
         pass
 
     out = runner.invoke(cli)
-
     assert out.exit_code == 0, out
-    assert "WARNING: using legacy resolver is deprecated" in out.stderr
+
+    expected_warning = "WARNING: using legacy resolver is deprecated"
+    if current_resolver == "legacy":
+        assert expected_warning in out.stderr
+    else:
+        assert expected_warning not in out.stderr


### PR DESCRIPTION
Resolves #1659 

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
