### PR TITLE
Use explicit output requirement file to test the exact output

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -94,7 +94,7 @@ def test_command_line_overrides_pip_conf(pip_with_index_conf, runner):
     ),
 )
 def test_command_line_setuptools_read(
-    runner, make_pip_conf, make_package, install_requires, expected_output
+    runner, make_package, install_requires, expected_output
 ):
     package_dir = make_package(
         name="fake-setuptools-a",
@@ -105,11 +105,14 @@ def test_command_line_setuptools_read(
         cli,
         (str(package_dir / "setup.py"), "--find-links", MINIMAL_WHEELS_PATH),
     )
-
-    assert expected_output in out.stderr.splitlines()
+    assert out.exit_code == 0
 
     # check that pip-compile generated a configuration file
-    assert (package_dir / "requirements.txt").exists()
+    output_file = package_dir / "requirements.txt"
+    assert output_file.exists()
+
+    # The package version must NOT be updated in the output file
+    assert expected_output in output_file.read_text().splitlines()
 
 
 @pytest.mark.network
@@ -195,6 +198,8 @@ def test_setuptools_preserves_environment_markers(
         cli,
         [
             str(bar_dir / "setup.py"),
+            "--output-file",
+            "-",
             "--no-header",
             "--no-annotate",
             "--no-emit-find-links",
@@ -204,7 +209,7 @@ def test_setuptools_preserves_environment_markers(
     )
 
     assert out.exit_code == 0, out.stderr
-    assert out.stderr == 'foo==1.0 ; python_version >= "1"\n'
+    assert out.stdout == 'foo==1.0 ; python_version >= "1"\n'
 
 
 def test_find_links_option(runner):
@@ -349,8 +354,8 @@ def test_trusted_host_envvar(monkeypatch, pip_conf, runner):
 def test_all_no_emit_options(runner, options):
     with open("requirements.in", "w"):
         pass
-    out = runner.invoke(cli, ["--no-header", *options])
-    assert out.stderr.strip().splitlines() == []
+    out = runner.invoke(cli, ["--output-file", "-", "--no-header", *options])
+    assert out.stdout.strip().splitlines() == []
 
 
 @pytest.mark.parametrize(
@@ -367,10 +372,19 @@ def test_emit_index_url_option(runner, option, expected_output):
         pass
 
     out = runner.invoke(
-        cli, ["--no-header", "--index-url", "https://index-url", option]
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--quiet",
+            "--no-header",
+            "--index-url",
+            "https://index-url",
+            option,
+        ],
     )
 
-    assert out.stderr.strip().splitlines() == expected_output
+    assert out.stdout.strip().splitlines() == expected_output
 
 
 @pytest.mark.network
@@ -466,12 +480,12 @@ def test_editable_package_constraint_without_non_editable_duplicate(pip_conf, ru
             "\nsmall_fake_with_unpinned_deps"  # This one also requires small_fake_a
         )
 
-    out = runner.invoke(cli, ["-n"])
+    out = runner.invoke(cli, ["--output-file", "-", "--quiet"])
 
     assert out.exit_code == 0
-    assert fake_package_dir in out.stderr
+    assert fake_package_dir in out.stdout
     # Shouldn't include a non-editable small-fake-a==<version>.
-    assert "small-fake-a==" not in out.stderr
+    assert "small-fake-a==" not in out.stdout
 
 
 @legacy_resolver_only
@@ -551,10 +565,20 @@ def test_compile_cached_vcs_package(runner, venv):
     with open("requirements.in", "w") as req_in:
         req_in.write(vcs_package)
 
-    out = runner.invoke(cli, ["--no-header", "--no-emit-options", "--no-annotate"])
+    out = runner.invoke(
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--quiet",
+            "--no-header",
+            "--no-emit-options",
+            "--no-annotate",
+        ],
+    )
 
     assert out.exit_code == 0, out
-    assert vcs_package == out.stderr.strip()
+    assert vcs_package == out.stdout.strip()
 
 
 @legacy_resolver_only
@@ -881,27 +905,27 @@ def test_upgrade_packages_version_option_and_upgrade_no_existing_file(pip_conf, 
     assert "small-fake-b==0.1" in out.stderr
 
 
-def test_quiet_option(runner):
-    with open("requirements", "w"):
-        pass
-    out = runner.invoke(cli, ["--quiet", "requirements"])
-    # Pinned requirements result has not been written to stdout or stderr:
-    assert not out.stdout_bytes
-    assert not out.stderr_bytes
+def test_quiet_option(pip_conf, runner):
+    with open("requirements.in", "w") as req_in:
+        req_in.write("small-fake-a")
+
+    out = runner.invoke(cli, ["--quiet"])
+    # Pinned requirements result has not been written to stderr:
+    assert b"small-fake-a" not in out.stderr_bytes
 
 
 def test_dry_run_noisy_option(runner):
-    with open("requirements", "w"):
+    with open("requirements.in", "w"):
         pass
-    out = runner.invoke(cli, ["--dry-run", "requirements"])
+    out = runner.invoke(cli, ["--dry-run"])
     # Dry-run message has been written to output
     assert "Dry-run, so nothing updated." in out.stderr.splitlines()
 
 
 def test_dry_run_quiet_option(runner):
-    with open("requirements", "w"):
+    with open("requirements.in", "w"):
         pass
-    out = runner.invoke(cli, ["--dry-run", "--quiet", "requirements"])
+    out = runner.invoke(cli, ["--output-file", "-", "--dry-run", "--quiet"])
     # Neither dry-run message nor pinned requirements written to output:
     assert not out.stdout_bytes
     # Dry-run message has not been written to stderr:
@@ -964,16 +988,18 @@ def test_generate_hashes_with_annotations(runner):
     with open("requirements.in", "w") as fp:
         fp.write("six==1.15.0")
 
-    out = runner.invoke(cli, ["--generate-hashes"])
-    assert out.stderr == dedent(
-        f"""\
-        #
-        # This file is autogenerated by pip-compile with python \
-{sys.version_info.major}.{sys.version_info.minor}
-        # To update, run:
-        #
-        #    pip-compile --generate-hashes
-        #
+    out = runner.invoke(
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--quiet",
+            "--no-header",
+            "--generate-hashes",
+        ],
+    )
+    assert out.stdout == dedent(
+        """\
         six==1.15.0 \\
             --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \\
             --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
@@ -1087,16 +1113,20 @@ def test_generate_hashes_with_split_style_annotations(runner):
         fp.write("pytz==2020.4\n")
         fp.write("sqlparse==0.3.1\n")
 
-    out = runner.invoke(cli, ["--generate-hashes", "--annotation-style", "split"])
-    assert out.stderr == dedent(
-        f"""\
-        #
-        # This file is autogenerated by pip-compile with python \
-{sys.version_info.major}.{sys.version_info.minor}
-        # To update, run:
-        #
-        #    pip-compile --generate-hashes
-        #
+    out = runner.invoke(
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--quiet",
+            "--no-header",
+            "--generate-hashes",
+            "--annotation-style",
+            "split",
+        ],
+    )
+    assert out.stdout == dedent(
+        """\
         django==1.11.29 \\
             --hash=sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f \\
             --hash=sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c
@@ -1143,16 +1173,20 @@ def test_generate_hashes_with_line_style_annotations(runner):
         fp.write("pytz==2020.4\n")
         fp.write("sqlparse==0.3.1\n")
 
-    out = runner.invoke(cli, ["--generate-hashes", "--annotation-style", "line"])
-    assert out.stderr == dedent(
-        f"""\
-        #
-        # This file is autogenerated by pip-compile with python \
-{sys.version_info.major}.{sys.version_info.minor}
-        # To update, run:
-        #
-        #    pip-compile --annotation-style=line --generate-hashes
-        #
+    out = runner.invoke(
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--quiet",
+            "--no-header",
+            "--generate-hashes",
+            "--annotation-style",
+            "line",
+        ],
+    )
+    assert out.stdout == dedent(
+        """\
         django==1.11.29 \\
             --hash=sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f \\
             --hash=sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c
@@ -1185,14 +1219,14 @@ def test_filter_pip_markers(pip_conf, runner):
     """
     Check that pip-compile works with pip environment markers (PEP496)
     """
-    with open("requirements", "w") as req_in:
+    with open("requirements.in", "w") as req_in:
         req_in.write("small-fake-a==0.1\nunknown_package==0.1; python_version == '1'")
 
-    out = runner.invoke(cli, ["-n", "requirements"])
+    out = runner.invoke(cli, ["--output-file", "-", "--quiet"])
 
     assert out.exit_code == 0
-    assert "small-fake-a==0.1" in out.stderr
-    assert "unknown_package" not in out.stderr
+    assert "small-fake-a==0.1" in out.stdout
+    assert "unknown_package" not in out.stdout
 
 
 def test_bad_setup_file(runner):
@@ -1286,22 +1320,14 @@ def test_stdin(pip_conf, runner):
     """
     out = runner.invoke(
         cli,
-        ["-", "--output-file", "requirements.txt", "-n", "--no-emit-find-links"],
+        ["-", "--output-file", "-", "--quiet", "--no-emit-options", "--no-header"],
         input="small-fake-a==0.1",
     )
 
-    assert out.stderr == dedent(
-        f"""\
-        #
-        # This file is autogenerated by pip-compile with python \
-{sys.version_info.major}.{sys.version_info.minor}
-        # To update, run:
-        #
-        #    pip-compile --no-emit-find-links --output-file=requirements.txt -
-        #
+    assert out.stdout == dedent(
+        """\
         small-fake-a==0.1
             # via -r -
-        Dry-run, so nothing updated.
         """
     )
 
@@ -1329,53 +1355,29 @@ def test_multiple_input_files_without_output_file(runner):
     (
         pytest.param(
             ("--annotate",),
-            f"""\
-            #
-            # This file is autogenerated by pip-compile with python \
-{sys.version_info.major}.{sys.version_info.minor}
-            # To update, run:
-            #
-            #    pip-compile --no-emit-find-links
-            #
+            """\
             small-fake-a==0.1
                 # via
                 #   -c constraints.txt
                 #   small-fake-with-deps
             small-fake-with-deps==0.1
                 # via -r requirements.in
-            Dry-run, so nothing updated.
             """,
             id="annotate",
         ),
         pytest.param(
             ("--annotate", "--annotation-style", "line"),
-            f"""\
-            #
-            # This file is autogenerated by pip-compile with python \
-{sys.version_info.major}.{sys.version_info.minor}
-            # To update, run:
-            #
-            #    pip-compile --annotation-style=line --no-emit-find-links
-            #
+            """\
             small-fake-a==0.1         # via -c constraints.txt, small-fake-with-deps
             small-fake-with-deps==0.1  # via -r requirements.in
-            Dry-run, so nothing updated.
             """,
             id="annotate line style",
         ),
         pytest.param(
             ("--no-annotate",),
-            f"""\
-            #
-            # This file is autogenerated by pip-compile with python \
-{sys.version_info.major}.{sys.version_info.minor}
-            # To update, run:
-            #
-            #    pip-compile --no-annotate --no-emit-find-links
-            #
+            """\
             small-fake-a==0.1
             small-fake-with-deps==0.1
-            Dry-run, so nothing updated.
             """,
             id="no annotate",
         ),
@@ -1391,10 +1393,13 @@ def test_annotate_option(pip_conf, runner, options, expected):
         req_in.write("-c constraints.txt\n")
         req_in.write("small_fake_with_deps")
 
-    out = runner.invoke(cli, [*options, "-n", "--no-emit-find-links"])
+    out = runner.invoke(
+        cli,
+        [*options, "--output-file", "-", "--quiet", "--no-emit-options", "--no-header"],
+    )
 
     assert out.exit_code == 0, out
-    assert out.stderr == dedent(expected)
+    assert out.stdout == dedent(expected)
 
 
 @pytest.mark.parametrize(
@@ -1451,6 +1456,9 @@ def test_allow_unsafe_option(pip_conf, monkeypatch, runner, option, expected):
     out = runner.invoke(
         cli,
         [
+            "--output-file",
+            "-",
+            "--quiet",
             "--no-header",
             "--no-emit-options",
             "--no-annotate",
@@ -1459,7 +1467,7 @@ def test_allow_unsafe_option(pip_conf, monkeypatch, runner, option, expected):
     )
 
     assert out.exit_code == 0, out
-    assert out.stderr == expected
+    assert out.stdout == expected
 
 
 @pytest.mark.parametrize(
@@ -1816,10 +1824,10 @@ def test_remove_outdated_options(runner, input_opts, output_opts):
     with open("requirements.txt", "w") as req_txt:
         req_txt.write(output_opts)
 
-    out = runner.invoke(cli, ["--no-header"])
+    out = runner.invoke(cli, ["--output-file", "-", "--quiet", "--no-header"])
 
     assert out.exit_code == 0, out
-    assert out.stderr.strip() == input_opts
+    assert out.stdout.strip() == input_opts
 
 
 def test_sub_dependencies_with_constraints(pip_conf, runner):
@@ -2071,7 +2079,16 @@ def test_combine_different_extras_of_the_same_package(
         )
 
     out = runner.invoke(
-        cli, ["--find-links", str(dists_dir), "--no-header", "--no-emit-options"]
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--quiet",
+            "--find-links",
+            str(dists_dir),
+            "--no-header",
+            "--no-emit-options",
+        ],
     )
     assert out.exit_code == 0
     assert (
@@ -2089,7 +2106,7 @@ def test_combine_different_extras_of_the_same_package(
             # via -r requirements.in
         """
         )
-        == out.stderr
+        == out.stdout
     )
 
 
@@ -2341,7 +2358,9 @@ def test_all_extras(fake_dists, runner, make_module, fname, content):
     out = runner.invoke(
         cli,
         [
-            "-n",
+            "--output-file",
+            "-",
+            "--quiet",
             "--all-extras",
             "--find-links",
             fake_dists,
@@ -2351,7 +2370,7 @@ def test_all_extras(fake_dists, runner, make_module, fname, content):
             meta_path,
         ],
     )
-    assert out.exit_code == 0, out.stderr
+    assert out.exit_code == 0, out
     assert (
         dedent(
             """\
@@ -2361,10 +2380,9 @@ def test_all_extras(fake_dists, runner, make_module, fname, content):
             small-fake-d==0.4
             small-fake-e==0.5
             small-fake-f==0.6
-            Dry-run, so nothing updated.
             """
         )
-        == out.stderr
+        == out.stdout
     )
 
 
@@ -2471,9 +2489,17 @@ def test_preserve_via_requirements_constrained_dependencies_when_run_twice(
 
     # First run of the command will generate `requirements.txt`, which doesn't yet exist.
     first_out = runner.invoke(cli, cli_arguments)
+    assert first_out.exit_code == 0, first_out
+
+    with open("requirements.txt") as req_txt:
+        first_output = req_txt.read()
 
     # Second run of the command will update `requirements.txt`.
     second_out = runner.invoke(cli, cli_arguments)
+    assert second_out.exit_code == 0, second_out
+
+    with open("requirements.txt") as req_txt:
+        second_output = req_txt.read()
 
     expected_output = dedent(
         """\
@@ -2485,10 +2511,8 @@ def test_preserve_via_requirements_constrained_dependencies_when_run_twice(
             # via -r requirements.in
         """
     )
-
-    for output in (first_out, second_out):
-        assert output.exit_code == 0, output
-        assert output.stderr == expected_output
+    assert first_output == expected_output
+    assert second_output == expected_output
 
 
 def test_failure_of_legacy_resolver_prompts_for_backtracking(


### PR DESCRIPTION
When a test asserts the exact content of the output requirement file make sure it uses the output file not stderr, otherwise the test will fail when something appears in stderr (e.g., a warning).


Addresses https://github.com/jazzband/pip-tools/pull/1724#issuecomment-1312477383.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
