### PR TITLE
Replace deprecated set-output in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,9 @@ jobs:
         run: python --version --version
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Pip cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -35,8 +35,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Pip cache
         uses: actions/cache@v3
         with:
@@ -81,8 +82,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Pip cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Pip cache
         uses: actions/cache@v3
         with:
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-
       - name: Prepare cache key
         id: cache-key
-        run: echo "::set-output name=sha-256::$(python -VV | sha256sum | cut -d' ' -f1)"
+        run: echo "sha-256=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
