### PR TITLE
Support build isolation using `setuptools/pyproject.toml` requirement files

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -481,7 +481,8 @@ def cli(
             setup_file_found = True
             try:
                 metadata = project_wheel_metadata(
-                    os.path.dirname(os.path.abspath(src_file))
+                    os.path.dirname(os.path.abspath(src_file)),
+                    isolated=build_isolation,
                 )
             except BuildBackendException as e:
                 log.error(str(e))

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1494,7 +1494,9 @@ def test_cert_option(parse_requirements, runner, option, attr, expected):
     (("--build-isolation", True), ("--no-build-isolation", False)),
 )
 @mock.patch("piptools.scripts.compile.parse_requirements")
-def test_build_isolation_option(parse_requirements, runner, option, expected):
+def test_parse_requirements_build_isolation_option(
+    parse_requirements, runner, option, expected
+):
     """
     A value of the --build-isolation/--no-build-isolation flag
     must be passed to parse_requirements().
@@ -1507,6 +1509,36 @@ def test_build_isolation_option(parse_requirements, runner, option, expected):
     # Ensure the options in parse_requirements has the expected build_isolation option
     args, kwargs = parse_requirements.call_args
     assert kwargs["options"].build_isolation is expected
+
+
+@pytest.mark.parametrize(
+    ("option", "expected"),
+    (("--build-isolation", True), ("--no-build-isolation", False)),
+)
+@mock.patch("piptools.scripts.compile.project_wheel_metadata")
+def test_project_wheel_metadata_isolation_option(
+    project_wheel_metadata, runner, option, expected
+):
+    """
+    A value of the --build-isolation/--no-build-isolation flag
+    must be passed to project_wheel_metadata().
+    """
+
+    with open("setup.py", "w") as package:
+        package.write(
+            dedent(
+                """\
+                from setuptools import setup
+                setup(install_requires=[])
+                """
+            )
+        )
+
+    runner.invoke(cli, [option])
+
+    # Ensure the options in project_wheel_metadata has the isolated kwarg
+    _, kwargs = project_wheel_metadata.call_args
+    assert kwargs["isolated"] is expected
 
 
 @mock.patch("piptools.scripts.compile.PyPIRepository")


### PR DESCRIPTION
Pass `--build-isolation/--no-build-isolation` option to metadata builder when setuptools/pyproject.toml requirement file is used.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
