### PR TITLE
Make slowest test_override_newline x90 faster

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1032,6 +1032,7 @@ def test_generate_hashes_with_annotations(runner):
     ),
 )
 def test_override_newline(
+    pip_conf,
     runner,
     gen_hashes,
     annotate_options,
@@ -1048,11 +1049,7 @@ def test_override_newline(
     example_dir.mkdir()
     in_path = example_dir / "requirements.in"
     out_path = example_dir / "requirements.txt"
-    in_path.write_bytes(
-        b"six==1.15.0\n"
-        b"setuptools\n"
-        b"pip-tools @ git+https://github.com/jazzband/pip-tools\n"
-    )
+    in_path.write_bytes(b"small-fake-a==0.1\nsmall-fake-b\n")
 
     runner.invoke(
         cli, [*opts, f"--output-file={os.fsdecode(out_path)}", os.fsdecode(in_path)]


### PR DESCRIPTION
before:
```
17.92s tests/test_cli_compile.py::test_override_newline[legacy resolver-native-annotate_options0-True]
```

after:
```
0.20s tests/test_cli_compile.py::test_override_newline[backtracking resolver-native-annotate_options0-True]
```