### PR TITLE
Speedup tests using `--no-build-isolation`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,9 @@ testing =
     pytest
     pytest-rerunfailures
     pytest-xdist
+    # build deps for tests
+    flit_core >=2,<4
+    poetry_core>=1.0.0
 coverage = pytest-cov
 
 [options.entry_points]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,9 +418,6 @@ def fake_dists(tmpdir, make_package, make_wheel):
         make_package("small-fake-a", version="0.1"),
         make_package("small-fake-b", version="0.2"),
         make_package("small-fake-c", version="0.3"),
-        make_package("small-fake-d", version="0.4"),
-        make_package("small-fake-e", version="0.5"),
-        make_package("small-fake-f", version="0.6"),
     ]
     for pkg in pkgs:
         make_wheel(pkg, dists_path)


### PR DESCRIPTION
Before:
<img width="416" alt="image" src="https://user-images.githubusercontent.com/7377671/202877387-d025b7d3-9eab-443f-acde-ae192f94f353.png">

After:
<img width="473" alt="image" src="https://user-images.githubusercontent.com/7377671/202877391-4376e3e6-d64b-4c68-92b0-e4a470e32b5f.png">


x2/x3 speedup.
<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
