### PR TITLE
Support tox v4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 skip_missing_interpreters = True
 
 [testenv]
+description = run the tests with pytest
 extras =
     testing
     coverage: coverage
@@ -24,25 +25,29 @@ passenv = CI GITHUB_ACTIONS
 pip_pre=True
 
 [testenv:checkqa]
+description = format the code base and check its quality
 skip_install = True
 deps = pre-commit
 commands_pre =
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:readme]
+description = check whether the long description will render correctly on PyPI
 deps = twine
 commands_pre =
-commands = twine check {distdir}/*
+commands =
+    python -m build -o {envtmpdir} -s -w .
+    twine check {envtmpdir}{/}*
+skip_install = true
 
 [testenv:build-docs]
-basepython = python3
+description = build the documentation
 deps =
   -r{toxinidir}/docs/requirements.txt
   # FIXME: re-enable the "-r" + "-c" paradigm once the pip bug is fixed.
   # Ref: https://github.com/pypa/pip/issues/9243
   # -r{toxinidir}/docs/requirements.in
   # -c{toxinidir}/docs/requirements.txt
-description = Build The Docs
 commands_pre =
 commands =
   # Retrieve possibly missing commits:
@@ -76,18 +81,17 @@ isolated_build = true
 passenv =
   SSH_AUTH_SOCK
 skip_install = true
-whitelist_externals =
+allowlist_externals =
   git
 
 [testenv:linkcheck-docs]
-basepython = python3
+description = check links in the documentation
 deps =
   -r{toxinidir}/docs/requirements.txt
   # FIXME: re-enable the "-r" + "-c" paradigm once the pip bug is fixed.
   # Ref: https://github.com/pypa/pip/issues/9243
   # -r{toxinidir}/docs/requirements.in
   # -c{toxinidir}/docs/requirements.txt
-description = Linkcheck The Docs
 commands_pre =
 commands =
   # Retrieve possibly missing commits:
@@ -109,5 +113,5 @@ isolated_build = true
 passenv =
   SSH_AUTH_SOCK
 skip_install = true
-whitelist_externals =
+allowlist_externals =
   git

--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,12 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:readme]
 description = check whether the long description will render correctly on PyPI
-deps = twine
+deps =
+    build
+    twine
 commands_pre =
 commands =
-    python -m build -o {envtmpdir} -s -w .
+    python -m build --outdir {envtmpdir} --sdist {toxinidir}
     twine check {envtmpdir}{/}*
 skip_install = true
 


### PR DESCRIPTION
Fixes [failed](https://github.com/jazzband/pip-tools/actions/runs/3642580320) CI jobs due to tox v4.


Failed `linkcheck-docs` job will be fixed in https://github.com/jazzband/pip-tools/pull/1758.