### PR TITLE
Fix failing tests that depend on a logger verbosity level

### DIFF
--- a/piptools/logging.py
+++ b/piptools/logging.py
@@ -16,9 +16,9 @@ class LogContext:
     stream = sys.stderr
 
     def __init__(self, verbosity: int = 0, indent_width: int = 2):
-        self.verbosity = verbosity
-        self.current_indent = 0
-        self._indent_width = indent_width
+        self.verbosity = self._initial_verbosity = verbosity
+        self.current_indent = self._initial_indent = 0
+        self._indent_width = self._initial_indent_width = indent_width
 
     def log(self, message: str, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault("err", True)
@@ -57,6 +57,12 @@ class LogContext:
             yield
         finally:
             self._dedent()
+
+    def reset(self) -> None:
+        """Reset logger to initial state."""
+        self.verbosity = self._initial_verbosity
+        self.current_indent = self._initial_indent
+        self._indent_width = self._initial_indent_width
 
 
 log = LogContext()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from pip._vendor.pkg_resources import Requirement
 from piptools._compat.pip_compat import uses_pkg_resources
 from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
+from piptools.logging import log
 from piptools.repositories import PyPIRepository
 from piptools.repositories.base import BaseRepository
 from piptools.resolver import BacktrackingResolver, LegacyResolver
@@ -432,3 +433,13 @@ def venv(tmp_path):
         check=True,
     )
     return tmp_path / ("Scripts" if platform.system() == "Windows" else "bin")
+
+
+@pytest.fixture(autouse=True)
+def _reset_log():
+    """
+    Since piptools.logging.log is a global variable we have to restore its initial
+    state. Some tests can change logger verbosity which might cause a conflict
+    with other tests that depend on it.
+    """
+    log.reset()


### PR DESCRIPTION
Reset the logger to its initial state so that tests which update or depend on logger's verbosity wouldn't [conflict](https://github.com/jazzband/pip-tools/actions/runs/3515128716/jobs/5890003279) with each other.

Partially addresses #1720.
Supersedes #1743.

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
