### PR TITLE
Fix passenv for tox v4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,9 @@ commands_pre =
     piplatest: python -m pip install -U pip
     pip --version
 commands = pytest {posargs}
-passenv = CI GITHUB_ACTIONS
+passenv =
+    CI
+    GITHUB_ACTIONS
 pip_pre=True
 
 [testenv:checkqa]


### PR DESCRIPTION
Fixes [failing](https://github.com/jazzband/pip-tools/actions/runs/3668381392/jobs/6201467032) CI:

> piplatest-coverage: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'CI GITHUB_ACTIONS'

