### PR TITLE
Add test: ignore unavailable versions in preexisting output

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -23,6 +23,12 @@ legacy_resolver_only = pytest.mark.parametrize(
     indirect=("current_resolver",),
 )
 
+backtracking_resolver_only = pytest.mark.parametrize(
+    "current_resolver",
+    ("backtracking",),
+    indirect=("current_resolver",),
+)
+
 
 @pytest.fixture(
     autouse=True,
@@ -2030,11 +2036,8 @@ def test_preserve_compiled_prerelease_version(pip_conf, runner):
     assert "small-fake-a==0.3b1" in out.stderr.splitlines()
 
 
+@backtracking_resolver_only
 def test_ignore_compiled_unavailable_version(pip_conf, runner, current_resolver):
-    if current_resolver == "legacy":
-        pytest.xfail(
-            "We know this is broken in the legacy resolver, but no fix is planned."
-        )
 
     with open("requirements.in", "w") as req_in:
         req_in.write("small-fake-a")


### PR DESCRIPTION
Before running `pip-compile`, the output file may contain a pinned requirement which can't be found in PyPI or whichever repo (e.g. a revoked release). This test checks that we gracefully discard these un-find-able pins, rather than cause the compile operation to fail.

The test only succeeds with the backtracking resolver, and is marked as xfail for legacy.

Related: 
- #1530
- #1531, which this PR replaces

I think it would be appropriate to label this with `skip-changelog`.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
