### PR TITLE
Add `pyproject.toml` as default input file format

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -33,9 +33,7 @@ from ..utils import (
 )
 from ..writer import OutputWriter
 
-DEFAULT_REQUIREMENTS_FILES = (
-    "requirements.in", "setup.py", "pyproject.toml"
-)
+DEFAULT_REQUIREMENTS_FILES = ("requirements.in", "setup.py", "pyproject.toml")
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})
 
@@ -351,8 +349,7 @@ def cli(
         else:
             raise click.BadParameter(
                 (
-                    "If you do not specify an input file, "
-                    "the default is one of: {}"
+                    "If you do not specify an input file, " "the default is one of: {}"
                 ).format(", ".join(DEFAULT_REQUIREMENTS_FILES))
             )
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -33,7 +33,12 @@ from ..utils import (
 )
 from ..writer import OutputWriter
 
-DEFAULT_REQUIREMENTS_FILES = ("requirements.in", "setup.py", "setup.cfg", "pyproject.toml")
+DEFAULT_REQUIREMENTS_FILES = (
+    "requirements.in",
+    "setup.py",
+    "setup.cfg",
+    "pyproject.toml",
+)
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -36,8 +36,8 @@ from ..writer import OutputWriter
 DEFAULT_REQUIREMENTS_FILES = (
     "requirements.in",
     "setup.py",
-    "setup.cfg",
     "pyproject.toml",
+    "setup.cfg",
 )
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -354,7 +354,7 @@ def cli(
         else:
             raise click.BadParameter(
                 (
-                    "If you do not specify an input file, " "the default is one of: {}"
+                    "If you do not specify an input file, the default is one of: {}"
                 ).format(", ".join(DEFAULT_REQUIREMENTS_FILES))
             )
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -33,7 +33,7 @@ from ..utils import (
 )
 from ..writer import OutputWriter
 
-DEFAULT_REQUIREMENTS_FILES = ("requirements.in", "setup.py", "pyproject.toml")
+DEFAULT_REQUIREMENTS_FILES = ("requirements.in", "setup.py", "setup.cfg", "pyproject.toml")
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -33,7 +33,9 @@ from ..utils import (
 )
 from ..writer import OutputWriter
 
-DEFAULT_REQUIREMENTS_FILE = "requirements.in"
+DEFAULT_REQUIREMENTS_FILES = (
+    "requirements.in", "setup.py", "pyproject.toml"
+)
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})
 
@@ -342,16 +344,16 @@ def cli(
     log.verbosity = verbose - quiet
 
     if len(src_files) == 0:
-        if os.path.exists(DEFAULT_REQUIREMENTS_FILE):
-            src_files = (DEFAULT_REQUIREMENTS_FILE,)
-        elif os.path.exists("setup.py"):
-            src_files = ("setup.py",)
+        for file_path in DEFAULT_REQUIREMENTS_FILES:
+            if os.path.exists(file_path):
+                src_files = (file_path,)
+                break
         else:
             raise click.BadParameter(
                 (
                     "If you do not specify an input file, "
-                    "the default is {} or setup.py"
-                ).format(DEFAULT_REQUIREMENTS_FILE)
+                    "the default is one of: {}"
+                ).format(", ".join(DEFAULT_REQUIREMENTS_FILES))
             )
 
     if not output_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -381,18 +381,19 @@ def make_sdist(run_setup_file):
 def make_module(tmpdir):
     """
     Make a metadata file with the given name and content and a fake module.
+
+    By default, the file is created in the temporary directory; passing the
+    `base_dir` argument allows for fine-tuning the file's location.
     """
 
-    def _make_module(fname, content, base_dir=None):
-        if base_dir is None:
-            base_dir = tmpdir
-        path = os.path.join(base_dir, "sample_lib")
+    def _make_module(fname, content):
+        path = os.path.join(tmpdir, "sample_lib")
         os.mkdir(path)
-        path = os.path.join(base_dir, "sample_lib", "__init__.py")
+        path = os.path.join(tmpdir, "sample_lib", "__init__.py")
         with open(path, "w") as stream:
             stream.write("'example module'\n__version__ = '1.2.3'")
         if fname == "setup.cfg":
-            path = os.path.join(base_dir, "pyproject.toml")
+            path = os.path.join(tmpdir, "pyproject.toml")
             with open(path, "w") as stream:
                 stream.write(
                     "\n".join(
@@ -403,7 +404,7 @@ def make_module(tmpdir):
                         )
                     )
                 )
-        path = os.path.join(base_dir, fname)
+        path = os.path.join(tmpdir, fname)
         with open(path, "w") as stream:
             stream.write(dedent(content))
         return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -381,9 +381,6 @@ def make_sdist(run_setup_file):
 def make_module(tmpdir):
     """
     Make a metadata file with the given name and content and a fake module.
-
-    By default, the file is created in the temporary directory; passing the
-    `base_dir` argument allows for fine-tuning the file's location.
     """
 
     def _make_module(fname, content):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -383,14 +383,16 @@ def make_module(tmpdir):
     Make a metadata file with the given name and content and a fake module.
     """
 
-    def _make_module(fname, content):
-        path = os.path.join(tmpdir, "sample_lib")
+    def _make_module(fname, content, base_dir=None):
+        if base_dir is None:
+            base_dir = tmpdir
+        path = os.path.join(base_dir, "sample_lib")
         os.mkdir(path)
-        path = os.path.join(tmpdir, "sample_lib", "__init__.py")
+        path = os.path.join(base_dir, "sample_lib", "__init__.py")
         with open(path, "w") as stream:
             stream.write("'example module'\n__version__ = '1.2.3'")
         if fname == "setup.cfg":
-            path = os.path.join(tmpdir, "pyproject.toml")
+            path = os.path.join(base_dir, "pyproject.toml")
             with open(path, "w") as stream:
                 stream.write(
                     "\n".join(
@@ -401,7 +403,7 @@ def make_module(tmpdir):
                         )
                     )
                 )
-        path = os.path.join(tmpdir, fname)
+        path = os.path.join(base_dir, fname)
         with open(path, "w") as stream:
             stream.write(dedent(content))
         return path

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2448,24 +2448,33 @@ METADATA_TEST_CASES = (
 
 
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
-def test_not_specified_input_file(runner, make_module, fname, content):
+def test_not_specified_input_file(runner, make_module, fname, content, tmpdir, monkeypatch):
     """
     It should raise an error if there are no input files or default input files
     such as "setup.py", "requirements.in" or "pyproject.toml".
     """
-    default_file_names = ("requirements.in", "setup.py", "pyproject.toml", "setup.cfg")
-    make_module(fname=fname, content=content, base_dir=os.getcwd())
+    make_module(fname=fname, content=content)
+
+    monkeypatch.chdir(tmpdir)
     out = runner.invoke(cli)
-    if fname in default_file_names:
-        assert "small-fake-a==0.1" in out.stderr
-        assert "small-fake-b" not in out.stderr
-        assert "small-fake-c" not in out.stderr
-        assert "extra ==" not in out.stderr
-    else:
-        assert "If you do not specify an input file" in out.stderr
-        assert out.exit_code == 2
-        for file_name in default_file_names:
-            assert file_name in out.stderr
+    monkeypatch.undo()
+
+    assert "small-fake-a==0.1" in out.stderr
+    assert "small-fake-b" not in out.stderr
+    assert "small-fake-c" not in out.stderr
+    assert "extra ==" not in out.stderr
+
+
+def test_not_specified_input_file_without_allowed_files(runner):
+    """
+    It should raise an error if there are no input files or default input files
+    such as "setup.py" or "requirements.in".
+    """
+    out = runner.invoke(cli)
+    assert "If you do not specify an input file" in out.stderr
+    assert out.exit_code == 2
+    for file_name in ("requirements.in", "setup.py", "pyproject.toml"):
+        assert file_name in out.stderr
 
 
 @pytest.mark.network

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2474,6 +2474,15 @@ def test_not_specified_input_file(
 
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1\n" == out.stdout
+            "--no-build-isolation",
+            "--find-links",
+            fake_dists,
+        ],
+    )
+    monkeypatch.undo()
+
+    assert out.exit_code == 0, out.stderr
+    assert "small-fake-a==0.1\n" == out.stdout
 
 
 def test_not_specified_input_file_without_allowed_files(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2474,15 +2474,6 @@ def test_not_specified_input_file(
 
     assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1\n" == out.stdout
-            "--no-build-isolation",
-            "--find-links",
-            fake_dists,
-        ],
-    )
-    monkeypatch.undo()
-
-    assert out.exit_code == 0, out.stderr
-    assert "small-fake-a==0.1\n" == out.stdout
 
 
 def test_not_specified_input_file_without_allowed_files(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2481,6 +2481,7 @@ def test_not_specified_input_file_without_allowed_files(runner):
     )
     assert expected_error in out.stderr.splitlines()
 
+
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_input_formats(fake_dists, runner, make_module, fname, content):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2448,7 +2448,9 @@ METADATA_TEST_CASES = (
 
 
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
-def test_not_specified_input_file(runner, make_module, fname, content, tmpdir, monkeypatch):
+def test_not_specified_input_file(
+    runner, make_module, fname, content, tmpdir, monkeypatch
+):
     """
     It should raise an error if there are no input files or default input files
     such as "setup.py", "requirements.in" or "pyproject.toml".

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2452,8 +2452,7 @@ def test_not_specified_input_file(
     runner, make_module, fname, content, tmpdir, monkeypatch
 ):
     """
-    It should raise an error if there are no input files or default input files
-    such as "setup.py", "requirements.in" or "pyproject.toml".
+    Test that a default-named file is parsed if present.
     """
     make_module(fname=fname, content=content)
 
@@ -2465,6 +2464,7 @@ def test_not_specified_input_file(
     assert "small-fake-b" not in out.stderr
     assert "small-fake-c" not in out.stderr
     assert "extra ==" not in out.stderr
+    assert out.exit_code == 1
 
 
 def test_not_specified_input_file_without_allowed_files(runner):
@@ -2475,9 +2475,11 @@ def test_not_specified_input_file_without_allowed_files(runner):
     out = runner.invoke(cli)
     assert "If you do not specify an input file" in out.stderr
     assert out.exit_code == 2
-    for file_name in ("requirements.in", "setup.py", "pyproject.toml"):
-        assert file_name in out.stderr
-
+    expected_error = (
+        "Error: Invalid value: If you do not specify an input file, the default "
+        "is one of: requirements.in, setup.py, pyproject.toml, setup.cfg"
+    )
+    assert expected_error in out.stderr.splitlines()
 
 @pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2447,24 +2447,24 @@ METADATA_TEST_CASES = (
 )
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(("fname", "content"), METADATA_TEST_CASES)
 def test_not_specified_input_file(
-    runner, make_module, fname, content, tmpdir, monkeypatch
+    fake_dists, runner, make_module, fname, content, monkeypatch
 ):
     """
     Test that a default-named file is parsed if present.
     """
-    make_module(fname=fname, content=content)
-
-    monkeypatch.chdir(tmpdir)
-    out = runner.invoke(cli)
+    meta_path = make_module(fname=fname, content=content)
+    monkeypatch.chdir(os.path.dirname(meta_path))
+    out = runner.invoke(cli, ["-n", "--no-build-isolation", "--find-links", fake_dists])
     monkeypatch.undo()
 
+    assert out.exit_code == 0, out.stderr
     assert "small-fake-a==0.1" in out.stderr
     assert "small-fake-b" not in out.stderr
     assert "small-fake-c" not in out.stderr
     assert "extra ==" not in out.stderr
-    assert out.exit_code == 1
 
 
 def test_not_specified_input_file_without_allowed_files(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2473,7 +2473,6 @@ def test_not_specified_input_file_without_allowed_files(runner):
     such as "setup.py" or "requirements.in".
     """
     out = runner.invoke(cli)
-    assert "If you do not specify an input file" in out.stderr
     assert out.exit_code == 2
     expected_error = (
         "Error: Invalid value: If you do not specify an input file, the default "

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2457,14 +2457,23 @@ def test_not_specified_input_file(
     """
     meta_path = make_module(fname=fname, content=content)
     monkeypatch.chdir(os.path.dirname(meta_path))
-    out = runner.invoke(cli, ["-n", "--no-build-isolation", "--find-links", fake_dists])
+    out = runner.invoke(
+        cli,
+        [
+            "--output-file",
+            "-",
+            "--no-header",
+            "--no-emit-options",
+            "--no-annotate",
+            "--no-build-isolation",
+            "--find-links",
+            fake_dists,
+        ],
+    )
     monkeypatch.undo()
 
     assert out.exit_code == 0, out.stderr
-    assert "small-fake-a==0.1" in out.stderr
-    assert "small-fake-b" not in out.stderr
-    assert "small-fake-c" not in out.stderr
-    assert "extra ==" not in out.stderr
+    assert "small-fake-a==0.1\n" == out.stdout
 
 
 def test_not_specified_input_file_without_allowed_files(runner):


### PR DESCRIPTION
Added `pyproject.toml` as a default input file name that is searched for when `pip-compile` is invoked without arguments; see https://github.com/jazzband/pip-tools/issues/1779 for details.

The default file names are searched in the following order, with the first encountered being used to compile:

1. `requirements.in`
2. `setup.py`
3. `setup.cfg`
4. `pyproject.toml`

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
