### PR TITLE
Raise error if input and output filenames are matched

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -382,7 +382,7 @@ def cli(
             ctx.call_on_close(safecall(output_file.close_intelligently))
 
     for src_file in src_files:
-        if src_file == output_file.name:
+        if src_file != "-" and src_file == output_file.name:
             raise click.BadArgumentUsage(
                 f"input and output filenames must not be matched: {src_file}"
             )

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -381,6 +381,12 @@ def cli(
         if isinstance(output_file, LazyFile):  # pragma: no cover
             ctx.call_on_close(safecall(output_file.close_intelligently))
 
+    for src_file in src_files:
+        if src_file == output_file.name:
+            raise click.BadArgumentUsage(
+                f"input and output filenames must not be matched: {src_file}"
+            )
+
     if resolver_name == "legacy":
         log.warning(
             "WARNING: the legacy dependency resolver is deprecated and will be removed"

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -381,11 +381,10 @@ def cli(
         if isinstance(output_file, LazyFile):  # pragma: no cover
             ctx.call_on_close(safecall(output_file.close_intelligently))
 
-    for src_file in src_files:
-        if src_file != "-" and src_file == output_file.name:
-            raise click.BadArgumentUsage(
-                f"input and output filenames must not be matched: {src_file}"
-            )
+    if output_file.name != "-" and output_file.name in src_files:
+        raise click.BadArgumentUsage(
+            f"input and output filenames must not be matched: {output_file.name}"
+        )
 
     if resolver_name == "legacy":
         log.warning(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2741,3 +2741,31 @@ def test_print_deprecation_warning_if_using_legacy_resolver(runner, current_reso
         assert expected_warning in out.stderr
     else:
         assert expected_warning not in out.stderr
+
+
+@pytest.mark.parametrize(
+    "input_filenames",
+    (
+        pytest.param(("requirements.txt",), id="one file"),
+        pytest.param(("requirements.txt", "dev-requirements.in"), id="multiple files"),
+    ),
+)
+def test_raise_error_when_input_and_output_filenames_are_matched(
+    runner, tmp_path, input_filenames
+):
+    req_in_paths = []
+    for input_filename in input_filenames:
+        req_in = tmp_path / input_filename
+        req_in.touch()
+        req_in_paths.append(req_in.as_posix())
+
+    req_out = tmp_path / "requirements.txt"
+    req_out_path = req_out.as_posix()
+
+    out = runner.invoke(cli, req_in_paths + ["--output-file", req_out_path])
+    assert out.exit_code == 2
+
+    expected_error = (
+        f"Error: input and output filenames must not be matched: {req_out_path}"
+    )
+    assert expected_error in out.stderr.splitlines()


### PR DESCRIPTION
Fixes #1762.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
