### PR TITLE
Fix a regression with unsafe packages for `--allow-unsafe`

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -181,7 +181,7 @@ class OutputWriter:
         hashes: dict[InstallRequirement, set[str]] | None = None,
     ) -> Iterator[str]:
         # default values
-        unsafe_packages = unsafe_packages if not self.allow_unsafe else set()
+        unsafe_packages = unsafe_packages if self.allow_unsafe else set()
         hashes = hashes or {}
 
         # Check for unhashed or unpinned packages if at least one package does have

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1500,6 +1500,8 @@ def test_annotate_option(pip_conf, runner, options, expected):
                 """\
                 small-fake-a==0.1
                 small-fake-b==0.3
+
+                # The following packages are considered to be unsafe in a requirements file:
                 small-fake-with-deps==0.1
                 """
             ),


### PR DESCRIPTION
<!--- Describe the changes here. --->
Closes #1786
##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
