### PR TITLE
Include package local versions in --generate-hashes

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -383,10 +383,11 @@ class PyPIRepository(BaseRepository):
         # satisfy this constraint.
         all_candidates = self.find_all_candidates(ireq.name)
         candidates_by_version = lookup_table(all_candidates, key=candidate_version)
-        matching_versions = list(
+        matching_versions = set(
             ireq.specifier.filter(candidate.version for candidate in all_candidates)
         )
-        return candidates_by_version[matching_versions[0]]
+        candidates_for_all_versions = [candidates_by_version[mv] for mv in matching_versions]
+        return set().union(*candidates_for_all_versions)
 
     def _get_file_hash(self, link: Link) -> str:
         log.debug(f"Hashing {link.show_url}")

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -386,7 +386,9 @@ class PyPIRepository(BaseRepository):
         matching_versions = set(
             ireq.specifier.filter(candidate.version for candidate in all_candidates)
         )
-        candidates_for_all_versions = [candidates_by_version[mv] for mv in matching_versions]
+        candidates_for_all_versions = [
+            candidates_by_version[mv] for mv in matching_versions
+        ]
         return set().union(*candidates_for_all_versions)
 
     def _get_file_hash(self, link: Link) -> str:


### PR DESCRIPTION
Enables using --generate-hashes with packages that have local versions (https://peps.python.org/pep-0440/#local-version-identifiers). Some public projects, like PyTorch (https://download.pytorch.org/whl/cpu) use local versions for distributing different builds of their packages.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
