### PR TITLE
Fix for sync error when the ireqs being merged have no names

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -104,7 +104,11 @@ def merge(
                 if existing_ireq:
                     # NOTE: We check equality here since we can assume that the
                     # requirements are all pinned
-                    if ireq.specifier != existing_ireq.specifier:
+                    if (
+                        ireq.req
+                        and existing_ireq.req
+                        and ireq.specifier != existing_ireq.specifier
+                    ):
                         raise IncompatibleRequirements(ireq, existing_ireq)
 
             # TODO: Always pick the largest specifier in case of a conflict

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -115,6 +115,26 @@ def test_merge_urls(from_line):
     )
 
 
+@pytest.mark.parametrize(
+    "install_req",
+    (
+        "from_line",
+        "from_editable",
+    ),
+)
+def test_merge_no_name_urls(install_req, request):
+    install_req = request.getfixturevalue(install_req)
+    url = "file:///example.zip"
+    requirements = [
+        install_req(url),
+        install_req(url),
+    ]
+
+    assert Counter(requirements[1:]) == Counter(
+        merge(requirements, ignore_conflicts=False)
+    )
+
+
 def test_diff_should_do_nothing():
     installed = []  # empty env
     reqs = []  # no requirements


### PR DESCRIPTION
When no name was provided, the ireqs would have no underlying req attribute. Calling `ireq.specifier` while comparing them in `merge`, would raise an `AttributeError`.

Fixes #1710 

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
