### PR TITLE
Remove extras from user-supplied constraints in backtracking resolver (fixes #1806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 6.12.2 (2022-12-25)
+
+Bug Fixes:
+
+- Raise error if input and output filenames are matched
+  ([#1787](https://github.com/jazzband/pip-tools/pull/1787)). Thanks @atugushev
+- Add `pyproject.toml` as default input file format
+  ([#1780](https://github.com/jazzband/pip-tools/pull/1780)). Thanks @berislavlopac
+- Fix a regression with unsafe packages for `--allow-unsafe`
+  ([#1788](https://github.com/jazzband/pip-tools/pull/1788)). Thanks @q0w
+
 ## 6.12.1 (2022-12-16)
 
 Bug Fixes:

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -520,6 +520,8 @@ class BacktrackingResolver(BaseResolver):
         ), get_build_tracker() as build_tracker, global_tempdir_manager(), indent_log():
             # Mark direct/primary/user_supplied packages
             for ireq in self.constraints:
+                if ireq.constraint:
+                    ireq.extras = set()  # pip does not support extras in constraints
                 ireq.user_supplied = True
 
             # Pass compiled requirements from `requirements.txt`
@@ -535,7 +537,7 @@ class BacktrackingResolver(BaseResolver):
                     if not primary_ireq.specifier.contains(version, prereleases):
                         continue
 
-                ireq.extras = set()  # pip does not support extras in constraints
+                ireq.extras = set()
                 ireq.constraint = True
                 ireq.user_supplied = False
                 compatible_existing_constraints[key_from_ireq(ireq)] = ireq

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -939,6 +939,29 @@ def test_upgrade_packages_version_option_and_upgrade_no_existing_file(pip_conf, 
     assert "small-fake-b==0.1" in out.stderr
 
 
+def test_upgrade_packages_with_extra(pip_conf, make_package, runner):
+    """
+    piptools ignores extras on --upgrade-package/-P items if already constrained.
+    """
+    package_with_extra = make_package(
+        "package_with_extra",
+        extras_require={
+            "extra": ["small-fake-a==0.1"],
+        },
+    )
+
+    with open("requirements.in", "w") as req_in:
+        req_in.write(f"{package_with_extra}[extra]")
+
+    out = runner.invoke(
+        cli, ["--no-annotate", "--upgrade-package", "package_with_extra[extra]"]
+    )
+
+    assert out.exit_code == 0
+    assert "package_with_extra" in out.stderr
+    assert "small-fake-a==" in out.stderr
+
+
 def test_quiet_option(pip_conf, runner):
     with open("requirements.in", "w") as req_in:
         req_in.write("small-fake-a")

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -956,7 +956,7 @@ def test_upgrade_package_with_extra(runner, make_package, make_sdist, tmpdir):
 
     # Constrain our requirement with an extra
     with open("requirements.in", "w") as req_in:
-        req_in.write(f"test-package-1[more]")
+        req_in.write("test-package-1[more]")
 
     # Run update on test-package-1[more] -- this should be equivalent to running update on test-package-1
     out = runner.invoke(
@@ -979,7 +979,7 @@ def test_upgrade_package_with_extra(runner, make_package, make_sdist, tmpdir):
     assert out.exit_code == 0, out
     assert (
         dedent(
-            f"""\
+            """\
             test-package-1[more]==0.1
             test-package-2==0.1
             """

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -939,7 +939,7 @@ def test_upgrade_packages_version_option_and_upgrade_no_existing_file(pip_conf, 
     assert "small-fake-b==0.1" in out.stderr
 
 
-def test_upgrade_packages_with_extra(pip_conf, make_package, runner):
+def test_upgrade_package_with_extra(pip_conf, make_package, runner):
     """
     piptools ignores extras on --upgrade-package/-P items if already constrained.
     """

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -958,7 +958,8 @@ def test_upgrade_package_with_extra(runner, make_package, make_sdist, tmpdir):
     with open("requirements.in", "w") as req_in:
         req_in.write("test-package-1[more]")
 
-    # Run update on test-package-1[more] -- this should be equivalent to running update on test-package-1
+    # Run update on test-package-1[more] -- this should be equivalent
+    # to running an update on test-package-1
     out = runner.invoke(
         cli,
         [

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -972,8 +972,8 @@ def test_upgrade_package_with_extra(runner, make_package, make_sdist, tmpdir):
             "--no-emit-options",
             "--no-build-isolation",
             "--upgrade-package",
-            "test-package-1[more]"
-        ]
+            "test-package-1[more]",
+        ],
     )
 
     assert out.exit_code == 0, out


### PR DESCRIPTION
This change ensures extras are removed from user-supplied constraints in the backtracking resolver, fixing #1806 and https://github.com/dependabot/dependabot-core/pull/6550. Credit goes to @deivid-rodriguez for the suggestion.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
