### PR TITLE
Pass `--cache-dir` to `--pip-args` for backtracking resolver

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -424,6 +424,8 @@ def cli(
         pip_args.append("--no-build-isolation")
     if resolver_name == "legacy":
         pip_args.extend(["--use-deprecated", "legacy-resolver"])
+    if resolver_name == "backtracking" and cache_dir:
+        pip_args.extend(["--cache-dir", cache_dir])
     pip_args.extend(right_args)
 
     repository: BaseRepository

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2853,3 +2853,18 @@ def test_raise_error_when_input_and_output_filenames_are_matched(
         f"Error: input and output filenames must not be matched: {req_out_path}"
     )
     assert expected_error in out.stderr.splitlines()
+
+
+@pytest.mark.network
+@backtracking_resolver_only
+def test_pass_pip_cache_to_pip_args(tmpdir, runner, current_resolver):
+    cache_dir = tmpdir.mkdir("cache_dir")
+
+    with open("requirements.in", "w") as fp:
+        fp.write("six==1.15.0")
+
+    out = runner.invoke(
+        cli, ["--cache-dir", str(cache_dir), "--resolver", current_resolver]
+    )
+    assert out.exit_code == 0
+    assert os.listdir(os.path.join(str(cache_dir), "http"))


### PR DESCRIPTION
<!--- Describe the changes here. --->
Closes #1795 
##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
