### PR TITLE
Add support for `pip==23.1` where deprecated `--install-option` has been removed

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -21,6 +21,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Distribution, Requirement, get_distribution
 
+from piptools._compat import PIP_VERSION
 from piptools.subprocess_utils import run_python_snippet
 
 _KT = TypeVar("_KT")
@@ -456,7 +457,6 @@ def copy_install_requirement(
         "markers": template.markers,
         "use_pep517": template.use_pep517,
         "isolated": template.isolated,
-        "install_options": template.install_options,
         "global_options": template.global_options,
         "hash_options": template.hash_options,
         "constraint": template.constraint,
@@ -464,6 +464,9 @@ def copy_install_requirement(
         "user_supplied": template.user_supplied,
     }
     kwargs.update(extra_kwargs)
+
+    if PIP_VERSION[:2] <= (23, 0):
+        kwargs["install_options"] = template.install_options
 
     # Original link does not belong to install requirements constructor,
     # pop it now to update later.


### PR DESCRIPTION
Resolves #1825.


##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
