### PR TITLE
Add support for pip==23.1 where removed FormatControl in WheelCache

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .pip_compat import PIP_VERSION, parse_requirements
+from .pip_compat import PIP_VERSION, create_wheel_cache, parse_requirements
 
-__all__ = ["PIP_VERSION", "parse_requirements"]
+__all__ = ["PIP_VERSION", "parse_requirements", "create_wheel_cache"]

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -4,6 +4,7 @@ import optparse
 from typing import Callable, Iterable, Iterator, cast
 
 import pip
+from pip._internal.cache import WheelCache
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement
@@ -74,3 +75,10 @@ else:
             for req in reqs
             if not req.marker or req.marker.evaluate({"extra": None})
         ]
+
+
+def create_wheel_cache(cache_dir: str, format_control: str | None = None) -> WheelCache:
+    kwargs: dict[str, str | None] = {"cache_dir": cache_dir}
+    if PIP_VERSION[:2] <= (23, 0):
+        kwargs["format_control"] = format_control
+    return WheelCache(**kwargs)

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -30,6 +30,7 @@ from pip._vendor.packaging.tags import Tag
 from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.requests import RequestException, Session
 
+from .._compat import create_wheel_cache
 from ..exceptions import NoCandidateFound
 from ..logging import log
 from ..utils import (
@@ -234,7 +235,10 @@ class PyPIRepository(BaseRepository):
                 os.makedirs(download_dir, exist_ok=True)
 
             with global_tempdir_manager():
-                wheel_cache = WheelCache(self._cache_dir, self.options.format_control)
+                wheel_cache = create_wheel_cache(
+                    cache_dir=self._cache_dir,
+                    format_control=self.options.format_control,
+                )
                 self._dependencies_cache[ireq] = self.resolve_reqs(
                     download_dir, ireq, wheel_cache
                 )

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -8,7 +8,6 @@ from itertools import chain, count, groupby
 from typing import Any, Container, DefaultDict, Iterable, Iterator
 
 import click
-from pip._internal.cache import WheelCache
 from pip._internal.exceptions import DistributionNotFound
 from pip._internal.operations.build.build_tracker import (
     get_build_tracker,
@@ -28,6 +27,7 @@ from pip._vendor.resolvelib.resolvers import ResolutionImpossible, Result
 from piptools.cache import DependencyCache
 from piptools.repositories.base import BaseRepository
 
+from ._compat import create_wheel_cache
 from .exceptions import PipToolsError
 from .logging import log
 from .utils import (
@@ -542,8 +542,9 @@ class BacktrackingResolver(BaseResolver):
                 ireq.user_supplied = False
                 compatible_existing_constraints[key_from_ireq(ireq)] = ireq
 
-            wheel_cache = WheelCache(
-                self.options.cache_dir, self.options.format_control
+            wheel_cache = create_wheel_cache(
+                cache_dir=self.options.cache_dir,
+                format_control=self.options.format_control,
             )
 
             temp_dir = TempDirectory(


### PR DESCRIPTION
https://github.com/pypa/pip/pull/11872


##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
