### PR TITLE
Use continue-on-error on pip-version=main matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
   test:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,10 +53,12 @@ jobs:
         pip-version:
           - "latest"
           - "previous"
+        experimental: [false]
         include:
           - os: Ubuntu
             python-version: 3.7
             pip-version: main
+            experimental: true
     env:
       TOXENV: pip${{ matrix.pip-version }}-coverage
     steps:


### PR DESCRIPTION
Don't block PRs if tests are failing against pip's main branch. 