### PR TITLE
Use covdefaults

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,8 @@
 [run]
-branch = True
-source = .
+plugins = covdefaults
 omit =
     piptools/_compat/*
 
 [report]
 include = piptools/*, tests/*
+fail_under = 99

--- a/piptools/__main__.py
+++ b/piptools/__main__.py
@@ -15,5 +15,5 @@ cli.add_command(sync.cli, "sync")
 
 
 # Enable ``python -m piptools ...``.
-if __name__ == "__main__":  # pragma: no branch
+if __name__ == "__main__":
     cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testing = [
   "flit_core >=2,<4",
   "poetry_core>=1.0.0",
 ]
-coverage = ["pytest-cov"]
+coverage = ["covdefaults", "pytest-cov"]
 
 [project.scripts]
 pip-compile = "piptools.scripts.compile:cli"

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2809,7 +2809,7 @@ def test_failure_of_legacy_resolver_prompts_for_backtracking(
         assert "Consider using backtracking resolver with" in out.stderr
     elif current_resolver == "backtracking":
         assert out.exit_code == 0, out
-    else:  # pragma: no cover
+    else:
         raise AssertionError("unreachable")
 
 


### PR DESCRIPTION
It provides many sensible default settings, e.g. [exclude_lines](https://github.com/asottile/covdefaults#coveragereport).
Also addresses https://github.com/jazzband/pip-tools/pull/1791#issuecomment-1499658356