### PR TITLE
Add pyprojects.toml example for using setuptools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,19 +91,13 @@ and you want to pin it for production. You can declare the project metadata as:
     build-backend = "setuptools.build_meta"
 
     [project]
+    requires-python = ">=3.9"
     name = "foobar"
-    description = "foobar description"
-    classifiers = [
-        "Programming Language :: Python",    
-        "Programming Language :: Python :: 3",
-    ]
-    dynamic = ["version", "dependencies"]
-
-    [project.urls]
-    homepage = "https://github.com/xyz/foobar"
+    dynamic = ["dependencies", "optional-dependencies"]
 
     [tool.setuptools.dynamic]
-    dependencies = { file = [".config/requirements.in"] }
+    dependencies = { file = ["requirements.in"] }
+    optional-dependencies.test = { file = ["requirements-test.txt"] }
 
 If you have a Django application that is packaged using ``Hatch``, and you
 want to pin it for production. You also want to pin your development tools

--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,34 @@ supports both installing your ``project.dependencies`` as well as your
 ``project.optional-dependencies``. Thanks to the fact that this is an
 official standard, you can use ``pip-compile`` to pin the dependencies
 in projects that use modern standards-adhering packaging tools like
-`Hatch <https://hatch.pypa.io/>`_ or `flit <https://flit.pypa.io/>`_.
+`Setuptools <https://setuptools.pypa.io>`_ , `Hatch <https://hatch.pypa.io/>`_
+or `flit <https://flit.pypa.io/>`_.
 
-Suppose you have a Django application that is packaged using ``Hatch``, and you
+Suppose you have a 'foobar' Python application that is packaged using ``Setuptools``,
+and you want to pin it for production. You can declare the project metadata as:
+
+.. code-block:: toml
+
+    [build-system]
+    requires = ["setuptools", "setuptools-scm"]
+    build-backend = "setuptools.build_meta"
+
+    [project]
+    name = "foobar"
+    description = "foobar description"
+    classifiers = [
+        "Programming Language :: Python",    
+        "Programming Language :: Python :: 3",
+    ]
+    dynamic = ["version", "dependencies"]
+
+    [project.urls]
+    homepage = "https://github.com/xyz/foobar"
+
+    [tool.setuptools.dynamic]
+    dependencies = { file = [".config/requirements.in"] }
+
+If you have a Django application that is packaged using ``Hatch``, and you
 want to pin it for production. You also want to pin your development tools
 in a separate pin file. You declare ``django`` as a dependency and create an
 optional dependency ``dev`` that includes ``pytest``:


### PR DESCRIPTION
<!--- Describe the changes here. --->
This will add example of pyproject.toml when using with setuptools.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Fixes: #1816