### PR TITLE
Support config defaults using .pip-tools.toml or pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,6 @@ repos:
           - toml==0.10.2
           - pip==20.3.4
           - build==0.9.0
-          - types-toml==0.10.2
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
           - toml==0.10.2
           - pip==20.3.4
           - build==0.9.0
+          - types-toml==0.10.2
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ $ pip-compile requirements.in --pip-args "--retries 10 --timeout 30"
 
 You can define project-level defaults for `pip-compile` and `pip-sync` by
 writing them to a configuration file in the same directory as your requirements
-input file. By default, both `pip-compile` and `pip-sync` will look first
+input files (or the current working directory if piping input from stdin). 
+By default, both `pip-compile` and `pip-sync` will look first
 for a `.pip-tools.toml` file and then in your `pyproject.toml`. You can
 also specify an alternate TOML configuration file with the `--config` option.
 
@@ -291,11 +292,6 @@ For example, to by default generate `pip` hashes in the resulting
 requirements file output, you can specify in a configuration file
 
 ```toml
-# In a .pip-tools.toml file
-[pip-tools]
-generate-hashes = true
-
-# In a pyproject.toml file
 [tool.pip-tools]
 generate-hashes = true
 ```

--- a/README.md
+++ b/README.md
@@ -281,6 +281,29 @@ $ pip-compile requirements.in --pip-args "--retries 10 --timeout 30"
 
 ### Configuration
 
+You can define project-level defaults for `pip-compile` and `pip-sync` by
+writing them to a configuration file in the same directory as your requirements
+input file. By default, both `pip-compile` and `pip-sync` will look first
+for a `.pip-tools.toml` file and then in your `pyproject.toml`. You can
+also specify an alternate TOML configuration file with the `--config` option.
+
+For example, to by default generate `pip` hashes in the resulting
+requirements file output, you can specify in a configuration file
+
+```toml
+# In a .pip-tools.toml file
+[pip-tools]
+generate-hashes = true
+
+# In a pyproject.toml file
+[tool.pip-tools]
+generate-hashes = true
+```
+
+Options to `pip-compile` and `pip-sync` that may be used more than once
+must be defined as lists in a configuration file, even if they only have one
+value.
+
 You might be wrapping the `pip-compile` command in another script. To avoid
 confusing consumers of your custom script you can override the update command
 generated at the top of requirements files by setting the

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ $ pip-compile requirements.in --pip-args "--retries 10 --timeout 30"
 
 You can define project-level defaults for `pip-compile` and `pip-sync` by
 writing them to a configuration file in the same directory as your requirements
-input files (or the current working directory if piping input from stdin). 
+input files (or the current working directory if piping input from stdin).
 By default, both `pip-compile` and `pip-sync` will look first
 for a `.pip-tools.toml` file and then in your `pyproject.toml`. You can
 also specify an alternate TOML configuration file with the `--config` option.
@@ -294,6 +294,7 @@ requirements file output, you can specify in a configuration file
 ```toml
 [tool.pip-tools]
 generate-hashes = true
+
 ```
 
 Options to `pip-compile` and `pip-sync` that may be used more than once

--- a/piptools/locations.py
+++ b/piptools/locations.py
@@ -4,3 +4,6 @@ from pip._internal.utils.appdirs import user_cache_dir
 
 # The user_cache_dir helper comes straight from pip itself
 CACHE_DIR = user_cache_dir("pip-tools")
+
+# The project defaults specific to pip-tools should be written to this filename
+CONFIG_FILE_NAME = ".pip-tools.toml"

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -27,8 +27,8 @@ from ..repositories.base import BaseRepository
 from ..resolver import BacktrackingResolver, LegacyResolver
 from ..utils import (
     UNSAFE_PACKAGES,
-    determine_config_file,
     dedup,
+    determine_config_file,
     drop_extras,
     is_pinned_requirement,
     key_from_ireq,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -27,7 +27,7 @@ from ..repositories.base import BaseRepository
 from ..resolver import BacktrackingResolver, LegacyResolver
 from ..utils import (
     UNSAFE_PACKAGES,
-    callback_config_file_defaults,
+    determine_config_file,
     dedup,
     drop_extras,
     is_pinned_requirement,
@@ -317,7 +317,7 @@ def _determine_linesep(
     help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
     "pyproject.toml.",
     is_eager=True,
-    callback=callback_config_file_defaults,
+    callback=determine_config_file,
 )
 def cli(
     ctx: click.Context,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -31,6 +31,7 @@ from ..utils import (
     is_pinned_requirement,
     key_from_ireq,
     parse_requirements_from_wheel_metadata,
+    pyproject_toml_defaults_cb,
 )
 from ..writer import OutputWriter
 
@@ -302,6 +303,20 @@ def _determine_linesep(
     help="Specify a package to consider unsafe; may be used more than once. "
     f"Replaces default unsafe packages: {', '.join(sorted(UNSAFE_PACKAGES))}",
 )
+@click.option(
+    "--config",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=False,
+        path_type=str,
+    ),
+    help="Path to a pyproject.toml file with specialized defaults for pip-tools",
+    is_eager=True,
+    callback=pyproject_toml_defaults_cb,
+)
 def cli(
     ctx: click.Context,
     verbose: int,
@@ -340,6 +355,7 @@ def cli(
     emit_index_url: bool,
     emit_options: bool,
     unsafe_package: tuple[str, ...],
+    config: str | None,
 ) -> None:
     """
     Compiles requirements.txt from requirements.in, pyproject.toml, setup.cfg,
@@ -390,6 +406,9 @@ def cli(
         raise click.BadArgumentUsage(
             f"input and output filenames must not be matched: {output_file.name}"
         )
+
+    if config:
+        log.info(f"Using pip-tools configuration defaults found in '{config}'.")
 
     if resolver_name == "legacy":
         log.warning(

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -16,6 +16,7 @@ from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 
+from pathlib import Path
 from .._compat import parse_requirements
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError
@@ -356,7 +357,7 @@ def cli(
     emit_index_url: bool,
     emit_options: bool,
     unsafe_package: tuple[str, ...],
-    config: str | None,
+    config: Path | None,
 ) -> None:
     """
     Compiles requirements.txt from requirements.in, pyproject.toml, setup.cfg,
@@ -409,7 +410,7 @@ def cli(
         )
 
     if config:
-        log.info(f"Using pip-tools configuration defaults found in '{config}'.")
+        log.info(f"Using pip-tools configuration defaults found in '{config !s}'.")
 
     if resolver_name == "legacy":
         log.warning(

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -28,7 +28,7 @@ from ..resolver import BacktrackingResolver, LegacyResolver
 from ..utils import (
     UNSAFE_PACKAGES,
     dedup,
-    determine_config_file,
+    override_defaults_from_config_file,
     drop_extras,
     is_pinned_requirement,
     key_from_ireq,
@@ -317,7 +317,7 @@ def _determine_linesep(
     help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
     "pyproject.toml.",
     is_eager=True,
-    callback=determine_config_file,
+    callback=override_defaults_from_config_file,
 )
 def cli(
     ctx: click.Context,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -28,10 +28,10 @@ from ..resolver import BacktrackingResolver, LegacyResolver
 from ..utils import (
     UNSAFE_PACKAGES,
     dedup,
-    override_defaults_from_config_file,
     drop_extras,
     is_pinned_requirement,
     key_from_ireq,
+    override_defaults_from_config_file,
     parse_requirements_from_wheel_metadata,
 )
 from ..writer import OutputWriter

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -19,19 +19,19 @@ from pip._internal.utils.misc import redact_auth_from_url
 from .._compat import parse_requirements
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError
-from ..locations import CACHE_DIR
+from ..locations import CACHE_DIR, CONFIG_FILE_NAME
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..repositories.base import BaseRepository
 from ..resolver import BacktrackingResolver, LegacyResolver
 from ..utils import (
     UNSAFE_PACKAGES,
+    callback_config_file_defaults,
     dedup,
     drop_extras,
     is_pinned_requirement,
     key_from_ireq,
     parse_requirements_from_wheel_metadata,
-    pyproject_toml_defaults_cb,
 )
 from ..writer import OutputWriter
 
@@ -313,9 +313,10 @@ def _determine_linesep(
         allow_dash=False,
         path_type=str,
     ),
-    help="Path to a pyproject.toml file with specialized defaults for pip-tools",
+    help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
+    "pyproject.toml.",
     is_eager=True,
-    callback=pyproject_toml_defaults_cb,
+    callback=callback_config_file_defaults,
 )
 def cli(
     ctx: click.Context,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import sys
 import tempfile
+from pathlib import Path
 from typing import IO, Any, BinaryIO, cast
 
 import click
@@ -16,7 +17,6 @@ from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 
-from pathlib import Path
 from .._compat import parse_requirements
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -22,11 +22,11 @@ from ..locations import CONFIG_FILE_NAME
 from ..logging import log
 from ..repositories import PyPIRepository
 from ..utils import (
-    override_defaults_from_config_file,
     flat_map,
     get_pip_version_for_python_executable,
     get_required_pip_specification,
     get_sys_path_for_python_executable,
+    override_defaults_from_config_file,
 )
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -17,14 +17,15 @@ from .. import sync
 from .._compat import parse_requirements
 from .._compat.pip_compat import Distribution
 from ..exceptions import PipToolsError
+from ..locations import CONFIG_FILE_NAME
 from ..logging import log
 from ..repositories import PyPIRepository
 from ..utils import (
+    callback_config_file_defaults,
     flat_map,
     get_pip_version_for_python_executable,
     get_required_pip_specification,
     get_sys_path_for_python_executable,
-    pyproject_toml_defaults_cb,
 )
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
@@ -97,9 +98,10 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
         allow_dash=False,
         path_type=str,
     ),
-    help="Path to a pyproject.toml file with specialized defaults for pip-tools",
+    help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
+    "pyproject.toml.",
     is_eager=True,
-    callback=pyproject_toml_defaults_cb,
+    callback=callback_config_file_defaults,
 )
 def cli(
     ask: bool,

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -22,7 +22,7 @@ from ..locations import CONFIG_FILE_NAME
 from ..logging import log
 from ..repositories import PyPIRepository
 from ..utils import (
-    callback_config_file_defaults,
+    determine_config_file,
     flat_map,
     get_pip_version_for_python_executable,
     get_required_pip_specification,
@@ -102,7 +102,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
     "pyproject.toml.",
     is_eager=True,
-    callback=callback_config_file_defaults,
+    callback=determine_config_file,
 )
 def cli(
     ask: bool,

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -22,7 +22,7 @@ from ..locations import CONFIG_FILE_NAME
 from ..logging import log
 from ..repositories import PyPIRepository
 from ..utils import (
-    determine_config_file,
+    override_defaults_from_config_file,
     flat_map,
     get_pip_version_for_python_executable,
     get_required_pip_specification,
@@ -102,7 +102,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
     "pyproject.toml.",
     is_eager=True,
-    callback=determine_config_file,
+    callback=override_defaults_from_config_file,
 )
 def cli(
     ask: bool,

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -24,6 +24,7 @@ from ..utils import (
     get_pip_version_for_python_executable,
     get_required_pip_specification,
     get_sys_path_for_python_executable,
+    pyproject_toml_defaults_cb,
 )
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
@@ -86,6 +87,20 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 )
 @click.argument("src_files", required=False, type=click.Path(exists=True), nargs=-1)
 @click.option("--pip-args", help="Arguments to pass directly to pip install.")
+@click.option(
+    "--config",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=False,
+        path_type=str,
+    ),
+    help="Path to a pyproject.toml file with specialized defaults for pip-tools",
+    is_eager=True,
+    callback=pyproject_toml_defaults_cb,
+)
 def cli(
     ask: bool,
     dry_run: bool,
@@ -103,6 +118,7 @@ def cli(
     client_cert: str | None,
     src_files: tuple[str, ...],
     pip_args: str | None,
+    config: str | None,
 ) -> None:
     """Synchronize virtual environment with requirements.txt."""
     log.verbosity = verbose - quiet
@@ -126,6 +142,9 @@ def cli(
         else:
             log.error("ERROR: " + msg)
             sys.exit(2)
+
+    if config:
+        log.info(f"Using pip-tools configuration defaults found in '{config}'.")
 
     if python_executable:
         _validate_python_executable(python_executable)

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -14,6 +14,7 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_environment
 
 from .. import sync
+from pathlib import Path
 from .._compat import parse_requirements
 from .._compat.pip_compat import Distribution
 from ..exceptions import PipToolsError
@@ -120,7 +121,7 @@ def cli(
     client_cert: str | None,
     src_files: tuple[str, ...],
     pip_args: str | None,
-    config: str | None,
+    config: Path | None,
 ) -> None:
     """Synchronize virtual environment with requirements.txt."""
     log.verbosity = verbose - quiet
@@ -146,7 +147,7 @@ def cli(
             sys.exit(2)
 
     if config:
-        log.info(f"Using pip-tools configuration defaults found in '{config}'.")
+        log.info(f"Using pip-tools configuration defaults found in '{config !s}'.")
 
     if python_executable:
         _validate_python_executable(python_executable)

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import shutil
 import sys
+from pathlib import Path
 from typing import cast
 
 import click
@@ -14,7 +15,6 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_environment
 
 from .. import sync
-from pathlib import Path
 from .._compat import parse_requirements
 from .._compat.pip_compat import Distribution
 from ..exceptions import PipToolsError

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -566,10 +566,9 @@ def callback_config_file_defaults(
     if not config:
         return None
 
-    defaults: dict[str, Any] = ctx.default_map.copy() if ctx.default_map else {}
-    defaults.update(config)
-
-    ctx.default_map = defaults
+    if ctx.default_map is None:
+        ctx.default_map = {}
+    ctx.default_map.update(config)
     return config_file
 
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -575,17 +575,17 @@ def select_config_file(src_files: tuple[str, ...]) -> Path | None:
     """
     Returns the config file to use for defaults given `src_files` provided.
     """
-    if not src_files:
-        # If no src_files were specified, we consider the current directory the only candidate
-        candidate_dirs = [Path.cwd()]
-    else:
-        # Collect the candidate directories based on the src_file arguments provided
-        src_files_as_paths = [
-            Path(Path.cwd(), src_file).resolve() for src_file in src_files
-        ]
-        candidate_dirs = [
-            src if src.is_dir() else src.parent for src in src_files_as_paths
-        ]
+    # NOTE: If no src_files were specified, consider the current directory the
+    # NOTE: only config file lookup candidate. This usually happens when a
+    # NOTE: pip-tools invocation gets its incoming requirements from standard
+    # NOTE: input.
+    src_files_as_paths = [
+        Path(Path.cwd(), src_file).resolve()
+        for src_file in src_files or ('.', )
+    ]
+    candidate_dirs = [
+        src if src.is_dir() else src.parent for src in src_files_as_paths
+    ]
     config_file_path = next(
         (
             candidate_dir / config_file

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -579,13 +579,14 @@ def select_config_file(src_files: tuple[str, ...]) -> Path | None:
     # NOTE: only config file lookup candidate. This usually happens when a
     # NOTE: pip-tools invocation gets its incoming requirements from standard
     # NOTE: input.
-    src_files_as_paths = [
+    src_files_as_paths = (
         Path(Path.cwd(), src_file).resolve()
         for src_file in src_files or ('.', )
-    ]
-    candidate_dirs = [
-        src if src.is_dir() else src.parent for src in src_files_as_paths
-    ]
+    )
+    candidate_dirs = (
+        src if src.is_dir() else src.parent
+        for src in src_files_as_paths
+    )
     config_file_path = next(
         (
             candidate_dir / config_file

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -533,7 +533,7 @@ def parse_requirements_from_wheel_metadata(
         )
 
 
-def callback_config_file_defaults(
+def determine_config_file(
     ctx: click.Context, param: click.Parameter, value: str | None
 ) -> Path | None:
     """

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -536,9 +536,9 @@ def parse_requirements_from_wheel_metadata(
 def determine_config_file(
     ctx: click.Context, param: click.Parameter, value: str | None
 ) -> Path | None:
-    """
-    Returns the path to the config file with defaults being used, or `None` if no such file is
-    found.
+    """Return the config file path.
+
+    ``None`` is returned if no such file is found.
 
     Defaults for `click.Command` parameters should be override-able in a config file. `pip-tools`
     will use the first file found, searching in this order: an explicitly given config file, a
@@ -555,8 +555,6 @@ def determine_config_file(
     config = parse_config_file(config_file)
     if config:
         _assign_config_to_cli_context(ctx, config)
-    else:
-        return None
 
     return config_file
 
@@ -625,7 +623,7 @@ MULTIPLE_VALUE_OPTIONS = [
 ]
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def parse_config_file(config_file: Path) -> dict[str, Any]:
     try:
         config = tomllib.loads(config_file.read_text(encoding="utf-8"))
@@ -640,11 +638,8 @@ def parse_config_file(config_file: Path) -> dict[str, Any]:
             hint=f"Could not parse '{config_file !s}': {value_err !s}",
         )
 
-    # In a pyproject.toml file, we expect the config to be under `[tool.pip-tools]`, but in our
-    # native configuration, it would be just `[pip-tools]`.
-    if config_file.name == "pyproject.toml":
-        config = config.get("tool", {})
-    piptools_config: dict[str, Any] = config.get("pip-tools", {})
+    # In a TOML file, we expect the config to be under `[tool.pip-tools]`
+    piptools_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {})
     piptools_config = {
         get_click_dest_for_option(k): v for k, v in piptools_config.items()
     }

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -533,18 +533,20 @@ def parse_requirements_from_wheel_metadata(
         )
 
 
-def determine_config_file(
+def override_defaults_from_config_file(
     ctx: click.Context, param: click.Parameter, value: str | None
 ) -> Path | None:
-    """Return the config file path.
+    """
+    Overrides ``click.Command`` defaults based on specified or discovered config
+    file, returning the ``pathlib.Path`` of that config file if specified or
+    discovered.
 
     ``None`` is returned if no such file is found.
 
-    Defaults for ``click.Command`` parameters should be override-able in a config
-    file. ``pip-tools`` will use the first file found, searching in this order:
-    an explicitly given config file, a ``.pip-tools.toml``, a ``pyproject.toml``
+    ``pip-tools`` will use the first config file found, searching in this order:
+    an explicitly given config file, a d``.pip-tools.toml``, a ``pyproject.toml``
     file. Those files are searched for in the same directory as the requirements
-    input file.
+    input file, or the current working directory if requirements come via stdin.
     """
     if value is None:
         config_file = select_config_file(ctx.params.get("src_files", ()))

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -580,13 +580,9 @@ def select_config_file(src_files: tuple[str, ...]) -> Path | None:
     # NOTE: pip-tools invocation gets its incoming requirements from standard
     # NOTE: input.
     src_files_as_paths = (
-        Path(Path.cwd(), src_file).resolve()
-        for src_file in src_files or ('.', )
+        Path(Path.cwd(), src_file).resolve() for src_file in src_files or (".",)
     )
-    candidate_dirs = (
-        src if src.is_dir() else src.parent
-        for src in src_files_as_paths
-    )
+    candidate_dirs = (src if src.is_dir() else src.parent for src in src_files_as_paths)
     config_file_path = next(
         (
             candidate_dir / config_file

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -552,11 +552,11 @@ def callback_config_file_defaults(
     else:
         config_file = Path(value)
 
-    config = parse_config_file(config_file)
-    if not config:
+    if config := parse_config_file(config_file):
+        _assign_config_to_cli_context(ctx, config)
+    else:
         return None
 
-    _assign_config_to_cli_context(ctx, config)
     return config_file
 
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -540,10 +540,11 @@ def determine_config_file(
 
     ``None`` is returned if no such file is found.
 
-    Defaults for `click.Command` parameters should be override-able in a config file. `pip-tools`
-    will use the first file found, searching in this order: an explicitly given config file, a
-    `.pip-tools.toml`, a `pyproject.toml` file. Those files are searched for in the same directory
-    as the requirements input file.
+    Defaults for ``click.Command`` parameters should be override-able in a config
+    file. ``pip-tools`` will use the first file found, searching in this order:
+    an explicitly given config file, a ``.pip-tools.toml``, a ``pyproject.toml``
+    file. Those files are searched for in the same directory as the requirements
+    input file.
     """
     if value is None:
         config_file = select_config_file(ctx.params.get("src_files", ()))
@@ -571,7 +572,7 @@ def _assign_config_to_cli_context(
 
 def select_config_file(src_files: tuple[str, ...]) -> Path | None:
     """
-    Returns the config file to use for defaults given `src_files` provided.
+    Returns the config file to use for defaults given ``src_files`` provided.
     """
     # NOTE: If no src_files were specified, consider the current directory the
     # NOTE: only config file lookup candidate. This usually happens when a
@@ -604,7 +605,9 @@ NON_STANDARD_OPTION_DEST_MAP: dict[str, str] = {
 
 
 def get_click_dest_for_option(option_name: str) -> str:
-    """Returns the click `dest` value for the given option name."""
+    """
+    Returns the click ``dest`` value for the given option name.
+    """
     # Format the keys properly
     option_name = option_name.lstrip("-").replace("-", "_").lower()
     # Some options have dest values that are overrides from the click generated default
@@ -623,7 +626,7 @@ MULTIPLE_VALUE_OPTIONS = [
 ]
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def parse_config_file(config_file: Path) -> dict[str, Any]:
     try:
         config = tomllib.loads(config_file.read_text(encoding="utf-8"))

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -625,7 +625,7 @@ MULTIPLE_VALUE_OPTIONS = [
 ]
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def parse_config_file(config_file: Path) -> dict[str, Any]:
     try:
         config = tomllib.loads(config_file.read_text(encoding="utf-8"))

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -579,8 +579,9 @@ def select_config_file(src_files: tuple[str, ...]) -> Path | None:
     # NOTE: only config file lookup candidate. This usually happens when a
     # NOTE: pip-tools invocation gets its incoming requirements from standard
     # NOTE: input.
+    working_directory = Path.cwd()
     src_files_as_paths = (
-        Path(Path.cwd(), src_file).resolve() for src_file in src_files or (".",)
+        (working_directory / src_file).resolve() for src_file in src_files or (".",)
     )
     candidate_dirs = (src if src.is_dir() else src.parent for src in src_files_as_paths)
     config_file_path = next(

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -624,7 +624,7 @@ MULTIPLE_VALUE_OPTIONS = [
 ]
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def parse_config_file(config_file: Path) -> dict[str, Any]:
     try:
         config = tomllib.loads(config_file.read_text(encoding="utf-8"))

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -12,12 +12,12 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, TypeVar, cast
 
-import click
-
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import toml
+    import tomli as tomllib
+
+import click
 from click.utils import LazyFile
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line, parse_req_from_line
@@ -631,13 +631,7 @@ MULTIPLE_VALUE_OPTIONS = [
 
 @functools.lru_cache()
 def parse_config_file(config_file: Path) -> dict[str, Any]:
-    if sys.version_info >= (3, 11):
-        # Python 3.11 stdlib tomllib load() requires a binary file object
-        with config_file.open("rb") as ifs:
-            config = tomllib.load(ifs)
-    else:
-        # Before 3.11, using the external toml library, load requires the filename
-        config = toml.load(str(config_file))
+    config = tomllib.loads(config_file.read_text(encoding="utf-8"))
     # In a pyproject.toml file, we expect the config to be under `[tool.pip-tools]`, but in our
     # native configuration, it would be just `[pip-tools]`.
     if config_file.name == "pyproject.toml":

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -566,10 +566,18 @@ def callback_config_file_defaults(
     if not config:
         return None
 
-    if ctx.default_map is None:
-        ctx.default_map = {}
-    ctx.default_map.update(config)
+    _assign_config_to_cli_context(ctx, config)
     return config_file
+
+
+def _assign_config_to_cli_context(
+    click_context: click.Context,
+    cli_config_mapping: dict[str, Any],
+) -> None:
+    if click_context.default_map is None:
+        click_context.default_map = {}
+
+    click_context.default_map.update(cli_config_mapping)
 
 
 def select_config_file(src_files: tuple[str, ...]) -> Path | None:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -633,12 +633,12 @@ def parse_config_file(config_file: Path) -> dict[str, Any]:
     except OSError as os_err:
         raise click.FileError(
             filename=str(config_file),
-            hint=f"Could not read '{config_file !s}': {os_err !s}"
+            hint=f"Could not read '{config_file !s}': {os_err !s}",
         )
     except ValueError as value_err:
         raise click.FileError(
             filename=str(config_file),
-            hint=f"Could not parse '{config_file !s}': {value_err !s}"
+            hint=f"Could not parse '{config_file !s}': {value_err !s}",
         )
 
     # In a pyproject.toml file, we expect the config to be under `[tool.pip-tools]`, but in our

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -535,7 +535,7 @@ def parse_requirements_from_wheel_metadata(
 
 def callback_config_file_defaults(
     ctx: click.Context, param: click.Parameter, value: str | None
-) -> str | None:
+) -> Path | None:
     """
     Returns the path to the config file with defaults being used, or `None` if no such file is
     found.
@@ -570,7 +570,7 @@ def callback_config_file_defaults(
     defaults.update(config)
 
     ctx.default_map = defaults
-    return str(config_file)
+    return config_file
 
 
 def select_config_file(src_files: tuple[str, ...]) -> Path | None:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -552,7 +552,8 @@ def determine_config_file(
     else:
         config_file = Path(value)
 
-    if config := parse_config_file(config_file):
+    config = parse_config_file(config_file)
+    if config:
         _assign_config_to_cli_context(ctx, config)
     else:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "build",
   "click >= 8",
   "pip >= 22.2",
-  "toml >= 0.10.1; python_version<'3.11'",
+  "tomli; python_version < '3.11'",
   # indirect dependencies
   "setuptools", # typically needed when pip-tools invokes setup.py
   "wheel", # pip plugin needed by pip-tools
@@ -58,7 +58,7 @@ testing = [
   "pytest >= 7.2.0",
   "pytest-rerunfailures",
   "pytest-xdist",
-  "toml >= 0.10.1",
+  "tomli-w",
   # build deps for tests
   "flit_core >=2,<4",
   "poetry_core>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "pip >= 22.2",
   # indirect dependencies
   "setuptools", # typically needed when pip-tools invokes setup.py
+  "toml >= 0.10.1",
   "wheel", # pip plugin needed by pip-tools
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dependencies = [
   "build",
   "click >= 8",
   "pip >= 22.2",
+  "toml >= 0.10.1; python_version<'3.11'",
   # indirect dependencies
   "setuptools", # typically needed when pip-tools invokes setup.py
-  "toml >= 0.10.1",
   "wheel", # pip plugin needed by pip-tools
 
 ]
@@ -58,6 +58,7 @@ testing = [
   "pytest >= 7.2.0",
   "pytest-rerunfailures",
   "pytest-xdist",
+  "toml >= 0.10.1",
   # build deps for tests
   "flit_core >=2,<4",
   "poetry_core>=1.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from pip._vendor.pkg_resources import Requirement
 from piptools._compat.pip_compat import PIP_VERSION, uses_pkg_resources
 from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
+from piptools.locations import CONFIG_FILE_NAME
 from piptools.logging import log
 from piptools.repositories import PyPIRepository
 from piptools.repositories.base import BaseRepository
@@ -455,15 +456,18 @@ def _reset_log():
 
 
 @pytest.fixture
-def make_pyproject_toml_conf(tmpdir_cwd):
-    def _maker(pyproject_param, new_default):
-        # Make a pyproject.toml with this one config default override
+def make_config_file(tmpdir_cwd):
+    def _maker(pyproject_param, new_default, config_file_name=CONFIG_FILE_NAME):
+        # Make a config file with this one config default override
         config_path = Path(tmpdir_cwd) / pyproject_param
-        config_file = config_path / "pyproject.toml"
-        config_path.mkdir()
+        config_file = config_path / config_file_name
+        config_path.mkdir(exist_ok=True)
 
+        config_to_dump = {"pip-tools": {pyproject_param: new_default}}
+        if config_file_name == "pyproject.toml":
+            config_to_dump = {"tool": config_to_dump}
         with open(config_file, "w") as ofs:
-            toml.dump({"tool": {"pip-tools": {pyproject_param: new_default}}}, ofs)
+            toml.dump(config_to_dump, ofs)
         return config_file
 
     return _maker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,7 +460,7 @@ def _reset_log():
 def make_config_file(tmpdir_cwd):
     """
     Make a config file for pip-tools with a given parameter set to a specific
-    value, returning a `pathlib.Path` to the config file.
+    value, returning a ``pathlib.Path`` to the config file.
     """
 
     def _maker(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,10 +459,13 @@ def _reset_log():
 @pytest.fixture
 def make_config_file(tmpdir_cwd):
     """
-    Make a config file for pip-tools with a given parameter set to a specific 
+    Make a config file for pip-tools with a given parameter set to a specific
     value, returning a `pathlib.Path` to the config file.
     """
-    def _maker(pyproject_param: str, new_default: Any, config_file_name: str = CONFIG_FILE_NAME) -> Path:
+
+    def _maker(
+        pyproject_param: str, new_default: Any, config_file_name: str = CONFIG_FILE_NAME
+    ) -> Path:
         # Make a config file with this one config default override
         config_path = Path(tmpdir_cwd) / pyproject_param
         config_file = config_path / config_file_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,11 @@ import sys
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import partial
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
+import toml
 from click.testing import CliRunner
 from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
@@ -450,3 +452,18 @@ def _reset_log():
     with other tests that depend on it.
     """
     log.reset()
+
+
+@pytest.fixture
+def make_pyproject_toml_conf(tmpdir_cwd):
+    def _maker(pyproject_param, new_default):
+        # Make a pyproject.toml with this one config default override
+        config_path = Path(tmpdir_cwd) / pyproject_param
+        config_file = config_path / "pyproject.toml"
+        config_path.mkdir()
+
+        with open(config_file, "w") as ofs:
+            toml.dump({"tool": {"pip-tools": {pyproject_param: new_default}}}, ofs)
+        return config_file
+
+    return _maker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
+from typing import Any
 
 import pytest
 import tomli_w
@@ -457,15 +458,17 @@ def _reset_log():
 
 @pytest.fixture
 def make_config_file(tmpdir_cwd):
-    def _maker(pyproject_param, new_default, config_file_name=CONFIG_FILE_NAME):
+    """
+    Make a config file for pip-tools with a given parameter set to a specific 
+    value, returning a `pathlib.Path` to the config file.
+    """
+    def _maker(pyproject_param: str, new_default: Any, config_file_name: str = CONFIG_FILE_NAME) -> Path:
         # Make a config file with this one config default override
         config_path = Path(tmpdir_cwd) / pyproject_param
         config_file = config_path / config_file_name
         config_path.mkdir(exist_ok=True)
 
-        config_to_dump = {"pip-tools": {pyproject_param: new_default}}
-        if config_file_name == "pyproject.toml":
-            config_to_dump = {"tool": config_to_dump}
+        config_to_dump = {"tool": {"pip-tools": {pyproject_param: new_default}}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
         return config_file
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
-import toml
+import tomli_w
 from click.testing import CliRunner
 from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
@@ -466,8 +466,7 @@ def make_config_file(tmpdir_cwd):
         config_to_dump = {"pip-tools": {pyproject_param: new_default}}
         if config_file_name == "pyproject.toml":
             config_to_dump = {"tool": config_to_dump}
-        with open(config_file, "w") as ofs:
-            toml.dump(config_to_dump, ofs)
+        config_file.write_text(tomli_w.dumps(config_to_dump))
         return config_file
 
     return _maker

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,6 @@ from piptools.scripts.compile import cli as compile_cli
 from piptools.utils import (
     as_tuple,
     dedup,
-    override_defaults_from_config_file,
     drop_extras,
     flat_map,
     format_requirement,
@@ -31,6 +30,7 @@ from piptools.utils import (
     key_from_ireq,
     lookup_table,
     lookup_table_from_tuples,
+    override_defaults_from_config_file,
 )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -597,7 +597,7 @@ def test_callback_config_file_defaults(pyproject_param, new_default, make_config
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
     found_config_file = callback_config_file_defaults(ctx, "config", None)
-    assert found_config_file == str(config_file)
+    assert found_config_file == config_file
     # Make sure the default has been updated
     lookup_param = get_click_dest_for_option(pyproject_param)
     assert ctx.default_map[lookup_param] == new_default

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -652,5 +652,5 @@ def test_callback_config_file_defaults_unreadable_toml(make_config_file):
         determine_config_file(
             ctx,
             "config",
-            "/path/does/not/exist/my-config.toml",
+            "/dev/null/path/does/not/exist/my-config.toml",
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ from piptools.scripts.compile import cli as compile_cli
 from piptools.utils import (
     as_tuple,
     dedup,
-    determine_config_file,
+    override_defaults_from_config_file,
     drop_extras,
     flat_map,
     format_requirement,
@@ -596,7 +596,7 @@ def test_callback_config_file_defaults(pyproject_param, new_default, make_config
     # Create a "compile" run example pointing to the config file
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
-    found_config_file = determine_config_file(ctx, "config", None)
+    found_config_file = override_defaults_from_config_file(ctx, "config", None)
     assert found_config_file == config_file
     # Make sure the default has been updated
     lookup_param = get_click_dest_for_option(pyproject_param)
@@ -619,7 +619,7 @@ def test_callback_config_file_defaults_multi_value_options(mv_option, make_confi
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
     with pytest.raises(BadOptionUsage, match="must be a list"):
-        determine_config_file(ctx, "config", None)
+        override_defaults_from_config_file(ctx, "config", None)
 
 
 def test_callback_config_file_defaults_bad_toml(make_config_file):
@@ -631,7 +631,7 @@ def test_callback_config_file_defaults_bad_toml(make_config_file):
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
     with pytest.raises(FileError, match="Could not parse "):
-        determine_config_file(ctx, "config", None)
+        override_defaults_from_config_file(ctx, "config", None)
 
 
 def test_callback_config_file_defaults_precedence(make_config_file):
@@ -639,7 +639,7 @@ def test_callback_config_file_defaults_precedence(make_config_file):
     project_config_file = make_config_file("newline", "CRLF", "pyproject.toml")
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(project_config_file),)
-    found_config_file = determine_config_file(ctx, "config", None)
+    found_config_file = override_defaults_from_config_file(ctx, "config", None)
     # The pip-tools specific config file should take precedence over pyproject.toml
     assert found_config_file == piptools_config_file
     lookup_param = get_click_dest_for_option("newline")
@@ -649,7 +649,7 @@ def test_callback_config_file_defaults_precedence(make_config_file):
 def test_callback_config_file_defaults_unreadable_toml(make_config_file):
     ctx = Context(compile_cli)
     with pytest.raises(FileError, match="Could not read "):
-        determine_config_file(
+        override_defaults_from_config_file(
             ctx,
             "config",
             "/dev/null/path/does/not/exist/my-config.toml",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from pip._vendor.packaging.version import Version
 from piptools.scripts.compile import cli as compile_cli
 from piptools.utils import (
     as_tuple,
-    callback_config_file_defaults,
+    determine_config_file,
     dedup,
     drop_extras,
     flat_map,
@@ -596,7 +596,7 @@ def test_callback_config_file_defaults(pyproject_param, new_default, make_config
     # Create a "compile" run example pointing to the config file
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
-    found_config_file = callback_config_file_defaults(ctx, "config", None)
+    found_config_file = determine_config_file(ctx, "config", None)
     assert found_config_file == config_file
     # Make sure the default has been updated
     lookup_param = get_click_dest_for_option(pyproject_param)
@@ -619,7 +619,7 @@ def test_callback_config_file_defaults_multi_value_options(mv_option, make_confi
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
     with pytest.raises(BadOptionUsage, match="must be a list"):
-        callback_config_file_defaults(ctx, "config", None)
+        determine_config_file(ctx, "config", None)
 
 
 def test_callback_config_file_defaults_bad_toml(make_config_file):
@@ -631,7 +631,7 @@ def test_callback_config_file_defaults_bad_toml(make_config_file):
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
     with pytest.raises(FileError, match="Could not parse "):
-        callback_config_file_defaults(ctx, "config", None)
+        determine_config_file(ctx, "config", None)
 
 
 def test_callback_config_file_defaults_precedence(make_config_file):
@@ -639,7 +639,7 @@ def test_callback_config_file_defaults_precedence(make_config_file):
     project_config_file = make_config_file("newline", "CRLF", "pyproject.toml")
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(project_config_file),)
-    found_config_file = callback_config_file_defaults(ctx, "config", None)
+    found_config_file = determine_config_file(ctx, "config", None)
     # The pip-tools specific config file should take precedence over pyproject.toml
     assert found_config_file == piptools_config_file
     lookup_param = get_click_dest_for_option("newline")
@@ -649,7 +649,7 @@ def test_callback_config_file_defaults_precedence(make_config_file):
 def test_callback_config_file_defaults_unreadable_toml(make_config_file):
     ctx = Context(compile_cli)
     with pytest.raises(FileError, match="Could not read "):
-        callback_config_file_defaults(
+        determine_config_file(
             ctx,
             "config",
             "/path/does/not/exist/my-config.toml",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,8 +15,8 @@ from pip._vendor.packaging.version import Version
 from piptools.scripts.compile import cli as compile_cli
 from piptools.utils import (
     as_tuple,
-    determine_config_file,
     dedup,
+    determine_config_file,
     drop_extras,
     flat_map,
     format_requirement,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -641,7 +641,7 @@ def test_callback_config_file_defaults_precedence(make_config_file):
     ctx.params["src_files"] = (str(project_config_file),)
     found_config_file = callback_config_file_defaults(ctx, "config", None)
     # The pip-tools specific config file should take precedence over pyproject.toml
-    assert found_config_file == str(piptools_config_file)
+    assert found_config_file == piptools_config_file
     lookup_param = get_click_dest_for_option("newline")
     assert ctx.default_map[lookup_param] == "LF"
 


### PR DESCRIPTION
Supports use of a `.pip-tools.toml`, `pyproject.toml`, or other explicitly specified TOML file to set configuration defaults for `pip-compile` and `pip-sync`.

Fixes #604.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
