### PR TITLE
Improve warning for `pip-compile` if no `--allow-unsafe` was passed

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -32,7 +32,7 @@ MESSAGE_UNHASHED_PACKAGE = comment(
 
 MESSAGE_UNSAFE_PACKAGES_UNPINNED = comment(
     "# WARNING: The following packages were not pinned, but pip requires them to be"
-    "\n# pinned when the requirements file includes hashes and the requirement is not "
+    "\n# pinned when the requirements file includes hashes and the requirement is not"
     "\n# satisfied by a package already installed. "
     "Consider using the --allow-unsafe flag."
 )


### PR DESCRIPTION
<!--- Describe the changes here. --->

Based on a suggestion from and fixes #1337

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
