### PR TITLE
🐛 Ignore matrix.to links in Sphinx's linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,4 +52,9 @@ html_theme = "furo"
 # -------------------------------------------------------------------------
 default_role = "any"
 nitpicky = True
+
+linkcheck_ignore = [
+    r'^https://matrix\.to/#',
+]
+
 suppress_warnings = ["myst.xref_missing"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ default_role = "any"
 nitpicky = True
 
 linkcheck_ignore = [
-    r'^https://matrix\.to/#',
+    r"^https://matrix\.to/#",
 ]
 
 suppress_warnings = ["myst.xref_missing"]


### PR DESCRIPTION
It started failing with #1881 since the anchors in such URLs are ephemeral.