### PR TITLE
Sync direct references with hashes

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
-from .pip_compat import PIP_VERSION, create_wheel_cache, parse_requirements
+from .pip_compat import (
+    PIP_VERSION,
+    Distribution,
+    create_wheel_cache,
+    parse_requirements,
+)
 
-__all__ = ["PIP_VERSION", "parse_requirements", "create_wheel_cache"]
+__all__ = ["PIP_VERSION", "Distribution", "parse_requirements", "create_wheel_cache"]

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import optparse
 from dataclasses import dataclass
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, TYPE_CHECKING
 
 import pip
 from pip._internal.cache import WheelCache
@@ -23,7 +23,8 @@ PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split("
 # importlib.metadata, so this compat layer allows for a consistent access
 # pattern. In pip 22.1, importlib.metadata became the default on Python 3.11
 # (and later), but is overridable. `select_backend` returns what's being used.
-
+if TYPE_CHECKING:
+    from pip._internal.metadata.importlib import Distribution as _ImportLibDist
 
 @dataclass(frozen=True)
 class Distribution:
@@ -48,7 +49,7 @@ class Distribution:
         )
 
     @classmethod
-    def _from_importlib(cls, dist) -> Distribution:
+    def _from_importlib(cls, dist: "_ImportLibDist") -> Distribution:
         """Mimics pkg_resources.Distribution.requires for the case of no
         extras. This doesn't fulfill that API's `extras` parameter but
         satisfies the needs of pip-tools."""

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import optparse
 from dataclasses import dataclass
-from typing import Iterable, Iterator, TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, Iterator
 
 import pip
 from pip._internal.cache import WheelCache
@@ -25,6 +25,7 @@ PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split("
 # (and later), but is overridable. `select_backend` returns what's being used.
 if TYPE_CHECKING:
     from pip._internal.metadata.importlib import Distribution as _ImportLibDist
+
 
 @dataclass(frozen=True)
 class Distribution:
@@ -49,7 +50,7 @@ class Distribution:
         )
 
     @classmethod
-    def _from_importlib(cls, dist: "_ImportLibDist") -> Distribution:
+    def _from_importlib(cls, dist: _ImportLibDist) -> Distribution:
         """Mimics pkg_resources.Distribution.requires for the case of no
         extras. This doesn't fulfill that API's `extras` parameter but
         satisfies the needs of pip-tools."""

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -52,7 +52,7 @@ def _uses_pkg_resources() -> bool:
 uses_pkg_resources = _uses_pkg_resources()
 
 if uses_pkg_resources:
-    from pip._vendor.pkg_resources import Distribution
+    from pip._internal.metadata.pkg_resources import Distribution
 
     def dist_requires(dist: Distribution) -> Iterable[Requirement]:
         res: Iterable[Requirement] = dist._dist.requires()
@@ -60,8 +60,9 @@ if uses_pkg_resources:
 
 else:
     from pip._internal.metadata import select_backend
+    from pip._internal.metadata.importlib import Distribution
 
-    Distribution = select_backend().Distribution
+    assert select_backend().Distribution is Distribution
 
     def dist_requires(dist: Distribution) -> Iterable[Requirement]:
         """Mimics pkg_resources.Distribution.requires for the case of no

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import optparse
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Optional
+from typing import Iterable, Iterator
 
 import pip
 from pip._internal.cache import WheelCache

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -8,7 +8,6 @@ import pip
 from pip._internal.cache import WheelCache
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import BaseDistribution
-from pip._internal.metadata.importlib import Distribution as _ImportLibDist
 from pip._internal.metadata.pkg_resources import Distribution as _PkgResourcesDist
 from pip._internal.models.direct_url import DirectUrl
 from pip._internal.network.session import PipSession
@@ -39,11 +38,8 @@ class Distribution:
         # instead of specializing by type.
         if isinstance(dist, _PkgResourcesDist):
             return cls._from_pkg_resources(dist)
-        if isinstance(dist, _ImportLibDist):
+        else:
             return cls._from_importlib(dist)
-        raise ValueError(
-            f"unsupported installed distribution class ({dist.__class__}): {dist}"
-        )
 
     @classmethod
     def _from_pkg_resources(cls, dist: _PkgResourcesDist) -> Distribution:
@@ -52,7 +48,7 @@ class Distribution:
         )
 
     @classmethod
-    def _from_importlib(cls, dist: _ImportLibDist) -> Distribution:
+    def _from_importlib(cls, dist) -> Distribution:
         """Mimics pkg_resources.Distribution.requires for the case of no
         extras. This doesn't fulfill that API's `extras` parameter but
         satisfies the needs of pip-tools."""

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -25,12 +25,13 @@ PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split("
 # pattern. In pip 22.1, importlib.metadata became the default on Python 3.11
 # (and later), but is overridable. `select_backend` returns what's being used.
 
+
 @dataclass(frozen=True)
 class Distribution:
     key: str
     version: str
     requires: Iterable[Requirement]
-    direct_url: Optional[DirectUrl]
+    direct_url: DirectUrl | None
 
     @classmethod
     def from_pip_distribution(cls, dist: BaseDistribution) -> Distribution:

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -303,4 +303,4 @@ def _get_installed_distributions(
         user_only=user_only,
         skip=[],
     )
-    return [cast(Distribution, dist)._dist for dist in dists]
+    return [cast(Distribution, dist) for dist in dists]

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -15,8 +15,7 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_environment
 
 from .. import sync
-from .._compat import parse_requirements
-from .._compat.pip_compat import Distribution
+from .._compat import Distribution, parse_requirements
 from ..exceptions import PipToolsError
 from ..locations import CONFIG_FILE_NAME
 from ..logging import log
@@ -303,4 +302,4 @@ def _get_installed_distributions(
         user_only=user_only,
         skip=[],
     )
-    return [cast(Distribution, dist) for dist in dists]
+    return [Distribution.from_pip_distribution(dist) for dist in dists]

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -17,7 +17,7 @@ from pip._internal.utils.direct_url_helpers import (
     direct_url_from_link,
 )
 
-from ._compat.pip_compat import Distribution, dist_requires
+from ._compat import Distribution
 from .exceptions import IncompatibleRequirements
 from .logging import log
 from .utils import (
@@ -66,7 +66,7 @@ def dependency_tree(
 
         dependencies.add(key)
 
-        for dep_specifier in dist_requires(v):
+        for dep_specifier in v.requires:
             dep_name = key_from_req(dep_specifier)
             if dep_name in installed_keys:
                 dep = installed_keys[dep_name]
@@ -131,12 +131,6 @@ def diff_key_from_ireq(ireq: InstallRequirement) -> str:
     if the contents at the URL have changed but the version has not.
     """
     if is_url_requirement(ireq):
-        if (
-            ireq.req
-            and (getattr(ireq.req, "key", None) or getattr(ireq.req, "name", None))
-            and ireq.specifier
-        ):
-            return key_from_ireq(ireq)
         if getattr(ireq.req, "name", None) and ireq.link.has_hash:
             return str(
                 direct_url_as_pep440_direct_reference(

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -60,7 +60,7 @@ def dependency_tree(
 
     while queue:
         v = queue.popleft()
-        key = key_from_req(v)
+        key = v.key
         if key in dependencies:
             continue
 
@@ -86,7 +86,7 @@ def get_dists_to_ignore(installed: Iterable[Distribution]) -> list[str]:
     locally, click should also be installed/uninstalled depending on the given
     requirements.
     """
-    installed_keys = {key_from_req(r): r for r in installed}
+    installed_keys = {r.key: r for r in installed}
     return list(
         flat_map(lambda req: dependency_tree(installed_keys, req), PACKAGES_TO_IGNORE)
     )
@@ -144,10 +144,9 @@ def diff_key_from_ireq(ireq: InstallRequirement) -> str:
 
 def diff_key_from_req(req: Distribution) -> str:
     """Get a unique key for the requirement."""
-    key = key_from_req(req)
+    key = req.key
     if (
-        hasattr(req, "direct_url")
-        and req.direct_url
+        req.direct_url
         and type(req.direct_url.info) == ArchiveInfo
         and req.direct_url.info.hash
     ):

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -147,7 +147,7 @@ def diff_key_from_req(req: Distribution) -> str:
     key = req.key
     if (
         req.direct_url
-        and type(req.direct_url.info) == ArchiveInfo
+        and isinstance(req.direct_url.info, ArchiveInfo)
         and req.direct_url.info.hash
     ):
         key = direct_url_as_pep440_direct_reference(req.direct_url, key)

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -30,7 +30,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import get_distribution
 
-from piptools._compat import PIP_VERSION, Distribution
+from piptools._compat import PIP_VERSION
 from piptools.locations import CONFIG_FILE_NAME
 from piptools.subprocess_utils import run_python_snippet
 
@@ -66,17 +66,9 @@ def key_from_ireq(ireq: InstallRequirement) -> str:
         return key_from_req(ireq.req)
 
 
-def key_from_req(req: InstallRequirement | Distribution | Requirement) -> str:
+def key_from_req(req: InstallRequirement | Requirement) -> str:
     """Get an all-lowercase version of the requirement's name."""
-    if isinstance(req, Distribution):
-        key = req.key
-    elif hasattr(req, "key"):
-        # from pkg_resources, such as installed dists for pip-sync
-        key = req.key
-    else:
-        # from packaging, such as install requirements from requirements.txt
-        key = req.name
-    return str(canonicalize_name(key))
+    return str(canonicalize_name(req.name))
 
 
 def comment(text: str) -> str:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -24,16 +24,15 @@ from pip._internal.req.constructors import install_req_from_line, parse_req_from
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.vcs import is_url
 from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
-from pip._vendor.pkg_resources import Requirement, get_distribution
+from pip._vendor.pkg_resources import get_distribution
 
-from piptools._compat import PIP_VERSION
+from piptools._compat import PIP_VERSION, Distribution
 from piptools.locations import CONFIG_FILE_NAME
 from piptools.subprocess_utils import run_python_snippet
-
-from ._compat.pip_compat import Distribution
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -69,14 +68,6 @@ def key_from_ireq(ireq: InstallRequirement) -> str:
 
 def key_from_req(req: InstallRequirement | Distribution | Requirement) -> str:
     """Get an all-lowercase version of the requirement's name."""
-    if (
-        isinstance(req, Distribution)
-        or req.__class__.__name__ == "FakeInstalledDistribution"
-    ):
-        # If this is a pip internal installed distribution (or the fake
-        # installed distribution used in tests), use the wrapped distribution
-        # object, not the pip internal one.
-        req = req._dist
     if hasattr(req, "key"):
         # from pkg_resources, such as installed dists for pip-sync
         key = req.key

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -68,11 +68,17 @@ def key_from_ireq(ireq: InstallRequirement) -> str:
 def key_from_req(req: InstallRequirement | Distribution | Requirement) -> str:
     """Get an all-lowercase version of the requirement's name."""
     if hasattr(req, "key"):
-        # from pkg_resources, such as installed dists for pip-sync
+        # From pkg_resources, such as installed dists for pip-sync.
         key = req.key
     else:
-        # from packaging, such as install requirements from requirements.txt
-        key = req.name
+        # From packaging, such as install requirements from requirements.txt.
+        # For installed distributions, pip internal backends derive from
+        # pip._internal.metadata.BaseDistribution, and have canonical_name
+        # instead of name.
+        if hasattr(req, "canonical_name"):
+            key = req.canonical_name
+        else:
+            key = req.name
     return str(canonicalize_name(key))
 
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -68,7 +68,9 @@ def key_from_ireq(ireq: InstallRequirement) -> str:
 
 def key_from_req(req: InstallRequirement | Distribution | Requirement) -> str:
     """Get an all-lowercase version of the requirement's name."""
-    if hasattr(req, "key"):
+    if isinstance(req, Distribution):
+        key = req.key
+    elif hasattr(req, "key"):
         # from pkg_resources, such as installed dists for pip-sync
         key = req.key
     else:

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -19,7 +19,6 @@ else:
 
 import click
 from click.utils import LazyFile
-from ._compat.pip_compat import Distribution
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line, parse_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
@@ -33,6 +32,8 @@ from pip._vendor.pkg_resources import Requirement, get_distribution
 from piptools._compat import PIP_VERSION
 from piptools.locations import CONFIG_FILE_NAME
 from piptools.subprocess_utils import run_python_snippet
+
+from ._compat.pip_compat import Distribution
 
 if TYPE_CHECKING:
     from typing import Protocol

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -69,11 +69,16 @@ def key_from_ireq(ireq: InstallRequirement) -> str:
 
 def key_from_req(req: InstallRequirement | Distribution | Requirement) -> str:
     """Get an all-lowercase version of the requirement's name."""
-    if isinstance(req, Distribution):
-        # Use the wrapped distribution object, not the pip internal one.
+    if (
+        isinstance(req, Distribution)
+        or req.__class__.__name__ == "FakeInstalledDistribution"
+    ):
+        # If this is a pip internal installed distribution (or the fake
+        # installed distribution used in tests), use the wrapped distribution
+        # object, not the pip internal one.
         req = req._dist
     if hasattr(req, "key"):
-        # from pkg_resources, such as installed dists for pip-sync.
+        # from pkg_resources, such as installed dists for pip-sync
         key = req.key
     else:
         # from packaging, such as install requirements from requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   # direct dependencies
   "build",
   "click >= 8",
+  "importlib-metadata == 1.4; python_version < '3.8'",
   "pip >= 22.2",
   "tomli; python_version < '3.11'",
   # indirect dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
   # direct dependencies
   "build",
   "click >= 8",
-  "importlib-metadata == 1.4; python_version < '3.8'",
   "pip >= 22.2",
   "tomli; python_version < '3.11'",
   # indirect dependencies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,8 @@ class FakeRepository(BaseRepository):
 
 
 class InnerFakeInstalledDistribution:
+    # Emulate relevant parts of the _dist attribute of
+    # piptools._compat.pip_compat.Distribution.
     def __init__(self, req, version, deps=None):
         self.req = req
         self.version = version
@@ -153,16 +155,14 @@ class InnerFakeInstalledDistribution:
 
 
 class FakeInstalledDistribution:
+    # Emulate relevant parts of piptools._compat.pip_compat.Distribution.
     def __init__(self, line, deps=None):
         req = Requirement.parse(line)
         if "==" in line:
             version = line.split("==")[1]
         else:
             version = "0+unknown"
-
         self._dist = InnerFakeInstalledDistribution(req, version, deps)
-        self.key = self._dist.key
-        self.canonical_name = self._dist.req.project_name
         self.version = version
         if req.url:
             self.direct_url = direct_url_from_link(Link(req.url))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,20 +126,6 @@ class FakeRepository(BaseRepository):
         """Not used"""
 
 
-def parse_fake_distribution(line, deps=[]):
-    req = Requirement.parse(line)
-    key = req.key
-    if "==" in line:
-        version = line.split("==")[1]
-    else:
-        version = "0+unknown"
-    requires = [Requirement.parse(d) for d in deps]
-    direct_url = None
-    if req.url:
-        direct_url = direct_url_from_link(Link(req.url))
-    return Distribution(key, version, requires, direct_url)
-
-
 def pytest_collection_modifyitems(config, items):
     for item in items:
         # Mark network tests as flaky
@@ -149,7 +135,21 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.fixture
 def fake_dist():
-    return parse_fake_distribution
+    def _fake_dist(line, deps=None):
+        if deps is None:
+            deps = []
+        req = Requirement.parse(line)
+        key = req.key
+        if "==" in line:
+            version = line.split("==")[1]
+        else:
+            version = "0+unknown"
+        requires = [Requirement.parse(d) for d in deps]
+        direct_url = None
+        if req.url:
+            direct_url = direct_url_from_link(Link(req.url))
+        return Distribution(key, version, requires, direct_url)
+    return _fake_dist
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,8 @@ class FakeRepository(BaseRepository):
 
 class InnerFakeInstalledDistribution:
     # Emulate relevant parts of the _dist attribute of
-    # piptools._compat.pip_compat.Distribution.
+    # piptools._compat.pip_compat.Distribution. See note below in
+    # FakeInstalledDistribution.
     def __init__(self, req, version, deps=None):
         self.req = req
         self.version = version
@@ -155,7 +156,12 @@ class InnerFakeInstalledDistribution:
 
 
 class FakeInstalledDistribution:
-    # Emulate relevant parts of piptools._compat.pip_compat.Distribution.
+    # Emulate relevant parts of piptools._compat.pip_compat.Distribution, which
+    # is currently aliasing a pip internal class implementing the protocol
+    # pip._internal.metadata.base.BaseDistribution.
+    # piptools uses only the version and direct_url fields directly from this
+    # type, and uses the delegate instance in the _dist attribute for the other
+    # values.
     def __init__(self, line, deps=None):
         req = Requirement.parse(line)
         if "==" in line:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,7 @@ def fake_dist():
         if req.url:
             direct_url = direct_url_from_link(Link(req.url))
         return Distribution(key, version, requires, direct_url)
+
     return _fake_dist
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -68,7 +68,7 @@ def mocked_tmp_req_file(mocked_tmp_file):
 )
 def test_dependency_tree(fake_dist, installed, root, expected):
     installed = {
-        distribution._dist.key: distribution
+        distribution.key: distribution
         for distribution in (fake_dist(name, deps) for name, deps in installed)
     }
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -290,8 +290,8 @@ def test_diff_with_unequal_url_hash(fake_dist, from_line):
     # if URL hashes mismatch, assume the contents have
     # changed and reinstall
     line = "example@file:///example.zip#"
-    installed = [fake_dist(line + "#sha1=abc")]
-    reqs = [from_line(line + "#sha1=def")]
+    installed = [fake_dist(line + "sha1=abc")]
+    reqs = [from_line(line + "sha1=def")]
 
     to_install, to_uninstall = diff(reqs, installed)
     assert to_install == set(reqs)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -68,7 +68,7 @@ def mocked_tmp_req_file(mocked_tmp_file):
 )
 def test_dependency_tree(fake_dist, installed, root, expected):
     installed = {
-        distribution.key: distribution
+        distribution._dist.key: distribution
         for distribution in (fake_dist(name, deps) for name, deps in installed)
     }
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -263,25 +263,39 @@ def test_diff_with_editable(fake_dist, from_editable):
     assert package.link.url == path_to_url(path_to_package)
 
 
-def test_diff_with_matching_url_versions(fake_dist, from_line):
+def test_diff_with_matching_url_hash(fake_dist, from_line):
     # if URL version is explicitly provided, use it to avoid reinstalling
-    installed = [fake_dist("example==1.0")]
-    reqs = [from_line("file:///example.zip#egg=example==1.0")]
+    line = "example@file:///example.zip#sha1=abc"
+    installed = [fake_dist(line)]
+    reqs = [from_line(line)]
 
     to_install, to_uninstall = diff(reqs, installed)
     assert to_install == set()
     assert to_uninstall == set()
 
 
-def test_diff_with_no_url_versions(fake_dist, from_line):
-    # if URL version is not provided, assume the contents have
+def test_diff_with_no_url_hash(fake_dist, from_line):
+    # if URL hash is not provided, assume the contents have
     # changed and reinstall
-    installed = [fake_dist("example==1.0")]
-    reqs = [from_line("file:///example.zip#egg=example")]
+    line = "example@file:///example.zip"
+    installed = [fake_dist(line)]
+    reqs = [from_line(line)]
 
     to_install, to_uninstall = diff(reqs, installed)
     assert to_install == set(reqs)
     assert to_uninstall == {"example"}
+
+
+def test_diff_with_unequal_url_hash(fake_dist, from_line):
+    # if URL hashes mismatch, assume the contents have
+    # changed and reinstall
+    line = "example@file:///example.zip#"
+    installed = [fake_dist(line + "#sha1=abc")]
+    reqs = [from_line(line + "#sha1=def")]
+
+    to_install, to_uninstall = diff(reqs, installed)
+    assert to_install == set(reqs)
+    assert to_uninstall == {"example @ file:///example.zip#sha1=abc"}
 
 
 def test_sync_install_temporary_requirement_file(


### PR DESCRIPTION
<!--- Describe the changes here. --->

When a direct reference is provided with hashes, use the direct reference string as the unique key for a requirement. The key can also be used for uninstalling the dist.

See the attached issue for more details on why we want to do this.

Fixes #1884.

##### Contributor checklist

- [X] Provided the tests for the changes.
- [X] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
