### PR TITLE
Specify build formats in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,9 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
-formats: all
+formats:
+  - pdf
+  - htmlzip
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
Fixes #1887 

@webknjaz Another solution would be the approach in IQSS/dataverse#3542, if you want to keep building EPUB.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
