### PR TITLE
Fix missing `via`s when more than two input files are used

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -502,7 +502,16 @@ class BacktrackingResolver(BaseResolver):
         self.unsafe_constraints: set[InstallRequirement] = set()
 
         self.existing_constraints = existing_constraints
-        self._constraints_map = {key_from_ireq(ireq): ireq for ireq in constraints}
+
+        # Categorize InstallRequirements into sets by key
+        constraints_sets: DefaultDict[str, set[InstallRequirement]] = collections.defaultdict(set)
+        for ireq in constraints:
+            constraints_sets[key_from_ireq(ireq)].add(ireq)
+        # Collapse each set of InstallRequirements using combine_install_requirements
+        self._constraints_map = {
+            ireq_key: combine_install_requirements(ireqs)
+            for ireq_key, ireqs in constraints_sets.items()
+        }
 
         # Make sure there is no enabled legacy resolver
         options.deprecated_features_enabled = omit_list_value(
@@ -759,9 +768,14 @@ class BacktrackingResolver(BaseResolver):
         ireq_key = key_from_ireq(ireq)
         pinned_ireq._required_by = reverse_dependencies.get(ireq_key, set())
 
-        # Save source for annotation
-        source_ireq = self._constraints_map.get(ireq_key)
-        if source_ireq is not None:
-            pinned_ireq._source_ireqs = [source_ireq]
+        # Save sources for annotation
+        constraint_ireq = self._constraints_map.get(ireq_key)
+        if constraint_ireq is not None:
+            if hasattr(constraint_ireq, "_source_ireqs"):
+                # If the constraint is combined (has _source_ireqs), use those
+                pinned_ireq._source_ireqs = constraint_ireq._source_ireqs
+            else:
+                # Otherwise (the constraint is not combined) it is the source
+                pinned_ireq._source_ireqs = [constraint_ireq]
 
         return pinned_ireq

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -504,7 +504,9 @@ class BacktrackingResolver(BaseResolver):
         self.existing_constraints = existing_constraints
 
         # Categorize InstallRequirements into sets by key
-        constraints_sets: DefaultDict[str, set[InstallRequirement]] = collections.defaultdict(set)
+        constraints_sets: DefaultDict[
+            str, set[InstallRequirement]
+        ] = collections.defaultdict(set)
         for ireq in constraints:
             constraints_sets[key_from_ireq(ireq)].add(ireq)
         # Collapse each set of InstallRequirements using combine_install_requirements

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1916,11 +1916,9 @@ def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
     annotation.
     See: https://github.com/jazzband/pip-tools/issues/1853
     """
-    in_files = [f"requirements{n:02d}.in" for n in range(1, num_inputs + 1)]
-
+    in_files = [tmp_path / f"requirements{n:02d}.in" for n in range(num_inputs)]
     for in_file in in_files:
-        with open(in_file, "w") as req_in:
-            req_in.write("small-fake-a==0.1\n")
+        req_in.write_text("small-fake-a==0.1\n")
 
     out = runner.invoke(
         cli,

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1908,6 +1908,7 @@ def test_upgrade_package_doesnt_remove_annotation(pip_conf, runner):
             """
         )
 
+
 @pytest.mark.parametrize(("num_inputs"), (2, 3, 10))
 def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
     """
@@ -1928,13 +1929,21 @@ def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
             "--quiet",
             "--no-header",
             "--no-emit-find-links",
-        ] + in_files,
+        ]
+        + in_files,
     )
     assert out.exit_code == 0, out.stderr
-    assert out.stdout == "\n".join([
-        "small-fake-a==0.1",
-        "    # via",
-    ] + [f"    #   -r {in_file}" for in_file in in_files]) + "\n"
+    assert (
+        out.stdout
+        == "\n".join(
+            [
+                "small-fake-a==0.1",
+                "    # via",
+            ]
+            + [f"    #   -r {in_file}" for in_file in in_files]
+        )
+        + "\n"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1916,8 +1916,8 @@ def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
     annotation.
     See: https://github.com/jazzband/pip-tools/issues/1853
     """
-    in_files = [tmp_path / f"requirements{n:02d}.in" for n in range(num_inputs)]
-    for in_file in in_files:
+    req_ins = [tmp_path / f"requirements{n:02d}.in" for n in range(num_inputs)]
+    for req_in in req_ins:
         req_in.write_text("small-fake-a==0.1\n")
 
     out = runner.invoke(
@@ -1929,7 +1929,7 @@ def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
             "--no-header",
             "--no-emit-find-links",
         ]
-        + in_files,
+        + req_ins,
     )
     assert out.exit_code == 0, out.stderr
     assert (
@@ -1939,7 +1939,7 @@ def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
                 "small-fake-a==0.1",
                 "    # via",
             ]
-            + [f"    #   -r {in_file}" for in_file in in_files]
+            + [f"    #   -r {req_in}" for req_in in req_ins]
         )
         + "\n"
     )

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1912,7 +1912,8 @@ def test_upgrade_package_doesnt_remove_annotation(pip_conf, runner):
 @pytest.mark.parametrize(("num_inputs"), (2, 3, 10))
 def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
     """
-    Tests that an entry required by multiple input files is attributed to all of them in the annotation.
+    Tests that an entry required by multiple input files is attributed to all of them in the
+    annotation.
     See: https://github.com/jazzband/pip-tools/issues/1853
     """
     in_files = [f"requirements{n:02d}.in" for n in range(1, num_inputs + 1)]

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1910,7 +1910,7 @@ def test_upgrade_package_doesnt_remove_annotation(pip_conf, runner):
 
 
 @pytest.mark.parametrize(("num_inputs"), (2, 3, 10))
-def test_many_inputs_includes_all_annotations(pip_conf, runner, num_inputs):
+def test_many_inputs_includes_all_annotations(pip_conf, runner, tmp_path, num_inputs):
     """
     Tests that an entry required by multiple input files is attributed to all of them in the
     annotation.

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1929,7 +1929,7 @@ def test_many_inputs_includes_all_annotations(pip_conf, runner, tmp_path, num_in
             "--no-header",
             "--no-emit-find-links",
         ]
-        + req_ins,
+        + [str(r) for r in req_ins],
     )
     assert out.exit_code == 0, out.stderr
     assert (


### PR DESCRIPTION
Fixes https://github.com/jazzband/pip-tools/issues/1853.

The gist of the problem is that

```py
self._constraints_map = {key_from_ireq(ireq): ireq for ireq in constraints}
```

only kept the last `ireq` for each key, rather than combining them (and thus their sources).

There are two changes here:

- `self._constraints_map` is no longer constructed directly from `constraints`; rather, the items in `constraints` are first grouped by key into sets, then those sets are "collapsed" via `combine_install_requirements()` into single `InstallRequirement`s.
- `pinned_ireq._source_ireqs` is no longer always a singleton list of the value from `self._constraints_map`; rather, if the constraint has `_source_ireqs`, then that list is used as `pinned_ireq._source_ireqs`. This effectively "unwraps" `_source_ireqs` (once) if possible.
  - A more sophisticated solution might be to just have `writer.py` recurse on `_source_ireqs` [when constructing `required_by`](https://github.com/lpulley/pip-tools/blob/1479ad95ca71b131e657e64b49862e58ceb14d59/piptools/writer.py#L294C50-L294C50), but that touches more code paths than are necessary to fix this, so I opted for this solution instead. Such recursion would enable combined `InstallRequirement`s to be combined further without issue, but that doesn't seem to be a requirement right now.

The new `test_many_inputs_includes_all_annotations` is parametrized for 2, 3, and 10 inputs; the 2 case was not broken but should still be tested.

---

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
