### PR TITLE
Exclude default config value from the pip-compile header

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -599,7 +599,14 @@ def select_config_file(src_files: tuple[str, ...]) -> Path | None:
         ),
         None,
     )
-    return config_file_path.relative_to(working_directory) if config_file_path else None
+    if config_file_path is None:
+        return None
+
+    return (
+        config_file_path.relative_to(working_directory)
+        if config_file_path.is_relative_to(working_directory)
+        else config_file_path
+    )
 
 
 # Some of the defined click options have different `dest` values than the defaults

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -604,7 +604,7 @@ def select_config_file(src_files: tuple[str, ...]) -> Path | None:
 
     return (
         config_file_path.relative_to(working_directory)
-        if config_file_path.is_relative_to(working_directory)
+        if is_path_relative_to(config_file_path, working_directory)
         else config_file_path
     )
 
@@ -667,3 +667,14 @@ def parse_config_file(config_file: Path) -> dict[str, Any]:
                 original_option, f"Config key '{original_option}' must be a list"
             )
     return piptools_config
+
+
+def is_path_relative_to(path1: Path, path2: Path) -> bool:
+    """Return True if ``path1`` is relative to ``path2``."""
+    # TODO: remove this function in favor of Path.is_relative_to()
+    #       when we drop support for Python 3.8
+    try:
+        path1.relative_to(path2)
+    except ValueError:
+        return False
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -473,6 +473,6 @@ def make_config_file(tmpdir_cwd):
 
         config_to_dump = {"tool": {"pip-tools": {pyproject_param: new_default}}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
-        return config_file
+        return config_file.relative_to(tmpdir_cwd)
 
     return _maker

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -386,6 +386,30 @@ def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):
         assert get_compile_command(ctx) == expected_command
 
 
+@pytest.mark.parametrize(
+    ("config_file", "expected_command"),
+    (
+        pytest.param(
+            "pyproject.toml", "pip-compile", id="exclude default pyproject.toml"
+        ),
+        pytest.param(
+            ".pip-tools.toml", "pip-compile", id="exclude default .pip-tools.toml"
+        ),
+        pytest.param(
+            "my-config.toml",
+            "pip-compile --config=my-config.toml",
+            id="include non-default my-config.toml",
+        ),
+    ),
+)
+def test_get_compile_command_with_config(tmpdir_cwd, config_file, expected_command):
+    """Test that get_compile_command excludes or includes config file."""
+    with open(config_file, "w"):
+        pass
+    with compile_cli.make_context("pip-compile", ["--config", config_file]) as ctx:
+        assert get_compile_command(ctx) == expected_command
+
+
 def test_get_compile_command_escaped_filenames(tmpdir_cwd):
     """
     Test that get_compile_command output (re-)escapes ' -- '-escaped filenames.


### PR DESCRIPTION
Resolves https://github.com/jazzband/pip-tools/pull/1863#issuecomment-1611728125

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
