### PR TITLE
🔧 Ignore PyPy 3.7 test outcome in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,4 +153,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@13b4244b312e8a314951e03958a2f91519a6a3c9
         with:
+          allowed-failures: pypy # FIXME: drop once updated to `pypy-3.8`
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This is supposed to be temporary until said interpreter is fixed or upgraded to PyPy 3.8 (via https://github.com/jazzband/pip-tools/pull/1879) as `pip-tools` is going to drop support for Python 3.7 in the upcoming release.