### PR TITLE
Default to `--resolver=backtracking`

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -282,7 +282,7 @@ def _determine_linesep(
     "--resolver",
     "resolver_name",
     type=click.Choice(("legacy", "backtracking")),
-    default="legacy",
+    default="backtracking",
     envvar="PIP_TOOLS_RESOLVER",
     help="Choose the dependency resolver.",
 )
@@ -415,9 +415,7 @@ def cli(
     if resolver_name == "legacy":
         log.warning(
             "WARNING: the legacy dependency resolver is deprecated and will be removed"
-            " in future versions of pip-tools. The default resolver will be changed to"
-            " 'backtracking' in pip-tools 7.0.0. Specify --resolver=backtracking to"
-            " silence this warning."
+            " in future versions of pip-tools."
         )
 
     ###


### PR DESCRIPTION
Since 7.0.0 is the next release, it's time to switch the default resolver as promised.
Refs: https://github.com/jazzband/pip-tools/issues/1659

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
