### PR TITLE
👷 Deduplicate cron GHA through workflow reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ on:
     branches:
       - main
     tags:
-  schedule:
-    # Run everyday at 03:53 UTC
-    - cron: 53 3 * * *
+  workflow_call:
+    inputs:
+      cpython-pip-version:
+        description: >-
+          A JSON string with pip versions
+          to test against under CPython.
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -48,15 +53,30 @@ jobs:
           - "3.10"
           - "3.9"
           - "3.8"
-        pip-version:
-          - "latest"
-          - "previous"
+        pip-version: >-
+          ${{
+            fromJSON(
+              github.job_workflow_sha
+              && inputs.cpython-pip-version
+              || '["latest", "previous"]'
+            )
+          }}
         include:
           - os: Ubuntu
-            python-version: 3.8
+            python-version: >-
+              ${{
+                github.job_workflow_sha
+                && '3.12-dev'
+                || '3.8'
+              }}
             pip-version: main
     env:
-      TOXENV: pip${{ matrix.pip-version }}-coverage
+      TOXENV: >-
+        pip${{ matrix.pip-version }}${{
+          !github.job_workflow_sha
+          && '-coverage'
+          || ''
+        }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }} from GitHub
@@ -95,6 +115,8 @@ jobs:
       - name: Test pip ${{ matrix.pip-version }}
         run: tox
       - name: Upload coverage to Codecov
+        if: >-
+          !github.job_workflow_sha
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
@@ -132,6 +154,22 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        shell: bash
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: Pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: >-
+            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
+            hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{
+            hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Install tox
         run: pip install tox
       - name: Prepare test environment

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,114 +2,13 @@ name: Cron
 
 on:
   schedule:
-    # Run every day at 00:00 UTC
-    - cron: 0 0 * * *
+    # Run everyday at 03:53 UTC
+    - cron: 53 3 * * *
 
 jobs:
   main:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - Ubuntu
-          - Windows
-          - MacOS
-        python-version:
-          - "3.11"
-          - "3.10"
-          - "3.9"
-          - "3.8"
-        pip-version:
-          - main
-        include:
-          - os: Ubuntu
-            python-version: 3.12-dev
-            pip-version: main
-    env:
-      PY_COLORS: 1
-      TOXENV: pip${{ matrix.pip-version }}
-      TOX_PARALLEL_NO_SPINNER: 1
-    steps:
-      - uses: actions/checkout@main
-      - name: Set up Python ${{ matrix.python-version }} from GitHub
-        id: python-install
-        if: "!endsWith(matrix.python-version, '-dev')"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set up Python ${{ matrix.python-version }} from deadsnakes
-        if: endsWith(matrix.python-version, '-dev')
-        uses: deadsnakes/action@v2.1.1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Get pip cache dir
-        id: pip-cache
-        shell: bash
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: Pip cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-      - name: Install test dependencies
-        run: python -m pip install -U tox virtualenv
-      - name: Prepare test environment
-        run: tox --notest -p auto --parallel-live
-      - name: Test pip ${{ matrix.pip-version }}
-        run: tox
-
-  pypy:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - Ubuntu
-          - MacOS
-          - Windows
-        python-version:
-          - pypy-3.8
-        pip-version:
-          - latest
-    env:
-      PY_COLORS: 1
-      TOXENV: pip${{ matrix.pip-version }}
-      TOX_PARALLEL_NO_SPINNER: 1
-    steps:
-      - uses: actions/checkout@main
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Get pip cache dir
-        id: pip-cache
-        shell: bash
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: Pip cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
-            hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{
-            hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-      - name: Install tox
-        run: pip install tox
-      - name: Prepare test environment
-        run: tox --notest -p auto --parallel-live
-      - name: Test pip ${{ matrix.pip-version }}
-        run: tox
+    name: CI
+    uses: ./.github/workflows/ci.yml
+    with:
+      cpython-pip-version: >-
+        ["main", "latest", "previous"]


### PR DESCRIPTION
This patch melts most of the separate cron workflow into the main CI workflow which it then includes as reusable.
Such an approach allows for less duplication of the same CI steps while keeping the cron workflow as a separate entity.
