### PR TITLE
🎨🔧👷 Wire in linters into the main workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ env:
     PRE_COMMIT_COLOR
 
 jobs:
+  linters:
+    name: Linters
+    uses: ./.github/workflows/reusable-qa.yml
+
   test:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.os }}-latest
@@ -181,6 +185,7 @@ jobs:
     if: always()
 
     needs:
+      - linters
       - pypy
       - test
 

--- a/.github/workflows/reusable-qa.yml
+++ b/.github/workflows/reusable-qa.yml
@@ -1,15 +1,7 @@
 name: QA
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
-    tags:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   qa:


### PR DESCRIPTION
This patch makes use of reusable workflows to embed the linting jobs into the main pipeline. The technique allows having modularized CI definitions stored in separate files but being voting in the alls-green gate used in branch protection.