### PR TITLE
Fix revealed default config in header if requirements in subfolder

### DIFF
--- a/piptools/locations.py
+++ b/piptools/locations.py
@@ -5,5 +5,5 @@ from pip._internal.utils.appdirs import user_cache_dir
 # The user_cache_dir helper comes straight from pip itself
 CACHE_DIR = user_cache_dir("pip-tools")
 
-# The project defaults specific to pip-tools should be written to this filename
-CONFIG_FILE_NAME = ".pip-tools.toml"
+# The project defaults specific to pip-tools should be written to this filenames
+DEFAULT_CONFIG_FILE_NAMES = (".pip-tools.toml", "pyproject.toml")

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -316,10 +316,10 @@ def _determine_linesep(
     ),
     help=(
         f"Read configuration from TOML file. By default, looks for the following "
-        f"files in the given order: {', '.join(DEFAULT_CONFIG_FILE_NAMES)}. "
+        f"files in the given order: {', '.join(DEFAULT_CONFIG_FILE_NAMES)}."
     ),
-    callback=override_defaults_from_config_file,
     is_eager=True,
+    callback=override_defaults_from_config_file,
 )
 @click.option(
     "--no-config",

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -20,7 +20,7 @@ from pip._internal.utils.misc import redact_auth_from_url
 from .._compat import parse_requirements
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError
-from ..locations import CACHE_DIR, CONFIG_FILE_NAME
+from ..locations import CACHE_DIR, DEFAULT_CONFIG_FILE_NAMES
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..repositories.base import BaseRepository
@@ -251,9 +251,7 @@ def _determine_linesep(
     default=10,
     help="Maximum number of rounds before resolving the requirements aborts.",
 )
-@click.argument(
-    "src_files", nargs=-1, type=click.Path(exists=True, allow_dash=True), is_eager=True
-)
+@click.argument("src_files", nargs=-1, type=click.Path(exists=True, allow_dash=True))
 @click.option(
     "--build-isolation/--no-build-isolation",
     is_flag=True,
@@ -316,9 +314,12 @@ def _determine_linesep(
         allow_dash=False,
         path_type=str,
     ),
-    help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
-    "pyproject.toml.",
+    help=(
+        f"Read configuration from TOML file. By default, looks for the following "
+        f"files in the given order: {', '.join(DEFAULT_CONFIG_FILE_NAMES)}. "
+    ),
     callback=override_defaults_from_config_file,
+    is_eager=True,
 )
 @click.option(
     "--no-config",

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -251,7 +251,9 @@ def _determine_linesep(
     default=10,
     help="Maximum number of rounds before resolving the requirements aborts.",
 )
-@click.argument("src_files", nargs=-1, type=click.Path(exists=True, allow_dash=True))
+@click.argument(
+    "src_files", nargs=-1, type=click.Path(exists=True, allow_dash=True), is_eager=True
+)
 @click.option(
     "--build-isolation/--no-build-isolation",
     is_flag=True,
@@ -316,7 +318,6 @@ def _determine_linesep(
     ),
     help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
     "pyproject.toml.",
-    is_eager=True,
     callback=override_defaults_from_config_file,
 )
 @click.option(

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -100,10 +100,10 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     ),
     help=(
         f"Read configuration from TOML file. By default, looks for the following "
-        f"files in the given order: {', '.join(DEFAULT_CONFIG_FILE_NAMES)}. "
+        f"files in the given order: {', '.join(DEFAULT_CONFIG_FILE_NAMES)}."
     ),
-    callback=override_defaults_from_config_file,
     is_eager=True,
+    callback=override_defaults_from_config_file,
 )
 @click.option(
     "--no-config",

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -17,7 +17,7 @@ from pip._internal.metadata import get_environment
 from .. import sync
 from .._compat import Distribution, parse_requirements
 from ..exceptions import PipToolsError
-from ..locations import CONFIG_FILE_NAME
+from ..locations import DEFAULT_CONFIG_FILE_NAMES
 from ..logging import log
 from ..repositories import PyPIRepository
 from ..utils import (
@@ -86,9 +86,7 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     help="Path to SSL client certificate, a single file containing "
     "the private key and the certificate in PEM format.",
 )
-@click.argument(
-    "src_files", required=False, type=click.Path(exists=True), nargs=-1, is_eager=True
-)
+@click.argument("src_files", required=False, type=click.Path(exists=True), nargs=-1)
 @click.option("--pip-args", help="Arguments to pass directly to pip install.")
 @click.option(
     "--config",
@@ -100,9 +98,12 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
         allow_dash=False,
         path_type=str,
     ),
-    help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
-    "pyproject.toml.",
+    help=(
+        f"Read configuration from TOML file. By default, looks for the following "
+        f"files in the given order: {', '.join(DEFAULT_CONFIG_FILE_NAMES)}. "
+    ),
     callback=override_defaults_from_config_file,
+    is_eager=True,
 )
 @click.option(
     "--no-config",

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -86,7 +86,9 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     help="Path to SSL client certificate, a single file containing "
     "the private key and the certificate in PEM format.",
 )
-@click.argument("src_files", required=False, type=click.Path(exists=True), nargs=-1)
+@click.argument(
+    "src_files", required=False, type=click.Path(exists=True), nargs=-1, is_eager=True
+)
 @click.option("--pip-args", help="Arguments to pass directly to pip install.")
 @click.option(
     "--config",
@@ -100,7 +102,6 @@ DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
     ),
     help=f"Read configuration from TOML file. By default, looks for a {CONFIG_FILE_NAME} or "
     "pyproject.toml.",
-    is_eager=True,
     callback=override_defaults_from_config_file,
 )
 @click.option(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -461,7 +461,7 @@ def make_config_file(tmpdir_cwd):
         config_dir.mkdir(exist_ok=True, parents=True)
 
         # Make a config file with this one config default override
-        config_file = Path(tmpdir_cwd / config_file_name)
+        config_file = tmpdir_cwd / config_file_name
         config_to_dump = {"tool": {"pip-tools": {pyproject_param: new_default}}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
         return cast(Path, config_file.relative_to(tmpdir_cwd))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -454,11 +454,12 @@ def make_config_file(tmpdir_cwd):
     def _maker(
         pyproject_param: str, new_default: Any, config_file_name: str = CONFIG_FILE_NAME
     ) -> Path:
-        # Make a config file with this one config default override
-        config_path = Path(tmpdir_cwd) / pyproject_param
-        config_file = config_path / config_file_name
-        config_path.mkdir(exist_ok=True)
+        # Create a nested directory structure if config_file_name includes directories
+        config_dir = Path(tmpdir_cwd / config_file_name).parent
+        config_dir.mkdir(exist_ok=True, parents=True)
 
+        # Make a config file with this one config default override
+        config_file = Path(tmpdir_cwd / config_file_name)
         config_to_dump = {"tool": {"pip-tools": {pyproject_param: new_default}}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
         return config_file.relative_to(tmpdir_cwd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -457,7 +457,7 @@ def make_config_file(tmpdir_cwd):
         config_file_name: str = DEFAULT_CONFIG_FILE_NAMES[0],
     ) -> Path:
         # Create a nested directory structure if config_file_name includes directories
-        config_dir = Path(tmpdir_cwd / config_file_name).parent
+        config_dir = (tmpdir_cwd / config_file_name).parent
         config_dir.mkdir(exist_ok=True, parents=True)
 
         # Make a config file with this one config default override

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ from pip._vendor.pkg_resources import Requirement
 from piptools._compat import PIP_VERSION, Distribution
 from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
-from piptools.locations import CONFIG_FILE_NAME
+from piptools.locations import DEFAULT_CONFIG_FILE_NAMES
 from piptools.logging import log
 from piptools.repositories import PyPIRepository
 from piptools.repositories.base import BaseRepository
@@ -452,7 +452,9 @@ def make_config_file(tmpdir_cwd):
     """
 
     def _maker(
-        pyproject_param: str, new_default: Any, config_file_name: str = CONFIG_FILE_NAME
+        pyproject_param: str,
+        new_default: Any,
+        config_file_name: str = DEFAULT_CONFIG_FILE_NAMES[0],
     ) -> Path:
         # Create a nested directory structure if config_file_name includes directories
         config_dir = Path(tmpdir_cwd / config_file_name).parent

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2975,6 +2975,18 @@ def test_config_option(pip_conf, runner, tmp_path, make_config_file):
     assert "Dry-run, so nothing updated" in out.stderr
 
 
+def test_default_config_option(pip_conf, runner, make_config_file, tmpdir_cwd):
+    make_config_file("dry-run", True)
+
+    req_in = tmpdir_cwd / "requirements.in"
+    req_in.ensure()
+
+    out = runner.invoke(cli)
+
+    assert out.exit_code == 0
+    assert "Dry-run, so nothing updated" in out.stderr
+
+
 def test_no_config_option_overrides_config_with_defaults(
     pip_conf, runner, tmp_path, make_config_file
 ):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2979,7 +2979,7 @@ def test_default_config_option(pip_conf, runner, make_config_file, tmpdir_cwd):
     make_config_file("dry-run", True)
 
     req_in = tmpdir_cwd / "requirements.in"
-    req_in.ensure()
+    req_in.touch()
 
     out = runner.invoke(cli)
 

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -375,6 +375,19 @@ def test_default_python_executable_option(run, runner):
 
 
 @mock.patch("piptools.sync.run")
+def test_default_config_option(run, runner, make_config_file, tmpdir_cwd):
+    make_config_file("dry-run", True)
+
+    with open(sync.DEFAULT_REQUIREMENTS_FILE, "w") as reqs_txt:
+        reqs_txt.write("six==1.10.0")
+
+    out = runner.invoke(cli)
+
+    assert out.exit_code == 1
+    assert "Would install:" in out.stdout
+
+
+@mock.patch("piptools.sync.run")
 def test_config_option(run, runner, make_config_file):
     config_file = make_config_file("dry-run", True)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -418,7 +418,7 @@ def test_get_compile_command_with_config(tmpdir_cwd, config_file, expected_comma
     (
         pytest.param("", id="empty config file"),
         pytest.param("[tool.pip-tools]", id="empty config section"),
-        pytest.param("[tool.pip-tools]\ndry-run = True", id="non-empty config section"),
+        pytest.param("[tool.pip-tools]\ndry-run = true", id="non-empty config section"),
     ),
 )
 def test_get_compile_command_does_not_include_default_config_if_reqs_file_in_subdir(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -424,9 +424,7 @@ def test_get_compile_command_does_not_include_default_config_if_reqs_file_in_sub
     (tmpdir_cwd / "subdir").mkdir()
     req_file = Path("subdir/requirements.in")
     req_file.touch()
-
-    with open(req_file, "w"):
-        pass
+    req_file.write_bytes(b"")
 
     # Make sure that the default config file is not included
     with compile_cli.make_context("pip-compile", [req_file.as_posix()]) as ctx:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
+from textwrap import dedent
 
 import pip
 import pytest
@@ -31,6 +32,7 @@ from piptools.utils import (
     lookup_table,
     lookup_table_from_tuples,
     override_defaults_from_config_file,
+    select_config_file,
 )
 
 
@@ -708,3 +710,52 @@ def test_callback_config_file_defaults_unreadable_toml(make_config_file):
             "config",
             "/dev/null/path/does/not/exist/my-config.toml",
         )
+
+
+def test_select_config_file_no_files(tmpdir_cwd):
+    assert select_config_file(()) is None
+
+
+@pytest.mark.parametrize("filename", ("pyproject.toml", ".pip-tools.toml"))
+def test_select_config_file_returns_config_in_cwd(make_config_file, filename):
+    config_file = make_config_file("dry-run", True, filename)
+    assert select_config_file(()) == config_file
+
+
+def test_select_config_file_returns_empty_config_file_in_cwd(tmpdir_cwd):
+    config_file = Path(".pip-tools.toml")
+    config_file.touch()
+
+    assert select_config_file(()) == config_file
+
+
+def test_select_config_file_cannot_find_config_in_cwd(tmpdir_cwd, make_config_file):
+    make_config_file("dry-run", True, "subdir/pyproject.toml")
+    assert select_config_file(()) is None
+
+
+def test_select_config_file_with_config_file_in_subdir(tmpdir_cwd, make_config_file):
+    config_file = make_config_file("dry-run", True, "subdir/.pip-tools.toml")
+
+    requirement_file = Path("subdir/requirements.in")
+    requirement_file.touch()
+
+    assert select_config_file((requirement_file.as_posix(),)) == config_file
+
+
+def test_select_config_file_prefers_pip_tools_toml_over_pyproject_toml(tmpdir_cwd):
+    pip_tools_file = Path(".pip-tools.toml")
+    pip_tools_file.touch()
+
+    pyproject_file = Path("pyproject.toml")
+    pyproject_file.write_text(
+        dedent(
+            """\
+        [build-system]
+        requires = ["setuptools>=63", "setuptools_scm[toml]>=7"]
+        build-backend = "setuptools.build_meta"
+        """
+        )
+    )
+
+    assert select_config_file(()) == pip_tools_file

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -410,16 +410,25 @@ def test_get_compile_command_with_config(tmpdir_cwd, config_file, expected_comma
         assert get_compile_command(ctx) == expected_command
 
 
+@pytest.mark.parametrize("config_file", ("pyproject.toml", ".pip-tools.toml"))
+@pytest.mark.parametrize(
+    "config_file_content",
+    (
+        pytest.param("", id="empty config file"),
+        pytest.param("[tool.pip-tools]", id="empty config section"),
+        pytest.param("[tool.pip-tools]\ndry-run = True", id="non-empty config section"),
+    ),
+)
 def test_get_compile_command_does_not_include_default_config_if_reqs_file_in_subdir(
-    tmpdir_cwd,
+    tmpdir_cwd, config_file, config_file_content
 ):
     """
     Test that ``get_compile_command`` does not include default config file
     if requirements file is in a subdirectory.
     Regression test for issue GH-1903.
     """
-    default_config_file = Path("pyproject.toml")
-    default_config_file.touch()
+    default_config_file = Path(config_file)
+    default_config_file.write_text(config_file_content)
 
     (tmpdir_cwd / "subdir").mkdir()
     req_file = Path("subdir/requirements.in")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -750,10 +750,10 @@ def test_select_config_file_prefers_pip_tools_toml_over_pyproject_toml(tmpdir_cw
     pyproject_file.write_text(
         dedent(
             """\
-        [build-system]
-        requires = ["setuptools>=63", "setuptools_scm[toml]>=7"]
-        build-backend = "setuptools.build_meta"
-        """
+            [build-system]
+            requires = ["setuptools>=63", "setuptools_scm[toml]>=7"]
+            build-backend = "setuptools.build_meta"
+            """
         )
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -410,6 +410,29 @@ def test_get_compile_command_with_config(tmpdir_cwd, config_file, expected_comma
         assert get_compile_command(ctx) == expected_command
 
 
+def test_get_compile_command_does_not_include_default_config_if_reqs_file_in_subdir(
+    tmpdir_cwd,
+):
+    """
+    Test that ``get_compile_command`` does not include default config file
+    if requirements file is in a subdirectory.
+    Regression test for issue GH-1903.
+    """
+    default_config_file = Path("pyproject.toml")
+    default_config_file.touch()
+
+    (tmpdir_cwd / "subdir").mkdir()
+    req_file = Path("subdir/requirements.in")
+    req_file.touch()
+
+    with open(req_file, "w"):
+        pass
+
+    # Make sure that the default config file is not included
+    with compile_cli.make_context("pip-compile", [req_file.as_posix()]) as ctx:
+        assert get_compile_command(ctx) == f"pip-compile {req_file.as_posix()}"
+
+
 def test_get_compile_command_escaped_filenames(tmpdir_cwd):
     """
     Test that get_compile_command output (re-)escapes ' -- '-escaped filenames.


### PR DESCRIPTION
Ensure `src_files` are handled prior to `--config`, as `override_defaults_from_config_file` is dependent on `src_files`.

Fixes #1903.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
