### PR TITLE
Don't use setuptools_scm from Sphinx itself

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,15 +3,12 @@
 
 from __future__ import annotations
 
-from functools import partial
+from importlib.metadata import version as get_version
 from pathlib import Path
-
-from setuptools_scm import get_version
 
 # -- Path setup --------------------------------------------------------------
 
 PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
-get_scm_version = partial(get_version, root=PROJECT_ROOT_DIR)
 
 
 # -- Project information -----------------------------------------------------
@@ -20,18 +17,11 @@ project = "pip-tools"
 author = f"{project} Contributors"
 copyright = f"The {author}"
 
-# The short X.Y version
-version = ".".join(
-    get_scm_version(
-        local_scheme="no-local-version",
-    ).split(
-        "."
-    )[:3],
-)
-
 # The full version, including alpha/beta/rc tags
-release = get_scm_version()
+release = get_version(project)
 
+# The short X.Y version
+version = ".".join(release.split(".")[:3])
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,9 @@ release = get_version(project)
 # The short X.Y version
 version = ".".join(release.split(".")[:3])
 
+print("pip-tools version:", version)
+print("pip-tools release:", release)
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -37,6 +40,7 @@ extensions = ["myst_parser"]
 # a list of builtin themes.
 #
 html_theme = "furo"
+html_title = f"<nobr>{project}</nobr> documentation v{release}"
 
 
 # -------------------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,11 @@ from __future__ import annotations
 from importlib.metadata import version as get_version
 from pathlib import Path
 
+from sphinx.util import logging
+from sphinx.util.console import bold
+
+logger = logging.getLogger(__name__)
+
 # -- Path setup --------------------------------------------------------------
 
 PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
@@ -23,8 +28,8 @@ release = get_version(project)
 # The short X.Y version
 version = ".".join(release.split(".")[:3])
 
-print("pip-tools version:", version)
-print("pip-tools release:", release)
+logger.info(bold("%s version: %s"), project, version)
+logger.info(bold("%s release: %s"), project, release)
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,4 @@ markers = ["network: mark tests that require internet access"]
 include = ["piptools*"]
 
 [tool.setuptools_scm]
+local_scheme = "dirty-tag"

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ changedir = {toxinidir}/docs
 isolated_build = true
 passenv =
   SSH_AUTH_SOCK
-skip_install = true
+skip_install = false
 allowlist_externals =
   git
 
@@ -151,6 +151,6 @@ changedir = {toxinidir}/docs
 isolated_build = true
 passenv =
   SSH_AUTH_SOCK
-skip_install = true
+skip_install = false
 allowlist_externals =
   git


### PR DESCRIPTION
Perhaps resolves #1846.

> It is discouraged to use `setuptools_scm` from Sphinx itself, instead use `importlib.metadata` after editable/real installation. The underlying reason is, that services like Read the Docs sometimes change the working directory for good reasons and using the installed metadata prevents using needless volatile data there.

https://github.com/pypa/setuptools_scm/#usage-from-sphinx


##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
