### PR TITLE
Refactor multi-value options validation

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -623,21 +623,25 @@ def test_callback_config_file_defaults(pyproject_param, new_default, make_config
 
 
 @pytest.mark.parametrize(
-    "mv_option",
+    ("param", "value"),
     (
-        "extra",
-        "upgrade-package",
-        "unsafe-package",
-        "find-links",
-        "extra-index-url",
-        "trusted-host",
+        ("extra", "not-a-list"),
+        ("upgrade_package", "not-a-list"),
+        ("unsafe_package", "not-a-list"),
+        ("find_links", "not-a-list"),
+        ("extra_index_url", "not-a-list"),
+        ("trusted_host", "not-a-list"),
+        ("annotate", "not-a-bool"),
+        ("max_rounds", "not-an-int"),
     ),
 )
-def test_callback_config_file_defaults_multi_value_options(mv_option, make_config_file):
-    config_file = make_config_file(mv_option, "not-a-list")
+def test_callback_config_file_defaults_multi_validate_value(
+    param, value, make_config_file
+):
+    config_file = make_config_file(param, value)
     ctx = Context(compile_cli)
     ctx.params["src_files"] = (str(config_file),)
-    with pytest.raises(BadOptionUsage, match="must be a list"):
+    with pytest.raises(BadOptionUsage, match="Invalid value for config key"):
         override_defaults_from_config_file(ctx, "config", None)
 
 


### PR DESCRIPTION
Move multi-value options validation logic to `_validate_config()`.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
