### PR TITLE
Update types using fresh dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,9 @@ repos:
         # Keep exclude in sync with mypy own excludes
         exclude: ^tests/test_data/
         additional_dependencies:
-          - click==8.0.1
-          - pep517==0.10.0
-          - toml==0.10.2
-          - pip==20.3.4
-          - build==0.9.0
+          - click==8.1.6
+          - pip==23.2
+          - build==0.10.0
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5
     hooks:

--- a/piptools/__main__.py
+++ b/piptools/__main__.py
@@ -5,7 +5,7 @@ import click
 from piptools.scripts import compile, sync
 
 
-@click.group()
+@click.group
 def cli() -> None:
     pass
 

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -131,11 +131,10 @@ def diff_key_from_ireq(ireq: InstallRequirement) -> str:
     if the contents at the URL have changed but the version has not.
     """
     if is_url_requirement(ireq):
-        if getattr(ireq.req, "name", None) and ireq.link.has_hash:
-            return str(
-                direct_url_as_pep440_direct_reference(
-                    direct_url_from_link(ireq.link), ireq.req.name
-                )
+        req_name = getattr(ireq.req, "name", None)
+        if req_name is not None and ireq.link is not None and ireq.link.has_hash:
+            return direct_url_as_pep440_direct_reference(
+                direct_url_from_link(ireq.link), req_name
             )
         # TODO: Also support VCS and editable installs.
         return str(ireq.link)
@@ -189,7 +188,7 @@ def diff(
 
 def sync(
     to_install: Iterable[InstallRequirement],
-    to_uninstall: Iterable[InstallRequirement],
+    to_uninstall: Iterable[str],
     dry_run: bool = False,
     install_flags: list[str] | None = None,
     ask: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,10 @@ module = ["tests.*"]
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["pip._vendor.requests.*", "pip._vendor.pkg_resources.*"]
+module = [
+  "pip._vendor.pkg_resources.*",
+  "pip._vendor.requests.*",
+]
 follow_imports = "skip"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
-ignore_missing_imports = true
 no_implicit_optional = true
 no_implicit_reexport = true
 strict_equality = true
@@ -94,6 +93,10 @@ exclude = "^tests/test_data/"
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["pip._vendor.requests.*", "pip._vendor.pkg_resources.*"]
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 addopts = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,15 +115,15 @@ class FakeRepository(BaseRepository):
 
     @property
     def session(self) -> PipSession:
-        """Not used"""
+        raise NotImplementedError("not used")
 
     @property
     def finder(self) -> PackageFinder:
-        """Not used"""
+        raise NotImplementedError("not used")
 
     @property
     def command(self) -> InstallCommand:
-        """Not used"""
+        raise NotImplementedError("not used")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,16 +114,16 @@ class FakeRepository(BaseRepository):
         return self._options
 
     @property
-    def session(self) -> PipSession:
-        raise NotImplementedError("not used")
+    def session(self) -> PipSession:  # type: ignore
+        """not used"""
 
     @property
-    def finder(self) -> PackageFinder:
-        raise NotImplementedError("not used")
+    def finder(self) -> PackageFinder:  # type: ignore
+        """not used"""
 
     @property
-    def command(self) -> InstallCommand:
-        raise NotImplementedError("not used")
+    def command(self) -> InstallCommand:  # type: ignore
+        """not used"""
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
Since 21.1 pip has [py.typed](https://github.com/pypa/pip/commit/09e8fa96c7bf821916e9a21135359d1507fa5b68) file, hence many updates on type annotations.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
