### PR TITLE
Allow options in config from both `pip-compile` and `pip-sync`

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -626,7 +626,10 @@ def _validate_config(
             except Exception as e:
                 raise click.BadOptionUsage(
                     option_name=key,
-                    message=f"Invalid value for config key {key!r}: {value!r}.",
+                    message=(
+                        f"Invalid value for config key {key!r}: {value!r}.{os.linesep}"
+                        f"Details: {e}"
+                    ),
                     ctx=click_context,
                 ) from e
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -625,7 +625,7 @@ def _validate_config(
         # Validate value against types of all associated params
         for param in associated_params:
             try:
-                param.type.convert(value=value, param=param, ctx=click_context)
+                param.type_cast_value(value=value, ctx=click_context)
             except Exception as e:
                 raise click.BadOptionUsage(
                     option_name=key,

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -615,12 +615,15 @@ def _validate_config(
                 ctx=click_context,
             )
 
-        # Validate values for both compile and sync
-        for cli_params in (compile_cli_params, sync_cli_params):
-            param = cli_params.get(key)
-            if param is None:
-                continue
+        # Get all params associated with this key in both compile and sync
+        associated_params = (
+            cli_params[key]
+            for cli_params in (compile_cli_params, sync_cli_params)
+            if key in cli_params
+        )
 
+        # Validate value against types of all associated params
+        for param in associated_params:
             try:
                 param.type.convert(value=value, param=param, ctx=click_context)
             except Exception as e:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3017,3 +3017,17 @@ def test_raise_error_on_invalid_config_option(
 
     assert out.exit_code == 2
     assert "Invalid value for config key 'dry_run': ['invalid', 'value']" in out.stderr
+
+
+def test_allow_in_config_pip_sync_option(pip_conf, runner, tmp_path, make_config_file):
+    config_file = make_config_file("--ask", True)  # pip-sync's option
+
+    req_in = tmp_path / "requirements.in"
+    req_in.touch()
+
+    out = runner.invoke(
+        cli, [req_in.as_posix(), "--verbose", "--config", config_file.as_posix()]
+    )
+
+    assert out.exit_code == 0
+    assert "Using pip-tools configuration defaults found" in out.stderr

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -424,3 +424,16 @@ def test_raise_error_on_invalid_config_option(run, runner, tmp_path, make_config
 
     assert out.exit_code == 2
     assert "Invalid value for config key 'dry_run': ['invalid', 'value']" in out.stderr
+
+
+@mock.patch("piptools.sync.run")
+def test_allow_in_config_pip_compile_option(run, runner, tmp_path, make_config_file):
+    config_file = make_config_file("generate-hashes", True)  # pip-compile's option
+
+    with open(sync.DEFAULT_REQUIREMENTS_FILE, "w") as reqs_txt:
+        reqs_txt.write("six==1.10.0")
+
+    out = runner.invoke(cli, ["--verbose", "--config", config_file.as_posix()])
+
+    assert out.exit_code == 0
+    assert "Using pip-tools configuration defaults found" in out.stderr


### PR DESCRIPTION
Fixes #1932.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
