### PR TITLE
Unshallow git clone on RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,9 @@ build:
   tools:
     python: >-
       3.11
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
 
 python:
   install:


### PR DESCRIPTION
Fetch full history so that setuptools-scm could detect correct version.

For the context:
- https://github.com/pypa/setuptools_scm/issues/790
- https://docs.readthedocs.io/en/latest/build-customization.html#unshallow-git-clone

Fixes #1939.

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
