### PR TITLE
Fix typo (`vor -> for`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Options to `pip-compile` and `pip-sync` that may be used more than once
 must be defined as lists in a configuration file, even if they only have one
 value.
 
-`pip-tools` supports default values vor [all valid command-line flags](/cli/index.md)
+`pip-tools` supports default values for [all valid command-line flags](/cli/index.md)
 of its subcommands. Configuration keys may contain underscores instead of dashes,
 so the above could also be specified in this format:
 


### PR DESCRIPTION
This PR fixes a minor typo in the README: the word `vor` is replaced with `for`.

##### Contributor checklist

- [ ] (N/A) Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
