### PR TITLE
Update CHANGELOG text structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 7.1.0 (2023-07-18)
+## v7.1.0
+
+18 Jul 2023
 
 Features:
 
@@ -10,7 +12,9 @@ Bug Fixes:
 - Fix a bug where pip-sync would unexpectedly uninstall some packages
   ([#1919](https://github.com/jazzband/pip-tools/pull/1919)). Thanks @atugushev
 
-## 7.0.0 (2023-07-14)
+## v7.0.0
+
+14 Jul 2023
 
 Backwards Incompatible Changes:
 
@@ -33,7 +37,9 @@ Bug Fixes:
 - Fix missing `via`s when more than two input files are used
   ([#1890](https://github.com/jazzband/pip-tools/pull/1890)). Thanks @lpulley
 
-## 6.14.0 (2023-06-28)
+## v6.14.0
+
+28 Jun 2023
 
 Features:
 
@@ -51,7 +57,9 @@ Other Changes:
 - Add pyprojects.toml example for using setuptools
   ([#1851](https://github.com/jazzband/pip-tools/pull/1851)). Thanks @shatakshiiii
 
-## 6.13.0 (2023-04-07)
+## v6.13.0
+
+07 Apr 2023
 
 Features:
 
@@ -74,7 +82,9 @@ Other Changes:
 - Update examples in README ([#1835](https://github.com/jazzband/pip-tools/pull/1835)).
   Thanks @lucaswerkmeister
 
-## 6.12.3 (2023-03-01)
+## v6.12.3
+
+01 Mar 2023
 
 Bug Fixes:
 
@@ -83,7 +93,9 @@ Bug Fixes:
 - Fix for sync error when the ireqs being merged have no names
   ([#1802](https://github.com/jazzband/pip-tools/pull/1802)). Thanks @richafrank
 
-## 6.12.2 (2022-12-25)
+## v6.12.2
+
+25 Dec 2022
 
 Bug Fixes:
 
@@ -94,14 +106,18 @@ Bug Fixes:
 - Fix a regression with unsafe packages for `--allow-unsafe`
   ([#1788](https://github.com/jazzband/pip-tools/pull/1788)). Thanks @q0w
 
-## 6.12.1 (2022-12-16)
+## v6.12.1
+
+16 Dec 2022
 
 Bug Fixes:
 
 - Set explicitly packages for setuptools
   ([#1782](https://github.com/jazzband/pip-tools/pull/1782)). Thanks @q0w
 
-## 6.12.0 (2022-12-13)
+## v6.12.0
+
+13 Dec 2022
 
 Features:
 
@@ -117,7 +133,9 @@ Bug Fixes:
 - Adopt PEP-621 for packaging
   ([#1763](https://github.com/jazzband/pip-tools/pull/1763)). Thanks @ssbarnea
 
-## 6.11.0 (2022-11-30)
+## v6.11.0
+
+30 Nov 2022
 
 Features:
 
@@ -140,7 +158,9 @@ Other Changes:
 - Bump pip minimum version to `>= 22.2`
   ([#1729](https://github.com/jazzband/pip-tools/pull/1729)). Thanks @atugushev
 
-## 6.10.0 (2022-11-13)
+## v6.10.0
+
+13 Nov 2022
 
 Features:
 
@@ -169,7 +189,9 @@ Other Changes:
 - Use HTTPS in a readme link ([#1716](https://github.com/jazzband/pip-tools/pull/1716)).
   Thanks @Arhell
 
-## 6.9.0 (2022-10-05)
+## v6.9.0
+
+05 Oct 2022
 
 Features:
 
@@ -190,7 +212,9 @@ Other Changes:
 - Add pyproject.toml & modern packaging to introduction.
   ([#1668](https://github.com/jazzband/pip-tools/pull/1668)). Thanks @hynek
 
-## 6.8.0 (2022-06-30)
+## v6.8.0
+
+30 Jun 2022
 
 Features:
 
@@ -198,7 +222,9 @@ Features:
   `pip-compile --resolver backtracking` to enable new resolver
   ([#1539](https://github.com/jazzband/pip-tools/pull/1539)). Thanks @atugushev
 
-## 6.7.0 (2022-06-27)
+## v6.7.0
+
+27 Jun 2022
 
 Features:
 
@@ -216,21 +242,27 @@ Other Changes:
   project metadata ([#1629](https://github.com/jazzband/pip-tools/pull/1629)). Thanks
   @AndydeCleyre
 
-## 6.6.2 (2022-05-23)
+## v6.6.2
+
+23 May 2022
 
 Bug Fixes:
 
 - Update `PyPIRepository::resolve_reqs()` for pip>=22.1.1
   ([#1624](https://github.com/jazzband/pip-tools/pull/1624)). Thanks @m000
 
-## 6.6.1 (2022-05-13)
+## v6.6.1
+
+13 May 2022
 
 Bug Fixes:
 
 - Fix support for pip>=22.1 ([#1618](https://github.com/jazzband/pip-tools/pull/1618)).
   Thanks @wizpig64
 
-## 6.6.0 (2022-04-06)
+## v6.6.0
+
+06 Apr 2022
 
 Features:
 
@@ -245,7 +277,9 @@ Bug Fixes:
 - Fix `--generate-hashes` when hashes are computed from files
   ([#1540](https://github.com/jazzband/pip-tools/pull/1540)). Thanks @RazerM
 
-## 6.5.1 (2022-02-08)
+## v6.5.1
+
+08 Feb 2022
 
 Bug Fixes:
 
@@ -253,7 +287,9 @@ Bug Fixes:
   reinstallations during sync
   ([#1572](https://github.com/jazzband/pip-tools/pull/1572)). Thanks @AndydeCleyre
 
-## 6.5.0 (2022-02-04)
+## v6.5.0
+
+04 Feb 2022
 
 Features:
 
@@ -267,7 +303,9 @@ Other Changes:
 - Minor doc edits ([#1445](https://github.com/jazzband/pip-tools/pull/1445)). Thanks
   @ssiano
 
-## 6.4.0 (2021-10-12)
+## v6.4.0
+
+12 Oct 2021
 
 Features:
 
@@ -281,7 +319,9 @@ Other Changes:
 - Bump pip minimum version to `>= 21.2`
   ([#1500](https://github.com/jazzband/pip-tools/pull/1500)). Thanks @atugushev
 
-## 6.3.1 (2021-10-08)
+## v6.3.1
+
+08 Oct 2021
 
 Bug Fixes:
 
@@ -293,7 +333,9 @@ Bug Fixes:
 - Improve clarity of help text for options supporting multiple
   ([#1492](https://github.com/jazzband/pip-tools/pull/1492)). Thanks @AndydeCleyre
 
-## 6.3.0 (2021-09-21)
+## v6.3.0
+
+21 Sep 2021
 
 Features:
 
@@ -311,7 +353,9 @@ Bug Fixes:
 - Allow passing `--no-upgrade` option
   ([#1438](https://github.com/jazzband/pip-tools/pull/1438)). Thanks @ssbarnea
 
-## 6.2.0 (2021-06-22)
+## v6.2.0
+
+22 Jun 2021
 
 Features:
 
@@ -345,7 +389,9 @@ Other Changes:
 - Better explain role of existing `requirements.txt`
   ([#1369](https://github.com/jazzband/pip-tools/pull/1369)). Thanks @mikepqr
 
-## 6.1.0 (2021-04-14)
+## v6.1.0
+
+14 Apr 2021
 
 Features:
 
@@ -360,7 +406,9 @@ Bug Fixes:
 - Restore ability to set compile cache with env var `PIP_TOOLS_CACHE_DIR`
   ([#1368](https://github.com/jazzband/pip-tools/pull/1368)). Thanks @AndydeCleyre
 
-## 6.0.1 (2021-03-15)
+## v6.0.1
+
+15 Mar 2021
 
 Bug Fixes:
 
@@ -372,7 +420,9 @@ Dependencies:
 - Add `pep517` dependency ([#1353](https://github.com/jazzband/pip-tools/pull/1353)).
   Thanks @atugushev
 
-## 6.0.0 (2021-03-12)
+## v6.0.0
+
+12 Mar 2021
 
 Backwards Incompatible Changes:
 
@@ -405,7 +455,9 @@ Dependencies:
 - Bump `pip` minimum version to `>= 20.3`
   ([#1340](https://github.com/jazzband/pip-tools/pull/1340)). Thanks @atugushev
 
-## 5.5.0 (2020-12-31)
+## v5.5.0
+
+31 Dec 2020
 
 Features:
 
@@ -436,7 +488,9 @@ Improved Documentation:
 - Add supported Python versions to `README`
   ([#1246](https://github.com/jazzband/pip-tools/pull/1246)). Thanks @jdufresne
 
-## 5.4.0 (2020-11-21)
+## v5.4.0
+
+21 Nov 2020
 
 Features:
 
@@ -451,7 +505,9 @@ Dependencies:
   ([1191](https://github.com/jazzband/pip-tools/pull/1191)). Thanks @atugushev and
   @AndydeCleyre
 
-## 5.3.1 (2020-07-31)
+## v5.3.1
+
+31 Jul 2020
 
 Bug Fixes:
 
@@ -459,7 +515,9 @@ Bug Fixes:
   stabilize in a constant number of rounds
   ([1194](https://github.com/jazzband/pip-tools/pull/1194)). Thanks @vphilippon
 
-## 5.3.0 (2020-07-26)
+## v5.3.0
+
+26 Jul 2020
 
 Features:
 
@@ -475,7 +533,9 @@ Features:
 - Add `--reuse-hashes/--no-reuse-hashes` options to `pip-compile`
   ([1177](https://github.com/jazzband/pip-tools/pull/1177)). Thanks @graingert
 
-## 5.2.1 (2020-06-09)
+## v5.2.1
+
+09 Jun 2020
 
 Bug Fixes:
 
@@ -483,7 +543,9 @@ Bug Fixes:
   `requirements.txt` ([1159](https://github.com/jazzband/pip-tools/pull/1159)). Thanks
   @richafrank
 
-## 5.2.0 (2020-05-27)
+## v5.2.0
+
+27 May 2020
 
 Features:
 
@@ -513,21 +575,27 @@ Other Changes:
 - Switch to `setuptools` declarative syntax through `setup.cfg`
   ([1141](https://github.com/jazzband/pip-tools/pull/1141)). Thanks @jdufresne
 
-## 5.1.2 (2020-05-05)
+## v5.1.2
+
+05 May 2020
 
 Bug Fixes:
 
 - Fix grouping of editables and non-editables requirements
   ([1132](https://github.com/jazzband/pip-tools/pull/1132)). Thanks @richafrank
 
-## 5.1.1 (2020-05-01)
+## v5.1.1
+
+01 May 2020
 
 Bug Fixes:
 
 - Fix a bug where `pip-compile` would generate hashes for `*.egg` files
   ([#1122](https://github.com/jazzband/pip-tools/pull/1122)). Thanks @atugushev
 
-## 5.1.0 (2020-04-27)
+## v5.1.0
+
+27 Apr 2020
 
 Features:
 
@@ -537,7 +605,9 @@ Features:
   increases the speed of hashes generation
   ([#1109](https://github.com/jazzband/pip-tools/pull/1109)). Thanks @atugushev
 
-## 5.0.0 (2020-04-16)
+## v5.0.0
+
+16 Apr 2020
 
 Backwards Incompatible Changes:
 
@@ -579,7 +649,9 @@ Improved Documentation:
 - Add versions compatibility table to `README`
   ([#1106](https://github.com/jazzband/pip-tools/pull/1106)). Thanks @atugushev
 
-## 4.5.1 (2020-02-26)
+## v4.5.1
+
+26 Feb 2020
 
 Bug Fixes:
 
@@ -592,7 +664,9 @@ Improved Documentation:
 - Updated `README` example outputs for primary requirement annotations
   ([#1072](https://github.com/jazzband/pip-tools/pull/1072)). Thanks @richafrank
 
-## 4.5.0 (2020-02-20)
+## v4.5.0
+
+20 Feb 2020
 
 Features:
 
@@ -610,7 +684,9 @@ Improved Documentation:
 - Replace outdated link in the `README` with rationale for pinning
   ([#1053](https://github.com/jazzband/pip-tools/pull/1053)). Thanks @m-aciek
 
-## 4.4.1 (2020-01-31)
+## v4.4.1
+
+31 Jan 2020
 
 Bug Fixes:
 
@@ -636,7 +712,9 @@ Improved Documentation:
   [Workflow for layered requirements](https://pip-tools.rtfd.io/en/latest/#workflow-for-layered-requirements)
   section ([#1044](https://github.com/jazzband/pip-tools/pull/1044)). Thanks @hramezani
 
-## 4.4.0 (2020-01-21)
+## v4.4.0
+
+21 Jan 2020
 
 Features:
 
@@ -651,7 +729,9 @@ Bug Fixes:
   not already required according to the `*.in` and `*.txt` files
   ([#1031](https://github.com/jazzband/pip-tools/pull/1031)). Thanks @AndydeCleyre
 
-## 4.3.0 (2019-11-25)
+## v4.3.0
+
+25 Nov 2019
 
 Features:
 
@@ -677,7 +757,9 @@ Improved Documentation:
   if you're compiling from scratch
   ([#959](https://github.com/jazzband/pip-tools/pull/959)). Thanks @hramezani
 
-## 4.2.0 (2019-10-12)
+## v4.2.0
+
+12 Oct 2019
 
 Features:
 
@@ -703,7 +785,9 @@ Improved Documentation:
 - Add info to `README` about layered requirements files and `-c` flag
   ([#905](https://github.com/jazzband/pip-tools/pull/905)). Thanks @jamescooke
 
-## 4.1.0 (2019-08-26)
+## v4.1.0
+
+26 Aug 2019
 
 Features:
 
@@ -718,7 +802,9 @@ Bug Fixes:
 - Fix resolution of requirements from Git URLs without `-e`
   ([#879](https://github.com/jazzband/pip-tools/pull/879)). Thanks @andersk
 
-## 4.0.0 (2019-07-25)
+## v4.0.0
+
+25 Jul 2019
 
 Backwards Incompatible Changes:
 
@@ -730,7 +816,9 @@ Bug Fixes:
 - Fix `pip>=19.2` compatibility
   ([#857](https://github.com/jazzband/pip-tools/pull/857)). Thanks @atugushev
 
-## 3.9.0 (2019-07-17)
+## v3.9.0
+
+17 Jul 2019
 
 Features:
 
@@ -745,7 +833,9 @@ Bug Fixes:
   ([#842](https://github.com/jazzband/pip-tools/pull/842)). Thanks @shipmints and
   @atugushev
 
-## 3.8.0 (2019-06-06)
+## v3.8.0
+
+06 Jun 2019
 
 Features:
 
@@ -763,7 +853,9 @@ Bug Fixes:
 - Option `--upgrade-package` now works even if the output file does not exist
   ([#831](https://github.com/jazzband/pip-tools/pull/831)). Thanks @adamchainz
 
-## 3.7.0 (2019-05-09)
+## v3.7.0
+
+09 May 2019
 
 Features:
 
@@ -783,14 +875,18 @@ Bug Fixes:
 - Fix replacing password to asterisks in `pip-compile`
   ([#808](https://github.com/jazzband/pip-tools/pull/808)). Thanks @atugushev
 
-## 3.6.1 (2019-04-24)
+## v3.6.1
+
+24 Apr 2019
 
 Bug Fixes:
 
 - Fix `pip>=19.1` compatibility
   ([#795](https://github.com/jazzband/pip-tools/pull/795)). Thanks @atugushev
 
-## 3.6.0 (2019-04-03)
+## v3.6.0
+
+03 Apr 2019
 
 Features:
 
@@ -799,7 +895,9 @@ Features:
 - Support the flag `--trusted-host` in `pip-sync`
   ([#777](https://github.com/jazzband/pip-tools/pull/777)). Thanks @firebirdberlin
 
-## 3.5.0 (2019-03-13)
+## v3.5.0
+
+13 Mar 2019
 
 Features:
 
@@ -815,7 +913,9 @@ Bug Fixes:
 - Fix order issue with generated lock file when `hashes` and `markers` are used together
   ([#763](https://github.com/jazzband/pip-tools/pull/763)). Thanks @milind-shakya-sp
 
-## 3.4.0 (2019-02-19)
+## v3.4.0
+
+19 Feb 2019
 
 Features:
 
@@ -829,7 +929,9 @@ Bug Fixes:
 - Fix `pip-sync` to use pip script depending on a python version
   ([#737](https://github.com/jazzband/pip-tools/pull/737)). Thanks @atugushev
 
-## 3.3.2 (2019-01-26)
+## v3.3.2
+
+26 Jan 2019
 
 Bug Fixes:
 
@@ -838,12 +940,16 @@ Bug Fixes:
 - Fix `pip-sync` to prevent uninstall of stdlib and dev packages
   ([#718](https://github.com/jazzband/pip-tools/pull/718)). Thanks @atugushev
 
-## 3.3.1 (2019-01-24)
+## v3.3.1
+
+24 Jan 2019
 
 - Re-release of 3.3.0 after fixing the deployment pipeline
   ([#716](https://github.com/jazzband/pip-tools/issues/716)). Thanks @atugushev
 
-## 3.3.0 (2019-01-23)
+## v3.3.0
+
+23 Jan 2019
 
 (Unreleased - Deployment pipeline issue, see 3.3.1)
 
@@ -859,7 +965,9 @@ Bug Fixes:
 - Fix `pip-sync` to check hashes
   ([#706](https://github.com/jazzband/pip-tools/pull/706)). Thanks @atugushev
 
-## 3.2.0 (2018-12-18)
+## v3.2.0
+
+18 Dec 2018
 
 Features:
 
@@ -867,14 +975,18 @@ Features:
   (`-P, --upgrade-package`) ([#694](https://github.com/jazzband/pip-tools/pull/694)).
   Thanks @richafrank
 
-## 3.1.0 (2018-10-05)
+## v3.1.0
+
+05 Oct 2018
 
 Features:
 
 - Added support of `pip` 18.1 ([#689](https://github.com/jazzband/pip-tools/pull/689)).
   Thanks @vphilippon
 
-## 3.0.0 (2018-09-24)
+## v3.0.0
+
+24 Sep 2018
 
 Major changes:
 
@@ -889,21 +1001,27 @@ Features:
 - Removed the dependency on the external library `first`
   ([#676](https://github.com/jazzband/pip-tools/pull/676)). Thanks @jdufresne
 
-## 2.0.2 (2018-04-28)
+## v2.0.2
+
+28 Apr 2018
 
 Bug Fixes:
 
 - Added clearer error reporting when skipping pre-releases
   ([#655](https://github.com/jazzband/pip-tools/pull/655)). Thanks @WoLpH
 
-## 2.0.1 (2018-04-15)
+## v2.0.1
+
+15 Apr 2018
 
 Bug Fixes:
 
 - Added missing package data from vendored pip, such as missing cacert.pem file. Thanks
   @vphilippon
 
-## 2.0.0 (2018-04-15)
+## v2.0.0
+
+15 Apr 2018
 
 Major changes:
 
@@ -927,7 +1045,9 @@ Bug fixes:
   environment ([#647](https://github.com/jazzband/pip-tools/pull/647)). Thanks
   @JoergRittinger
 
-## 1.11.0 (2017-11-30)
+## v1.11.0
+
+30 Nov 2017
 
 Features:
 
@@ -946,7 +1066,9 @@ Bug Fixes:
 - Add `-markerlib` to the list of `PACKAGES_TO_IGNORE` of `pip-sync`
   ([#613](https://github.com/jazzband/pip-tools/pull/613)).
 
-## 1.10.2 (2017-11-22)
+## v1.10.2
+
+22 Nov 2017
 
 Bug Fixes:
 
@@ -956,7 +1078,9 @@ Bug Fixes:
   ([600](https://github.com/jazzband/pip-tools/pull/600)). Thanks @hazmat345
 - Converted the ReadMe to have a nice description rendering on PyPI. Thanks @bittner
 
-## 1.10.1 (2017-09-27)
+## v1.10.1
+
+27 Sep 2017
 
 Bug Fixes:
 
@@ -964,7 +1088,9 @@ Bug Fixes:
   `TypeError: '<' not supported between instances of 'InstallRequirement' and 'InstallRequirement'`
   ([#570](https://github.com/jazzband/pip-tools/pull/570)).
 
-## 1.10.0 (2017-09-27)
+## v1.10.0
+
+27 Sep 2017
 
 Features:
 
@@ -994,7 +1120,9 @@ Bug Fixes:
 - Fixed package hashing doing unnecessary unpacking
   ([#557](https://github.com/jazzband/pip-tools/pull/557)). Thanks @suutari-ai
 
-## 1.9.0 (2017-04-12)
+## v1.9.0
+
+12 Apr 2017
 
 Features:
 
@@ -1025,14 +1153,18 @@ Bug Fixes:
 - Fixed duplicated --trusted-host, --extra-index-url and --index-url in the generated
   requirements.
 
-## 1.8.2 (2017-03-28)
+## v1.8.2
+
+28 Mar 2017
 
 - Regression fix: editable reqs were losing their dependencies after first round
   ([#476](https://github.com/jazzband/pip-tools/pull/476)) Thanks @mattlong
 - Remove duplicate index urls in generated requirements.txt
   ([#468](https://github.com/jazzband/pip-tools/pull/468)) Thanks @majuscule
 
-## 1.8.1 (2017-03-22)
+## v1.8.1
+
+22 Mar 2017
 
 - Recalculate secondary dependencies between rounds (#378)
 - Calculated dependencies could be left with wrong candidates when toplevel requirements
@@ -1042,7 +1174,9 @@ Bug Fixes:
 - Fix capitalization in the generated requirements.txt, packages will always be
   lowercased (#452)
 
-## 1.8.0 (2016-11-17)
+## v1.8.0
+
+17 Nov 2016
 
 - Adds support for upgrading individual packages with a new option `--upgrade-package`.
   To upgrade a _specific_ package to the latest or a specific version use
@@ -1055,32 +1189,46 @@ Bug Fixes:
 - Improve support for extras, like `hypothesis[django]`
 - Drop support for pip < 8
 
-## 1.7.1 (2016-10-20)
+## v1.7.1
+
+20 Oct 2016
 
 - Add `--allow-unsafe` option (#377)
 
-## 1.7.0 (2016-07-06)
+## v1.7.0
+
+06 Jul 2016
 
 - Add compatibility with pip >= 8.1.2 (#374) Thanks so much, @jmbowman!
 
-## 1.6.5 (2016-05-11)
+## v1.6.5
+
+11 May 2016
 
 - Add warning that pip >= 8.1.2 is not supported until 1.7.x is out
 
-## 1.6.4 (2016-05-03)
+## v1.6.4
+
+03 May 2016
 
 - Incorporate fix for atomic file saving behaviour on the Windows platform (see #351)
 
-## 1.6.3 (2016-05-02)
+## v1.6.3
+
+02 May 2016
 
 - PyPI won't let me upload 1.6.2
 
-## 1.6.2 (2016-05-02)
+## v1.6.2
+
+02 May 2016
 
 - Respect pip configuration from pip.{ini,conf}
 - Fixes for atomic-saving of output files on Windows (see #351)
 
-## 1.6.1 (2016-04-06)
+## v1.6.1
+
+06 Apr 2016
 
 Minor changes:
 
@@ -1093,7 +1241,9 @@ Fixes:
 
 - Change header format of output files to mention all input files
 
-## 1.6 (2016-02-05)
+## v1.6
+
+05 Feb 2016
 
 Major change:
 
@@ -1108,14 +1258,18 @@ Minor changes:
 - Bugfix where pip-compile would lose "via" info when on pip 8 (see #313)
 - Ensure cache dir exists (see #315)
 
-## 1.5 (2016-01-23)
+## v1.5
+
+23 Jan 2016
 
 - Add support for pip >= 8
 - Drop support for pip < 7
 - Fix bug where `pip-sync` fails to uninstall packages if you're using the `--no-index`
   (or other) flags
 
-## 1.4.5 (2016-01-20)
+## v1.4.5
+
+20 Jan 2016
 
 - Add `--no-index` flag to `pip-compile` to avoid emitting `--index-url` into the output
   (useful if you have configured a different index in your global ~/.pip/pip.conf, for
@@ -1125,40 +1279,54 @@ Minor changes:
 - Fix pip-sync failed uninstalling packages when using `--find-links` (#298)
 - Explicitly error when pip-tools is used with pip 8.0+ (for now)
 
-## 1.4.4 (2016-01-11)
+## v1.4.4
+
+11 Jan 2016
 
 - Fix: unintended change in behaviour where packages installed by `pip-sync` could
   accidentally get upgraded under certain conditions, even though the requirements.txt
   would dictate otherwise (see #290)
 
-## 1.4.3 (2016-01-06)
+## v1.4.3
+
+06 Jan 2016
 
 - Fix: add `--index-url` and `--extra-index-url` options to `pip-sync`
 - Fix: always install using `--upgrade` flag when running `pip-sync`
 
-## 1.4.2 (2015-12-13)
+## v1.4.2
+
+13 Dec 2015
 
 - Fix bug where umask was ignored when writing requirement files (#268)
 
-## 1.4.1 (2015-12-13)
+## v1.4.1
+
+13 Dec 2015
 
 - Fix bug where successive invocations of pip-sync with editables kept
   uninstalling/installing them (fixes #270)
 
-## 1.4.0 (2015-12-13)
+## v1.4.0
+
+13 Dec 2015
 
 - Add command line option -f / --find-links
 - Add command line option --no-index
 - Add command line alias -n (for --dry-run)
 - Fix a unicode issue
 
-## 1.3.0 (2015-12-08)
+## v1.3.0
+
+08 Dec 2015
 
 - Support multiple requirement files to pip-compile
 - Support requirements from stdin for pip-compile
 - Support --output-file option on pip-compile, to redirect output to a file (or stdout)
 
-## 1.2.0 (2015-11-30)
+## v1.2.0
+
+30 Nov 2015
 
 - Add CHANGELOG :)
 - Support pip-sync'ing editable requirements


### PR DESCRIPTION
Fixes #1935.
Supersedes #1942.
Preview: https://pip-tools--1945.org.readthedocs.build/en/1945/changelog/.

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [x] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
