### PR TITLE
Add `--no-strip-extras` and warn about strip extras by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ The `pip-compile` command lets you compile a `requirements.txt` file from
 your dependencies, specified in either `pyproject.toml`, `setup.cfg`,
 `setup.py`, or `requirements.in`.
 
-Run it with `pip-compile` or `python -m piptools compile`. If you use
-multiple Python versions, you can also run `py -X.Y -m piptools compile` on
-Windows and `pythonX.Y -m piptools compile` on other systems.
+Run it with `pip-compile` or `python -m piptools compile` (or
+`pipx run --spec pip-tools pip-compile` if `pipx` was installed with the
+appropriate Python version). If you use multiple Python versions, you can also
+run `py -X.Y -m piptools compile` on Windows and `pythonX.Y -m piptools compile`
+on other systems.
 
 `pip-compile` should be run from the same virtual environment as your
 project so conditional dependencies that require a specific Python version,

--- a/README.md
+++ b/README.md
@@ -564,9 +564,12 @@ This section lists `pip-tools` features that are currently deprecated.
 - In the next major release, the `--allow-unsafe` behavior will be enabled by
   default (https://github.com/jazzband/pip-tools/issues/989).
   Use `--no-allow-unsafe` to keep the old behavior. It is recommended
-  to pass the `--allow-unsafe` now to adapt to the upcoming change.
+  to pass `--allow-unsafe` now to adapt to the upcoming change.
 - The legacy resolver is deprecated and will be removed in future versions.
   The new default is `--resolver=backtracking`.
+- In the next major release, the `--strip-extras` behavior will be enabled by
+  default (https://github.com/jazzband/pip-tools/issues/1613).
+  Use `--no-strip-extras` to keep the old behavior.
 
 ### A Note on Resolvers
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -226,9 +226,9 @@ def _determine_linesep(
     ),
 )
 @click.option(
-    "--strip-extras",
+    "--strip-extras/--no-strip-extras",
     is_flag=True,
-    default=False,
+    default=None,
     help="Assure output file is constraints compatible, avoiding use of extras.",
 )
 @click.option(
@@ -365,7 +365,7 @@ def cli(
     output_file: LazyFile | IO[Any] | None,
     newline: str,
     allow_unsafe: bool,
-    strip_extras: bool,
+    strip_extras: bool | None,
     generate_hashes: bool,
     reuse_hashes: bool,
     src_files: tuple[str, ...],
@@ -675,6 +675,15 @@ def cli(
     linesep = _determine_linesep(
         strategy=newline, filenames=(output_file.name, *src_files)
     )
+
+    if strip_extras is None:
+        strip_extras = False
+        log.warning(
+            "WARNING: --strip-extras is becoming the default. "
+            "To silence this warning, "
+            "either use --strip-extras to opt into the new default "
+            "or use --no-strip-extras to retain the existing behavior."
+        )
 
     ##
     # Output

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -679,8 +679,8 @@ def cli(
     if strip_extras is None:
         strip_extras = False
         log.warning(
-            "WARNING: --strip-extras is becoming the default. "
-            "To silence this warning, "
+            "WARNING: --strip-extras is becoming the default "
+            "in version 8.0.0. To silence this warning, "
             "either use --strip-extras to opt into the new default "
             "or use --no-strip-extras to retain the existing behavior."
         )

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3102,3 +3102,33 @@ def test_invalid_cli_boolean_flag_config_option_captured(
 
     assert out.exit_code == 2
     assert "No such config key 'no_annnotate'." in out.stderr
+
+
+strip_extras_warning = (
+    "WARNING: --strip-extras is becoming the default in version 8.0.0."
+)
+
+
+def test_show_warning_on_default_strip_extras_option(
+    runner, make_package, make_sdist, tmp_path
+):
+    req_in = tmp_path / "requirements.in"
+    req_in.touch()
+
+    out = runner.invoke(cli, req_in.as_posix())
+
+    assert out.exit_code == 0
+    assert strip_extras_warning in out.stderr
+
+
+@pytest.mark.parametrize("option", ("--strip-extras", "--no-strip-extras"))
+def test_do_not_show_warning_on_explicit_strip_extras_option(
+    runner, make_package, make_sdist, tmp_path, option
+):
+    req_in = tmp_path / "requirements.in"
+    req_in.touch()
+
+    out = runner.invoke(cli, [option, req_in.as_posix()])
+
+    assert out.exit_code == 0
+    assert strip_extras_warning not in out.stderr


### PR DESCRIPTION
References #1613. In preparation for the next major release where `--strip-extras` will be the default, give a warning if the flag is not given and add a matching `--no-strip-extras` flag to allow forcing the existing behavior without the warning.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

----

I haven't written tests yet, because I'm not clear on the failures. I'm opening this PR for review and to see what the tests look like in the pull request.
