### PR TITLE
👷 Prevent tox pkg double build @ GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,9 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -U tox virtualenv
       - name: Prepare test environment
-        run: tox --notest -p auto --parallel-live
+        run: tox -vv --notest -p auto --parallel-live
       - name: Test pip ${{ matrix.pip-version }}
-        run: tox
+        run: tox --skip-pkg-install
       - name: Upload coverage to Codecov
         if: >-
           !github.job_workflow_sha

--- a/.github/workflows/reusable-qa.yml
+++ b/.github/workflows/reusable-qa.yml
@@ -51,6 +51,6 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Prepare test environment
-        run: tox --notest -p auto --parallel-live
+        run: tox -vv --notest -p auto --parallel-live
       - name: Test ${{ matrix.toxenv }}
-        run: tox
+        run: tox --skip-pkg-install


### PR DESCRIPTION
The first `tox --notest` invocation already builds the package and installs it. Without `--skip-pkg-install`, the second one repeats this, which is just a waste of resources.