### PR TITLE
Speed up tests execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ disallow_untyped_defs = false
 addopts = [
   # `pytest-xdist`:
   "--numprocesses=auto",
+  "--dist=worksteal",
 
   # Show 20 slowest invocations:
   "--durations=20",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,8 +286,8 @@ def pip_with_index_conf(make_pip_conf):
     )
 
 
-@pytest.fixture
-def make_package(tmp_path):
+@pytest.fixture(scope="session")
+def make_package(tmp_path_factory):
     """
     Make a package from a given name, version and list of required packages.
     """
@@ -303,7 +303,7 @@ def make_package(tmp_path):
             ",".join(f"{package!r}" for package in install_requires)
         )
 
-        package_dir = tmp_path / "packages" / name / version
+        package_dir = tmp_path_factory.mktemp("packages") / name / version
         package_dir.mkdir(parents=True)
 
         with (package_dir / "setup.py").open("w") as fp:
@@ -332,7 +332,7 @@ def make_package(tmp_path):
     return _make_package
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def run_setup_file():
     """
     Run a setup.py file from a given package dir.
@@ -350,7 +350,7 @@ def run_setup_file():
     return _run_setup_file
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def make_wheel(run_setup_file):
     """
     Make a wheel distribution from a given package dir.
@@ -408,12 +408,12 @@ def make_module(tmpdir):
     return _make_module
 
 
-@pytest.fixture
-def fake_dists(tmpdir, make_package, make_wheel):
+@pytest.fixture(scope="session")
+def fake_dists(tmp_path_factory, make_package, make_wheel):
     """
-    Generate distribution packages `small-fake-{a..f}`
+    Generate distribution packages `small-fake-*`
     """
-    dists_path = os.path.join(tmpdir, "dists")
+    dists_path = tmp_path_factory.mktemp("dists")
     pkgs = [
         make_package("small-fake-a", version="0.1"),
         make_package("small-fake-b", version="0.2"),

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1208,15 +1208,16 @@ def test_preserve_newline_from_input(runner, linesep, must_exclude):
     assert must_exclude not in txt
 
 
-@pytest.mark.network
-def test_generate_hashes_with_split_style_annotations(runner):
-    with open("requirements.in", "w") as fp:
-        fp.write("Django==1.11.29\n")
-        fp.write("django-debug-toolbar==1.11\n")
-        fp.write("django-storages==1.9.1\n")
-        fp.write("django-taggit==0.24.0\n")
-        fp.write("pytz==2020.4\n")
-        fp.write("sqlparse==0.3.1\n")
+def test_generate_hashes_with_split_style_annotations(pip_conf, runner, tmpdir_cwd):
+    reqs_in = tmpdir_cwd / "requirements.in"
+    reqs_in.write_text(
+        dedent(
+            """\
+            small_fake_with_deps
+            small-fake-a
+            """
+        )
+    )
 
     out = runner.invoke(
         cli,
@@ -1225,58 +1226,37 @@ def test_generate_hashes_with_split_style_annotations(runner):
             "-",
             "--quiet",
             "--no-header",
+            "--no-emit-options",
             "--generate-hashes",
             "--annotation-style",
             "split",
         ],
     )
+
     assert out.stdout == dedent(
         """\
-        django==1.11.29 \\
-            --hash=sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f \\
-            --hash=sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c
+        small-fake-a==0.1 \\
+            --hash=sha256:5e6071ee6e4c59e0d0408d366fe9b66781d2cf01be9a6e19a2433bb3c5336330
             # via
             #   -r requirements.in
-            #   django-debug-toolbar
-            #   django-storages
-            #   django-taggit
-        django-debug-toolbar==1.11 \\
-            --hash=sha256:89d75b60c65db363fb24688d977e5fbf0e73386c67acf562d278402a10fc3736 \\
-            --hash=sha256:c2b0134119a624f4ac9398b44f8e28a01c7686ac350a12a74793f3dd57a9eea0
+            #   small-fake-with-deps
+        small-fake-with-deps==0.1 \\
+            --hash=sha256:71403033c0545516cc5066c9196d9490affae65a865af3198438be6923e4762e
             # via -r requirements.in
-        django-storages==1.9.1 \\
-            --hash=sha256:3103991c2ee8cef8a2ff096709973ffe7106183d211a79f22cf855f33533d924 \\
-            --hash=sha256:a59e9923cbce7068792f75344ed7727021ee4ac20f227cf17297d0d03d141e91
-            # via -r requirements.in
-        django-taggit==0.24.0 \\
-            --hash=sha256:710b4d15ec1996550cc68a0abbc41903ca7d832540e52b1336e6858737e410d8 \\
-            --hash=sha256:bb8f27684814cd1414b2af75b857b5e26a40912631904038a7ecacd2bfafc3ac
-            # via -r requirements.in
-        pytz==2020.4 \\
-            --hash=sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268 \\
-            --hash=sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd
-            # via
-            #   -r requirements.in
-            #   django
-        sqlparse==0.3.1 \\
-            --hash=sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e \\
-            --hash=sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548
-            # via
-            #   -r requirements.in
-            #   django-debug-toolbar
         """
     )
 
 
-@pytest.mark.network
-def test_generate_hashes_with_line_style_annotations(runner):
-    with open("requirements.in", "w") as fp:
-        fp.write("Django==1.11.29\n")
-        fp.write("django-debug-toolbar==1.11\n")
-        fp.write("django-storages==1.9.1\n")
-        fp.write("django-taggit==0.24.0\n")
-        fp.write("pytz==2020.4\n")
-        fp.write("sqlparse==0.3.1\n")
+def test_generate_hashes_with_line_style_annotations(pip_conf, runner, tmpdir_cwd):
+    reqs_in = tmpdir_cwd / "requirements.in"
+    reqs_in.write_text(
+        dedent(
+            """\
+            small_fake_with_deps
+            small-fake-a
+            """
+        )
+    )
 
     out = runner.invoke(
         cli,
@@ -1285,37 +1265,21 @@ def test_generate_hashes_with_line_style_annotations(runner):
             "-",
             "--quiet",
             "--no-header",
+            "--no-emit-options",
             "--generate-hashes",
             "--annotation-style",
             "line",
         ],
     )
+
     assert out.stdout == dedent(
         """\
-        django==1.11.29 \\
-            --hash=sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f \\
-            --hash=sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c
-            # via -r requirements.in, django-debug-toolbar, django-storages, django-taggit
-        django-debug-toolbar==1.11 \\
-            --hash=sha256:89d75b60c65db363fb24688d977e5fbf0e73386c67acf562d278402a10fc3736 \\
-            --hash=sha256:c2b0134119a624f4ac9398b44f8e28a01c7686ac350a12a74793f3dd57a9eea0
+        small-fake-a==0.1 \\
+            --hash=sha256:5e6071ee6e4c59e0d0408d366fe9b66781d2cf01be9a6e19a2433bb3c5336330
+            # via -r requirements.in, small-fake-with-deps
+        small-fake-with-deps==0.1 \\
+            --hash=sha256:71403033c0545516cc5066c9196d9490affae65a865af3198438be6923e4762e
             # via -r requirements.in
-        django-storages==1.9.1 \\
-            --hash=sha256:3103991c2ee8cef8a2ff096709973ffe7106183d211a79f22cf855f33533d924 \\
-            --hash=sha256:a59e9923cbce7068792f75344ed7727021ee4ac20f227cf17297d0d03d141e91
-            # via -r requirements.in
-        django-taggit==0.24.0 \\
-            --hash=sha256:710b4d15ec1996550cc68a0abbc41903ca7d832540e52b1336e6858737e410d8 \\
-            --hash=sha256:bb8f27684814cd1414b2af75b857b5e26a40912631904038a7ecacd2bfafc3ac
-            # via -r requirements.in
-        pytz==2020.4 \\
-            --hash=sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268 \\
-            --hash=sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd
-            # via -r requirements.in, django
-        sqlparse==0.3.1 \\
-            --hash=sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e \\
-            --hash=sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548
-            # via -r requirements.in, django-debug-toolbar
         """
     )
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2948,6 +2948,7 @@ def test_compile_recursive_extras(runner, tmp_path, current_resolver):
     out = runner.invoke(
         cli,
         [
+            "--no-build-isolation",
             "--no-header",
             "--no-annotate",
             "--no-emit-options",


### PR DESCRIPTION
#### Session-scoped fixtures

The `fake_dists` fixture is one of the most time-consuming fixtures, so it makes sense to make it and all related fixtures session-scoped.

#### Finetune tests distribution over the run

Initially, tests are distributed evenly across all worker processes. But during the execution of tests, some processes may finish running tests faster than others. In these cases, the `--dist=worksteal` option allows these "free" workers to "steal" tests from the queue of other, still working, processes.

This is particularly useful if the run times of different tests vary greatly, as this distribution method ensures more efficient resource usage, improving the performance of testing.

#### Refactored slow tests

`test_generate_hashes_with_split_style_annotations` and `test_generate_hashes_with_line_style_annotations` were utilizing too many external packages. We should always prefer local packages as they are faster and pip-compile doesn't need network to compile them.

#### Stats

Locally, it increases speed by about 30%. Here are CI runs:

<img width="825" alt="Screenshot 2023-08-10 at 21 47 56" src="https://github.com/jazzband/pip-tools/assets/7377671/95e7e17e-71ae-42c0-8a47-6ea93db65bcb">
