### PR TITLE
Parse pyproject.toml statically where possible

### DIFF
--- a/piptools/build.py
+++ b/piptools/build.py
@@ -70,7 +70,7 @@ def maybe_statically_parse_project_metadata(
         with open(src_file, "rb") as f:
             pyproject_contents = tomllib.load(f)
     except tomllib.TOMLDecodeError:
-        pyproject_contents = {}
+        return None
 
     # Not valid PEP 621 metadata
     if (

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -97,6 +97,10 @@ def maybe_statically_parse_project_metadata(
     ):
         for req in reqs:
             requirement = Requirement(req)
+            if requirement.name == package_name:
+                # Similar to logic for handling self-referential requirements
+                # from _prepare_requirements
+                requirement.url = f"file://{src_file.parent}"
             # Note we don't need to modify `requirement` to include this extra
             marker = Marker(f"extra == '{extra}'")
             install_requirements.append(

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -79,18 +79,20 @@ def maybe_statically_parse_project_metadata(
     ):
         return None
 
+    project_table = pyproject_contents["project"]
+
     # Dynamic dependencies require build invocation
-    dynamic = pyproject_contents["project"].get("dynamic", [])
+    dynamic = project_table.get("dynamic", [])
     if "dependencies" in dynamic or "optional-dependencies" in dynamic:
         return None
 
-    package_name = pyproject_contents["project"]["name"]
+    package_name = project_table["name"]
     comes_from = f"{package_name} ({src_file})"
 
-    extras = pyproject_contents["project"].get("optional-dependencies", {}).keys()
+    extras = project_table.get("optional-dependencies", {}).keys()
     install_requirements = [
         InstallRequirement(Requirement(req), comes_from)
-        for req in pyproject_contents["project"].get("dependencies", [])
+        for req in project_table.get("dependencies", [])
     ]
     for extra, reqs in (
         pyproject_contents.get("project", {}).get("optional-dependencies", {}).items()

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -12,10 +12,10 @@ from typing import Any, Iterator, Protocol, TypeVar, overload
 import build
 import build.env
 import pyproject_hooks
-from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.requirements import Requirement
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line, parse_req_from_line
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.requirements import Requirement
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -82,20 +82,23 @@ def build_project_metadata(
 
         if "project" in pyproject_contents and "name" in pyproject_contents["project"]:
             dynamic = pyproject_contents["project"].get("dynamic", [])
-            if (
-                "dependencies" not in dynamic
-                and "optional-dependencies" not in dynamic
-            ):
+            if "dependencies" not in dynamic and "optional-dependencies" not in dynamic:
                 package_name = pyproject_contents["project"]["name"]
                 comes_from = f"{package_name} ({src_file})"
 
-                extras = pyproject_contents["project"].get("optional-dependencies", {}).keys()
+                extras = (
+                    pyproject_contents["project"]
+                    .get("optional-dependencies", {})
+                    .keys()
+                )
                 requirements = [
                     InstallRequirement(Requirement(req), comes_from)
                     for req in pyproject_contents["project"].get("dependencies", [])
                 ]
                 for extra, reqs in (
-                    pyproject_contents.get("project", {}).get("optional-dependencies", {}).items()
+                    pyproject_contents.get("project", {})
+                    .get("optional-dependencies", {})
+                    .items()
                 ):
                     for req in reqs:
                         requirement = Requirement(req)
@@ -108,7 +111,9 @@ def build_project_metadata(
                 comes_from = f"{package_name} ({src_file}::build-system.requires)"
                 build_requirements = [
                     InstallRequirement(Requirement(req), comes_from)
-                    for req in pyproject_contents.get("build-system", {}).get("requires", [])
+                    for req in pyproject_contents.get("build-system", {}).get(
+                        "requires", []
+                    )
                 ]
                 return ProjectMetadata(
                     extras=tuple(extras),

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -148,7 +148,7 @@ def build_project_metadata(
 
     if attempt_static_parse:
         if build_targets:
-            raise AssertionError(
+            raise ValueError(
                 "Cannot execute the PEP 517 optional get_requires_for_build* "
                 "hooks statically"
             )

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -100,7 +100,7 @@ def maybe_statically_parse_project_metadata(
             if requirement.name == package_name:
                 # Similar to logic for handling self-referential requirements
                 # from _prepare_requirements
-                requirement.url = f"file://{src_file.parent}"
+                requirement.url = f"file://{src_file.parent.as_posix()}"
             # Note we don't need to modify `requirement` to include this extra
             marker = Marker(f"extra == '{extra}'")
             install_requirements.append(

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -58,7 +58,7 @@ def maybe_statically_parse_project_metadata(
     src_file: pathlib.Path,
 ) -> StaticProjectMetadata | None:
     """
-    Return the metadata for a project, if it can be statically parsed from pyproject.toml.
+    Return the metadata for a project, if it can be statically parsed from ``pyproject.toml``.
 
     This function is typically significantly faster than invoking a build backend.
     Returns None if the project metadata cannot be statically parsed.

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -127,7 +127,7 @@ def build_project_metadata(
     Return the metadata for a project.
 
     First, optionally attempt to determine the metadata statically from the
-    pyproject.toml file. This will not work if build_targets are specified,
+    ``pyproject.toml`` file. This will not work if build_targets are specified,
     since we cannot determine build requirements statically.
 
     Uses the ``prepare_metadata_for_build_wheel`` hook for the wheel metadata
@@ -140,7 +140,7 @@ def build_project_metadata(
     :param build_targets: A tuple of build targets to get the dependencies
                                 of (``sdist`` or ``wheel`` or ``editable``).
     :param attempt_static_parse: Whether to attempt to statically parse the
-                                 project metadata from pyproject.toml.
+                                 project metadata from ``pyproject.toml``.
                                  Cannot be used with ``build_targets``.
     :param isolated: Whether to run invoke the backend in the current
                      environment or to create an isolated one and invoke it

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -100,7 +100,7 @@ def maybe_statically_parse_project_metadata(
             if requirement.name == package_name:
                 # Similar to logic for handling self-referential requirements
                 # from _prepare_requirements
-                requirement.url = f"file://{src_file.parent.as_posix()}"
+                requirement.url = src_file.parent.as_uri()
             # Note we don't need to modify `requirement` to include this extra
             marker = Marker(f"extra == '{extra}'")
             install_requirements.append(

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -81,7 +81,7 @@ def maybe_statically_parse_project_metadata(
 
     project_table = pyproject_contents["project"]
 
-    # Dynamic dependencies require build invocation
+    # Dynamic dependencies require build backend invocation
     dynamic = project_table.get("dynamic", [])
     if "dependencies" in dynamic or "optional-dependencies" in dynamic:
         return None
@@ -152,7 +152,7 @@ def build_project_metadata(
         if build_targets:
             raise ValueError(
                 "Cannot execute the PEP 517 optional get_requires_for_build* "
-                "hooks statically"
+                "hooks statically, as build requirements are requested"
             )
         project_metadata = maybe_statically_parse_project_metadata(src_file)
         if project_metadata is not None:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -16,7 +16,7 @@ from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 
 from .._compat import parse_requirements
-from ..build import build_project_metadata
+from ..build import ProjectMetadata, build_project_metadata
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError
 from ..logging import log
@@ -348,6 +348,7 @@ def cli(
                 metadata = build_project_metadata(
                     src_file=Path(src_file),
                     build_targets=build_deps_targets,
+                    attempt_static_parse=not bool(build_deps_targets),
                     isolated=build_isolation,
                     quiet=log.verbosity <= 0,
                 )
@@ -364,6 +365,7 @@ def cli(
                         raise click.BadParameter(msg)
                     extras = metadata.extras
             if build_deps_targets:
+                assert isinstance(metadata, ProjectMetadata)
                 constraints.extend(metadata.build_requirements)
         else:
             constraints.extend(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -94,6 +94,10 @@ baz = ["qux[extra]"]
     assert [str(r.req) for r in metadata.requirements] == ["bar>=1", "qux[extra]"]
     assert metadata.extras == ("baz",)
 
+    invalid_toml = """this is not valid toml"""
+    src_file.write_text(invalid_toml)
+    assert maybe_statically_parse_project_metadata(src_file) is None
+
     no_pep621 = """
 [build-system]
 requires = ["setuptools"]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -77,7 +77,7 @@ def test_build_project_metadata_raises_error(tmp_path):
         )
 
 
-def test_static_parse(tmp_path):
+def test_static_parse_valid(tmp_path):
     src_file = tmp_path / "pyproject.toml"
 
     valid = """
@@ -93,6 +93,10 @@ baz = ["qux[extra]"]
     assert isinstance(metadata, StaticProjectMetadata)
     assert [str(r.req) for r in metadata.requirements] == ["bar>=1", "qux[extra]"]
     assert metadata.extras == ("baz",)
+
+
+def test_static_parse_invalid(tmp_path):
+    src_file = tmp_path / "pyproject.toml"
 
     invalid_toml = """this is not valid toml"""
     src_file.write_text(invalid_toml)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,7 +5,11 @@ import shutil
 
 import pytest
 
-from piptools.build import StaticProjectMetadata, ProjectMetadata, build_project_metadata
+from piptools.build import (
+    ProjectMetadata,
+    StaticProjectMetadata,
+    build_project_metadata,
+)
 from tests.constants import PACKAGES_PATH
 
 
@@ -50,7 +54,7 @@ def test_build_project_metadata_static(tmp_path):
     requirements = [(r.name, r.extras, str(r.markers)) for r in metadata.requirements]
     requirements.sort(key=lambda x: x[0])
     assert requirements == [
-        ('fake_direct_extra_runtime_dep', {"with_its_own_extra"}, 'extra == "x"'),
-        ('fake_direct_runtime_dep', set(), 'None')
+        ("fake_direct_extra_runtime_dep", {"with_its_own_extra"}, 'extra == "x"'),
+        ("fake_direct_runtime_dep", set(), "None"),
     ]
     assert metadata.extras == ("x",)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,7 +5,7 @@ import shutil
 
 import pytest
 
-from piptools.build import build_project_metadata
+from piptools.build import ProjectMetadata, build_project_metadata
 from tests.constants import PACKAGES_PATH
 
 
@@ -25,8 +25,9 @@ def test_build_project_metadata_resolved_correct_build_dependencies(
     shutil.copytree(src_pkg_path, tmp_path, dirs_exist_ok=True)
     src_file = tmp_path / "setup.py"
     metadata = build_project_metadata(
-        src_file, ("editable",), isolated=True, quiet=False
+        src_file, ("editable",), attempt_static_parse=False, isolated=True, quiet=False
     )
+    assert isinstance(metadata, ProjectMetadata)
     build_requirements = sorted(r.name for r in metadata.build_requirements)
     assert build_requirements == [
         "fake_dynamic_build_dep_for_all",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -58,3 +58,19 @@ def test_build_project_metadata_static(tmp_path):
         ("fake_direct_runtime_dep", set(), "None"),
     ]
     assert metadata.extras == ("x",)
+
+
+def test_build_project_metadata_raises_error(tmp_path):
+    src_pkg_path = pathlib.Path(PACKAGES_PATH) / "small_fake_with_build_deps"
+    shutil.copytree(src_pkg_path, tmp_path, dirs_exist_ok=True)
+    src_file = tmp_path / "setup.py"
+    with pytest.raises(
+        ValueError, match="Cannot execute the PEP 517 optional.* hooks statically"
+    ):
+        build_project_metadata(
+            src_file,
+            ("editable",),
+            attempt_static_parse=True,
+            isolated=True,
+            quiet=False,
+        )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -9,6 +9,7 @@ from piptools.build import (
     ProjectMetadata,
     StaticProjectMetadata,
     build_project_metadata,
+    maybe_statically_parse_project_metadata,
 )
 from tests.constants import PACKAGES_PATH
 
@@ -74,3 +75,56 @@ def test_build_project_metadata_raises_error(tmp_path):
             isolated=True,
             quiet=False,
         )
+
+
+def test_static_parse(tmp_path):
+    src_file = tmp_path / "pyproject.toml"
+
+    valid = """
+[project]
+name = "foo"
+version = "0.1.0"
+dependencies = ["bar>=1"]
+[project.optional-dependencies]
+baz = ["qux[extra]"]
+"""
+    src_file.write_text(valid)
+    metadata = maybe_statically_parse_project_metadata(src_file)
+    assert isinstance(metadata, StaticProjectMetadata)
+    assert [str(r.req) for r in metadata.requirements] == ["bar>=1", "qux[extra]"]
+    assert metadata.extras == ("baz",)
+
+    no_pep621 = """
+[build-system]
+requires = ["setuptools"]
+"""
+    src_file.write_text(no_pep621)
+    assert maybe_statically_parse_project_metadata(src_file) is None
+
+    invalid_pep621 = """
+[project]
+# no name
+version = "0.1.0"
+"""
+    src_file.write_text(invalid_pep621)
+    assert maybe_statically_parse_project_metadata(src_file) is None
+
+    dynamic_deps = """
+[project]
+name = "foo"
+dynamic = ["dependencies"]
+"""
+    src_file.write_text(dynamic_deps)
+    assert maybe_statically_parse_project_metadata(src_file) is None
+
+    dynamic_optional_deps = """
+[project]
+name = "foo"
+dynamic = ["optional-dependencies"]
+"""
+    src_file.write_text(dynamic_optional_deps)
+    assert maybe_statically_parse_project_metadata(src_file) is None
+
+    src_file = tmp_path / "setup.py"
+    src_file.write_text("print('hello')")
+    assert maybe_statically_parse_project_metadata(src_file) is None

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3332,7 +3332,7 @@ small-fake-b==0.3
     try:
         assert out.exit_code == 0
         assert expected == out.stdout
-    except Exception:
+    except Exception:  # pragma: no cover
         print(out.stdout)
         print(out.stderr)
         raise
@@ -3382,7 +3382,7 @@ wheel==0.42.0
     try:
         assert out.exit_code == 0
         assert expected == out.stdout
-    except Exception:
+    except Exception:  # pragma: no cover
         print(out.stdout)
         print(out.stderr)
         raise

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3388,6 +3388,7 @@ def test_compile_recursive_extras_build_targets(runner, tmp_path, current_resolv
             """
         )
     )
+    (tmp_path / "constraints.txt").write_text("wheel<0.43")
     out = runner.invoke(
         cli,
         [
@@ -3402,6 +3403,8 @@ def test_compile_recursive_extras_build_targets(runner, tmp_path, current_resolv
             "--find-links",
             os.fspath(MINIMAL_WHEELS_PATH),
             os.fspath(tmp_path / "pyproject.toml"),
+            "--constraint",
+            os.fspath(tmp_path / "constraints.txt"),
             "--output-file",
             "-",
         ],

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3295,7 +3295,7 @@ def test_pass_pip_cache_to_pip_args(tmpdir, runner, current_resolver):
 
 
 @backtracking_resolver_only
-def test_compile_recursive_extras(runner, tmp_path, current_resolver):
+def test_compile_recursive_extras_static(runner, tmp_path, current_resolver):
     (tmp_path / "pyproject.toml").write_text(
         dedent(
             """
@@ -3329,8 +3329,63 @@ def test_compile_recursive_extras(runner, tmp_path, current_resolver):
 small-fake-a==0.2
 small-fake-b==0.3
 """
-    assert out.exit_code == 0
-    assert expected == out.stdout
+    try:
+        assert out.exit_code == 0
+        assert expected == out.stdout
+    except Exception:
+        print(out.stdout)
+        print(out.stderr)
+        raise
+
+
+@backtracking_resolver_only
+def test_compile_recursive_extras_build_targets(runner, tmp_path, current_resolver):
+    (tmp_path / "pyproject.toml").write_text(
+        dedent(
+            """
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            dependencies = ["small-fake-a"]
+            [project.optional-dependencies]
+            footest = ["small-fake-b"]
+            dev = ["foo[footest]"]
+            """
+        )
+    )
+    out = runner.invoke(
+        cli,
+        [
+            "--no-build-isolation",
+            "--no-header",
+            "--no-annotate",
+            "--no-emit-options",
+            "--extra",
+            "dev",
+            "--build-deps-for",
+            "wheel",
+            "--find-links",
+            os.fspath(MINIMAL_WHEELS_PATH),
+            os.fspath(tmp_path / "pyproject.toml"),
+            "--output-file",
+            "-",
+        ],
+    )
+    expected = rf"""foo[footest] @ {tmp_path.as_uri()}
+small-fake-a==0.2
+small-fake-b==0.3
+wheel==0.42.0
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools
+"""
+    try:
+        assert out.exit_code == 0
+        assert expected == out.stdout
+    except Exception:
+        print(out.stdout)
+        print(out.stderr)
+        raise
 
 
 def test_config_option(pip_conf, runner, tmp_path, make_config_file):

--- a/tests/test_data/packages/small_fake_with_pyproject/pyproject.toml
+++ b/tests/test_data/packages/small_fake_with_pyproject/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name="small_fake_with_pyproject"
+version=0.1
+dependencies=[
+    "fake_direct_runtime_dep",
+]
+[project.optional-dependencies]
+x = ["fake_direct_extra_runtime_dep[with_its_own_extra]"]


### PR DESCRIPTION
##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
