### PR TITLE
Add support for command-specific configuration sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ By default, both `pip-compile` and `pip-sync` will look first
 for a `.pip-tools.toml` file and then in your `pyproject.toml`. You can
 also specify an alternate TOML configuration file with the `--config` option.
 
+It is possible to specify configuration values both globally and tool-specific.
 For example, to by default generate `pip` hashes in the resulting
 requirements file output, you can specify in a configuration file:
 
@@ -309,6 +310,27 @@ so the above could also be specified in this format:
 ```toml
 [tool.pip-tools]
 generate_hashes = true
+```
+
+Configuration defaults specific to `pip-compile` and `pip-sync` can be put beneath
+separate sections. For example, to by default perform a dry-run with `pip-compile`:
+
+```toml
+[tool.pip-compile]
+dry-run = true
+```
+
+This does not affect the `pip-sync` command, which also has a `--dry-run` option.
+Note that tool-specific configuration overrides global settings, thus this would
+also make `pip-compile` generate hashes, but discard the global dry-run setting:
+
+```toml
+[tool.pip-tools]
+generate-hashes = true
+dry-run = true
+
+[tool.pip-compile]
+dry-run = false
 ```
 
 You might be wrapping the `pip-compile` command in another script. To avoid

--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ dry-run = true
 ```
 
 This does not affect the `pip-sync` command, which also has a `--dry-run` option.
-Note that local settings take preference over the global ones of the same name, 
-whenever both are declared, thus this would also make `pip-compile` generate hashes, 
+Note that local settings take preference over the global ones of the same name,
+whenever both are declared, thus this would also make `pip-compile` generate hashes,
 but discard the global dry-run setting:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ By default, both `pip-compile` and `pip-sync` will look first
 for a `.pip-tools.toml` file and then in your `pyproject.toml`. You can
 also specify an alternate TOML configuration file with the `--config` option.
 
-It is possible to specify configuration values both globally and tool-specific.
+It is possible to specify configuration values both globally and command-specific.
 For example, to by default generate `pip` hashes in the resulting
 requirements file output, you can specify in a configuration file:
 
@@ -316,20 +316,21 @@ Configuration defaults specific to `pip-compile` and `pip-sync` can be put benea
 separate sections. For example, to by default perform a dry-run with `pip-compile`:
 
 ```toml
-[tool.pip-compile]
+[tool.pip-tools.compile] # "sync" for pip-sync
 dry-run = true
 ```
 
 This does not affect the `pip-sync` command, which also has a `--dry-run` option.
-Note that tool-specific configuration overrides global settings, thus this would
-also make `pip-compile` generate hashes, but discard the global dry-run setting:
+Note that local settings take preference over the global ones of the same name, 
+whenever both are declared, thus this would also make `pip-compile` generate hashes, 
+but discard the global dry-run setting:
 
 ```toml
 [tool.pip-tools]
 generate-hashes = true
 dry-run = true
 
-[tool.pip-compile]
+[tool.pip-tools.compile]
 dry-run = false
 ```
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -68,7 +68,10 @@ def _determine_linesep(
     }[strategy]
 
 
-@click.command(context_settings={"help_option_names": options.help_option_names})
+@click.command(
+    name="pip-compile",
+    context_settings={"help_option_names": options.help_option_names},
+)
 @click.pass_context
 @options.version
 @options.verbose

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -30,7 +30,9 @@ from . import options
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 
 
-@click.command(context_settings={"help_option_names": options.help_option_names})
+@click.command(
+    name="pip-sync", context_settings={"help_option_names": options.help_option_names}
+)
 @options.version
 @options.ask
 @options.dry_run

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -682,8 +682,8 @@ def parse_config_file(
     # `[tool.pip-tools.compile]` or `[tool.pip-tools.sync]`
     piptools_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {})
 
-    # TODO: Replace with `str.removeprefix()` once dropped 3.8
     assert click_context.command.name is not None
+    # TODO: Replace with `str.removeprefix()` once dropped 3.8
     config_section_name = click_context.command.name[len("pip-") :]
 
     piptools_config.update(piptools_config.pop(config_section_name, {}))

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -546,9 +546,7 @@ def override_defaults_from_config_file(
     else:
         config_file = Path(value)
 
-    config = parse_config_file(
-        ctx, config_file
-    )
+    config = parse_config_file(ctx, config_file)
 
     _validate_config(ctx, config)
     _assign_config_to_cli_context(ctx, config)
@@ -683,26 +681,29 @@ def parse_config_file(
     # In a TOML file, we expect the config to be under `[tool.pip-tools]`,
     # `[tool.pip-compile]` or `[tool.pip-sync]`
     piptools_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {})
-    pipcompile_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {}).get("compile", {})
-    pipsync_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {}).get("sync", {})
+    pipcompile_config: dict[str, Any] = (
+        config.get("tool", {}).get("pip-tools", {}).get("compile", {})
+    )
+    pipsync_config: dict[str, Any] = (
+        config.get("tool", {}).get("pip-tools", {}).get("sync", {})
+    )
 
     config = piptools_config
-    
+
     if click_context.command.name == "pip-compile":
-        config.pop("compile")
-        config.update(pipcompile_config)
+        if pipcompile_config:
+            config.pop("compile")
+            config.update(pipcompile_config)
     elif click_context.command.name == "pip-sync":
-        config.pop("sync")
-        config.update(pipsync_config)
+        if pipsync_config:
+            config.pop("sync")
+            config.update(pipsync_config)
 
-    print(config)
-
-    if config:
-        config = _normalize_keys_in_config(config)
-        config = _invert_negative_bool_options_in_config(
-            ctx=click_context,
-            config=config,
-        )
+    config = _normalize_keys_in_config(config)
+    config = _invert_negative_bool_options_in_config(
+        ctx=click_context,
+        config=config,
+    )
 
     return config
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -684,7 +684,7 @@ def parse_config_file(
 
     # TODO: Replace with `str.removeprefix()` once dropped 3.8
     assert click_context.command.name is not None
-    config_section_name = click_context.command.name[len("pip-"):]
+    config_section_name = click_context.command.name[len("pip-") :]
 
     piptools_config.update(piptools_config.pop(config_section_name, {}))
     piptools_config.pop("compile", {})

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -546,21 +546,12 @@ def override_defaults_from_config_file(
     else:
         config_file = Path(value)
 
-    piptools_config, pipcompile_config, pipsync_config = parse_config_file(
+    config = parse_config_file(
         ctx, config_file
     )
 
-    configs = [piptools_config]
-
-    if ctx.command.name == "pip-compile":
-        configs.append(pipcompile_config)
-    elif ctx.command.name == "pip-sync":
-        configs.append(pipsync_config)
-
-    for config in configs:
-        if config:
-            _validate_config(ctx, config)
-            _assign_config_to_cli_context(ctx, config)
+    _validate_config(ctx, config)
+    _assign_config_to_cli_context(ctx, config)
 
     return config_file
 
@@ -675,7 +666,7 @@ def get_cli_options(ctx: click.Context) -> dict[str, click.Parameter]:
 
 def parse_config_file(
     click_context: click.Context, config_file: Path
-) -> tuple[dict[str, Any], ...]:
+) -> dict[str, Any]:
     try:
         config = tomllib.loads(config_file.read_text(encoding="utf-8"))
     except OSError as os_err:
@@ -692,21 +683,28 @@ def parse_config_file(
     # In a TOML file, we expect the config to be under `[tool.pip-tools]`,
     # `[tool.pip-compile]` or `[tool.pip-sync]`
     piptools_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {})
-    pipcompile_config: dict[str, Any] = config.get("tool", {}).get("pip-compile", {})
-    pipsync_config: dict[str, Any] = config.get("tool", {}).get("pip-sync", {})
+    pipcompile_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {}).get("compile", {})
+    pipsync_config: dict[str, Any] = config.get("tool", {}).get("pip-tools", {}).get("sync", {})
 
-    configs = []
+    config = piptools_config
+    
+    if click_context.command.name == "pip-compile":
+        config.pop("compile")
+        config.update(pipcompile_config)
+    elif click_context.command.name == "pip-sync":
+        config.pop("sync")
+        config.update(pipsync_config)
 
-    for config in (piptools_config, pipcompile_config, pipsync_config):
-        if config:
-            config = _normalize_keys_in_config(config)
-            config = _invert_negative_bool_options_in_config(
-                ctx=click_context,
-                config=config,
-            )
-        configs.append(config)
+    print(config)
 
-    return tuple(configs)
+    if config:
+        config = _normalize_keys_in_config(config)
+        config = _invert_negative_bool_options_in_config(
+            ctx=click_context,
+            config=config,
+        )
+
+    return config
 
 
 def _normalize_keys_in_config(config: dict[str, Any]) -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -502,6 +502,7 @@ def make_config_file(tmpdir_cwd):
         new_default: Any,
         config_file_name: str = DEFAULT_CONFIG_FILE_NAMES[0],
         section: str = "pip-tools",
+        subsection: str | None = None,
     ) -> Path:
         # Create a nested directory structure if config_file_name includes directories
         config_dir = (tmpdir_cwd / config_file_name).parent
@@ -509,7 +510,13 @@ def make_config_file(tmpdir_cwd):
 
         # Make a config file with this one config default override
         config_file = tmpdir_cwd / config_file_name
-        config_to_dump = {"tool": {section: {pyproject_param: new_default}}}
+
+        if subsection:
+            config_to_dump = {
+                "tool": {section: {subsection: {pyproject_param: new_default}}}
+            }
+        else:
+            config_to_dump = {"tool": {section: {pyproject_param: new_default}}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
         return cast(Path, config_file.relative_to(tmpdir_cwd))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -501,6 +501,7 @@ def make_config_file(tmpdir_cwd):
         pyproject_param: str,
         new_default: Any,
         config_file_name: str = DEFAULT_CONFIG_FILE_NAMES[0],
+        section: str = "pip-tools",
     ) -> Path:
         # Create a nested directory structure if config_file_name includes directories
         config_dir = (tmpdir_cwd / config_file_name).parent
@@ -508,7 +509,7 @@ def make_config_file(tmpdir_cwd):
 
         # Make a config file with this one config default override
         config_file = tmpdir_cwd / config_file_name
-        config_to_dump = {"tool": {"pip-tools": {pyproject_param: new_default}}}
+        config_to_dump = {"tool": {section: {pyproject_param: new_default}}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
         return cast(Path, config_file.relative_to(tmpdir_cwd))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -511,12 +511,10 @@ def make_config_file(tmpdir_cwd):
         # Make a config file with this one config default override
         config_file = tmpdir_cwd / config_file_name
 
+        nested_config = {pyproject_param: new_default}
         if subsection:
-            config_to_dump = {
-                "tool": {section: {subsection: {pyproject_param: new_default}}}
-            }
-        else:
-            config_to_dump = {"tool": {section: {pyproject_param: new_default}}}
+            nested_config = {subsection: nested_config}
+        config_to_dump = {"tool": {section: nested_config}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
         return cast(Path, config_file.relative_to(tmpdir_cwd))
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3565,7 +3565,12 @@ def test_origin_of_extra_requirement_not_written_to_annotations(
 
 
 def test_tool_specific_config_option(pip_conf, runner, tmp_path, make_config_file):
-    config_file = make_config_file("dry-run", True, section="pip-tools.compile")
+    config_file = make_config_file(
+        "dry-run", True, section="pip-tools", subsection="compile"
+    )
+
+    with open(config_file.as_posix()) as f:
+        print(f.read())
 
     req_in = tmp_path / "requirements.in"
     req_in.touch()

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3569,9 +3569,6 @@ def test_tool_specific_config_option(pip_conf, runner, tmp_path, make_config_fil
         "dry-run", True, section="pip-tools", subsection="compile"
     )
 
-    with open(config_file.as_posix()) as f:
-        print(f.read())
-
     req_in = tmp_path / "requirements.in"
     req_in.touch()
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3562,3 +3562,14 @@ def test_origin_of_extra_requirement_not_written_to_annotations(
         )
         == out.stdout
     )
+
+def test_tool_specific_config_option(pip_conf, runner, tmp_path, make_config_file):
+    config_file = make_config_file("dry-run", True, section="pip-compile")
+
+    req_in = tmp_path / "requirements.in"
+    req_in.touch()
+
+    out = runner.invoke(cli, [req_in.as_posix(), "--config", config_file.as_posix()])
+
+    assert out.exit_code == 0
+    assert "Dry-run, so nothing updated" in out.stderr

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3563,8 +3563,9 @@ def test_origin_of_extra_requirement_not_written_to_annotations(
         == out.stdout
     )
 
+
 def test_tool_specific_config_option(pip_conf, runner, tmp_path, make_config_file):
-    config_file = make_config_file("dry-run", True, section="pip-compile")
+    config_file = make_config_file("dry-run", True, section="pip-tools.compile")
 
     req_in = tmp_path / "requirements.in"
     req_in.touch()

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -450,3 +450,16 @@ def test_allow_in_config_pip_compile_option(run, runner, tmp_path, make_config_f
 
     assert out.exit_code == 0
     assert "Using pip-tools configuration defaults found" in out.stderr
+
+
+@mock.patch("piptools.sync.run")
+def test_tool_specific_config_option(run, runner, make_config_file):
+    config_file = make_config_file("dry-run", True, section="pip-sync")
+
+    with open(sync.DEFAULT_REQUIREMENTS_FILE, "w") as reqs_txt:
+        reqs_txt.write("six==1.10.0")
+
+    out = runner.invoke(cli, ["--config", config_file.as_posix()])
+
+    assert out.exit_code == 1
+    assert "Would install:" in out.stdout

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -454,7 +454,7 @@ def test_allow_in_config_pip_compile_option(run, runner, tmp_path, make_config_f
 
 @mock.patch("piptools.sync.run")
 def test_tool_specific_config_option(run, runner, make_config_file):
-    config_file = make_config_file("dry-run", True, section="pip-sync")
+    config_file = make_config_file("dry-run", True, section="pip-tools", subsection="sync")
 
     with open(sync.DEFAULT_REQUIREMENTS_FILE, "w") as reqs_txt:
         reqs_txt.write("six==1.10.0")

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -454,7 +454,9 @@ def test_allow_in_config_pip_compile_option(run, runner, tmp_path, make_config_f
 
 @mock.patch("piptools.sync.run")
 def test_tool_specific_config_option(run, runner, make_config_file):
-    config_file = make_config_file("dry-run", True, section="pip-tools", subsection="sync")
+    config_file = make_config_file(
+        "dry-run", True, section="pip-tools", subsection="sync"
+    )
 
     with open(sync.DEFAULT_REQUIREMENTS_FILE, "w") as reqs_txt:
         reqs_txt.write("six==1.10.0")


### PR DESCRIPTION
Addresses https://github.com/jazzband/pip-tools/pull/1933#issuecomment-1653068755

This introduces configuration sections specific to `pip-compile` and `pip-sync`.

I'd like to refactor the `make_config_file()` pytest fixture in a follow-up PR, to introduce tests for this feature using multiple configuration sections.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
