### PR TITLE
Update tox environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         pip-version:
           - latest
     env:
-      TOXENV: pip${{ matrix.pip-version }}
+      TOXENV: pip${{ matrix.pip-version }}-coverage
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
     py{37,38,39,310,311,312,py3}-pip{previous,latest,main}-coverage
+    pip{previous,latest,main}-coverage
     checkqa
     readme
 skip_missing_interpreters = True


### PR DESCRIPTION
Since `tox==4.9.0`, only explicitly declared environments are permitted to run.

Refs: https://github.com/tox-dev/tox/issues/3096#issuecomment-1683343825


<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
