### PR TITLE
Disable coverage report on PyPy tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         pip-version:
           - latest
     env:
-      TOXENV: pip${{ matrix.pip-version }}-coverage
+      TOXENV: pip${{ matrix.pip-version }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
     py{37,38,39,310,311,312,py3}-pip{previous,latest,main}-coverage
     pip{previous,latest,main}-coverage
+    pip{previous,latest,main}
     checkqa
     readme
 skip_missing_interpreters = True


### PR DESCRIPTION
PyPy tests job takes 17-18 minutes with coverage, and just 4 minutes without it. Since we don't have any PyPy specific tests, and due to slowness let's disable the coverage report for this job to avoid wasting CI time.

Refs: https://github.com/jazzband/pip-tools/pull/1967#discussion_r1298907385
