### PR TITLE
Bump pip minimum version to `>= 23.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   # direct dependencies
   "build",
   "click >= 8",
-  "pip >= 22.2",
+  "pip >= 23",
   "tomli; python_version < '3.11'",
   # indirect dependencies
   "setuptools", # typically needed when pip-tools invokes setup.py

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,6 +36,11 @@ from piptools.utils import (
 )
 
 
+def test_can_import_pyproject_hooks():
+    # TODO: Remove this test when there is code using this package
+    from pip._vendor import pyproject_hooks  # noqa: F401
+
+
 def test_format_requirement(from_line):
     ireq = from_line("test==1.2")
     assert format_requirement(ireq) == "test==1.2"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
-    py{37,38,39,310,311,312,py3}-pip{previous,latest,main}-coverage
+    py{38,39,310,311,312,py3}-pip{previous,latest,main}-coverage
     pip{previous,latest,main}-coverage
     pip{previous,latest,main}
     checkqa

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ extras =
     testing
     coverage: coverage
 deps =
-    pipprevious: pip==22.2.*
+    pipprevious: pip==23.0.*
     piplatest: pip
     pipmain: https://github.com/pypa/pip/archive/main.zip
 setenv =


### PR DESCRIPTION
##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
