### PR TITLE
Remove py37 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
-    py{37,38,39,310,311,312,py3}-pip{previous,latest,main}-coverage
+    py{38,39,310,311,312,py3}-pip{previous,latest,main}-coverage
     pip{previous,latest,main}-coverage
     pip{previous,latest,main}
     checkqa


### PR DESCRIPTION
... so that running `tox` locally at least has a chance of succeeding.

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
