### PR TITLE
Display `pyproject.toml`'s metatada parsing errors in verbose mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,8 @@ repos:
           - pep517==0.10.0
           - toml==0.10.2
           - pip==20.3.4
-          - build==0.9.0
+          - build==1.0.0
+          - pyproject_hooks==1.0.0
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5
     hooks:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -15,7 +15,7 @@ from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
-from pyproject_hooks import default_subprocess_runner
+from pyproject_hooks import default_subprocess_runner, quiet_subprocess_runner
 
 from .._compat import parse_requirements
 from ..cache import DependencyCache
@@ -320,11 +320,14 @@ def cli(
             constraints.extend(reqs)
         elif is_setup_file:
             setup_file_found = True
+            build_runner = quiet_subprocess_runner
+            if verbose:
+                build_runner = default_subprocess_runner
             try:
                 metadata = project_wheel_metadata(
                     os.path.dirname(os.path.abspath(src_file)),
                     isolated=build_isolation,
-                    runner=default_subprocess_runner,
+                    runner=build_runner,
                 )
             except BuildBackendException as e:
                 log.error(str(e))

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -320,14 +320,15 @@ def cli(
             constraints.extend(reqs)
         elif is_setup_file:
             setup_file_found = True
-            build_runner = quiet_subprocess_runner
-            if verbose:
-                build_runner = default_subprocess_runner
             try:
                 metadata = project_wheel_metadata(
                     os.path.dirname(os.path.abspath(src_file)),
                     isolated=build_isolation,
-                    runner=build_runner,
+                    runner=(
+                        default_subprocess_runner
+                        if verbose
+                        else quiet_subprocess_runner
+                    ),
                 )
             except BuildBackendException as e:
                 log.error(str(e))

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -11,6 +11,7 @@ from typing import IO, Any, BinaryIO, cast
 import click
 from build import BuildBackendException
 from build.util import project_wheel_metadata
+from pyproject_hooks import default_subprocess_runner
 from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
@@ -323,6 +324,7 @@ def cli(
                 metadata = project_wheel_metadata(
                     os.path.dirname(os.path.abspath(src_file)),
                     isolated=build_isolation,
+                    runner=default_subprocess_runner,
                 )
             except BuildBackendException as e:
                 log.error(str(e))

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -11,11 +11,11 @@ from typing import IO, Any, BinaryIO, cast
 import click
 from build import BuildBackendException
 from build.util import project_wheel_metadata
-from pyproject_hooks import default_subprocess_runner
 from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
+from pyproject_hooks import default_subprocess_runner
 
 from .._compat import parse_requirements
 from ..cache import DependencyCache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ classifiers = [
 keywords = ["pip", "requirements", "packaging"]
 dependencies = [
   # direct dependencies
-  "build",
+  "build >= 1.0.0",
+  "pyproject_hooks",
   "click >= 8",
   "pip >= 22.2",
   "tomli; python_version < '3.11'",

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2603,7 +2603,8 @@ def test_error_in_pyproject_toml(fake_dists, runner, make_module, capfd):
         cli, ["-n", "--no-build-isolation", "-v", "--find-links", fake_dists, meta_path]
     )
     assert out.exit_code == 2, out.stderr
-    assert "`project` must contain ['name'] properties" in capfd.readouterr().err
+    captured = capfd.readouterr()
+    assert "`project` must contain ['name'] properties" in captured.err
 
 
 @pytest.mark.network

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2582,7 +2582,10 @@ def test_input_formats(fake_dists, runner, make_module, fname, content):
     assert "extra ==" not in out.stderr
 
 
-def test_error_in_pyproject_toml(fake_dists, runner, make_module, capfd):
+@pytest.mark.parametrize("verbose_option", (True, False))
+def test_error_in_pyproject_toml(
+    fake_dists, runner, make_module, capfd, verbose_option
+):
     """
     Test that an error in pyproject.toml is reported.
     """
@@ -2594,17 +2597,23 @@ def test_error_in_pyproject_toml(fake_dists, runner, make_module, capfd):
         """
     )
     meta_path = make_module(fname=fname, content=invalid_content)
-    out = runner.invoke(
-        cli, ["-n", "--no-build-isolation", "--find-links", fake_dists, meta_path]
+
+    options = []
+    if verbose_option:
+        options = ["--verbose"]
+
+    options.extend(
+        ["-n", "--no-build-isolation", "--find-links", fake_dists, meta_path]
     )
-    assert out.exit_code == 2, out.stderr
-    assert "`project` must contain ['name'] properties" not in capfd.readouterr().err
-    out = runner.invoke(
-        cli, ["-n", "--no-build-isolation", "-v", "--find-links", fake_dists, meta_path]
-    )
+
+    out = runner.invoke(cli, options)
+
     assert out.exit_code == 2, out.stderr
     captured = capfd.readouterr()
-    assert "`project` must contain ['name'] properties" in captured.err
+
+    assert (
+        "`project` must contain ['name'] properties" in captured.err
+    ) is verbose_option
 
 
 @pytest.mark.network

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2589,9 +2589,9 @@ def test_error_in_pyproject_toml(fake_dists, runner, make_module, capfd):
     fname = "pyproject.toml"
     invalid_content = dedent(
         """\
-            [project]
-            invalid = "metadata"
-            """
+        [project]
+        invalid = "metadata"
+        """
     )
     meta_path = make_module(fname=fname, content=invalid_content)
     out = runner.invoke(


### PR DESCRIPTION
Fixes #1711.

Before the changes implemented in this PR, the execution of `pip-compile` was silent about an error in `pyproject.toml` file.
If the user made a mistake in the configuration file, the output of the command was:
```
Backend subprocess exited when trying to invoke prepare_metadata_for_build_wheel
```
Now, the output is the following (the error is in the "licence" field for demonstration):
```
<truncated traceback>
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']

Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

There are several issues already mentioned on GitHub:
https://github.com/jazzband/pip-tools/issues/1711
https://github.com/jazzband/pip-tools/issues/1794

The changes implemented in this PR are possible only because of the new `build` version release:
https://github.com/pypa/build/issues/615#issuecomment-1703239433
The particular change is this: https://github.com/pypa/build/pull/566.

Please pay attention that in case of an error, the traceback is huge, but unfortunately, the error is captured and printed inside `build.ProjectBuilder`, and it's currently impossible to capture it and show only a short error description. On the other hand, the traceback gives the user an extra debug information.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
