### PR TITLE
🐛 Fix collecting deps for all extras in multiple input packages

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -205,6 +205,10 @@ def cli(
                 ).format(", ".join(DEFAULT_REQUIREMENTS_FILES))
             )
 
+    if all_extras and extras:
+        msg = "--extra has no effect when used with --all-extras"
+        raise click.BadParameter(msg)
+
     if not output_file:
         # An output file must be provided for stdin
         if src_files == ("-",):
@@ -372,10 +376,7 @@ def cli(
             if not only_build_deps:
                 constraints.extend(metadata.requirements)
                 if all_extras:
-                    if extras:
-                        msg = "--extra has no effect when used with --all-extras"
-                        raise click.BadParameter(msg)
-                    extras = metadata.extras
+                    extras += metadata.extras
             if build_deps_targets:
                 constraints.extend(metadata.build_requirements)
         else:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3030,6 +3030,9 @@ def test_cli_compile_all_extras_with_multiple_packages(
     )
 
     assert out.exit_code == 0, out
+    assert "--all-extras" in out.stderr
+    assert "test_package_1/0.1/setup.py" in out.stderr
+    assert "test_package_2/0.1/setup.py" in out.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3001,6 +3001,37 @@ def test_cli_compile_strip_extras(runner, make_package, make_sdist, tmpdir):
     assert "[more]" not in out.stderr
 
 
+def test_cli_compile_all_extras_with_multiple_packages(
+    runner, make_package, make_sdist, tmpdir
+):
+    """
+    Assures that ``--all-extras`` works when multiple sources are specified.
+    """
+    test_package_1 = make_package(
+        "test_package_1",
+        version="0.1",
+        extras_require={"more": []},
+    )
+    test_package_2 = make_package(
+        "test_package_2",
+        version="0.1",
+        extras_require={"more": []},
+    )
+
+    out = runner.invoke(
+        cli,
+        [
+            "--all-extras",
+            "--output-file",
+            "requirements.txt",
+            str(test_package_1 / "setup.py"),
+            str(test_package_2 / "setup.py"),
+        ],
+    )
+
+    assert out.exit_code == 0, out
+
+
 @pytest.mark.parametrize(
     ("package_specs", "constraints", "existing_reqs", "expected_reqs"),
     (
@@ -3132,7 +3163,6 @@ def test_resolver_drops_existing_conflicting_constraint(
     with open("requirements.txt") as req_txt:
         req_txt_content = req_txt.read()
         assert expected_requirements.issubset(req_txt_content.splitlines())
-
 
 def test_resolution_failure(runner):
     """Test resolution impossible for unknown package."""

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3031,8 +3031,8 @@ def test_cli_compile_all_extras_with_multiple_packages(
 
     assert out.exit_code == 0, out
     assert "--all-extras" in out.stderr
-    assert "test_package_1/0.1/setup.py" in out.stderr
-    assert "test_package_2/0.1/setup.py" in out.stderr
+    assert f"test_package_1{os.path.sep}0.1{os.path.sep}setup.py" in out.stderr
+    assert f"test_package_2{os.path.sep}0.1{os.path.sep}setup.py" in out.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3164,6 +3164,7 @@ def test_resolver_drops_existing_conflicting_constraint(
         req_txt_content = req_txt.read()
         assert expected_requirements.issubset(req_txt_content.splitlines())
 
+
 def test_resolution_failure(runner):
     """Test resolution impossible for unknown package."""
     with open("requirements.in", "w") as reqs_out:


### PR DESCRIPTION
Previously, an error would always be thrown when running `compile` with `--all-extras` on multiple source files containing extras. The reason was that the first iteration over the first source file would fill the `extras` variable, which in the second iteration would trigger an error since both `all_extras` and `extras` would be set.

This change moves the check outside the loop and early in the script to avoid unnecessary processing before throwing the error.

Further, only moving the check outside the loop would currently leave us with only the extras from the last `src_file` in the iteration over `src_files`.

This change also ensures all extras are in fact collected from all packages when `--all-extras` is passed as an argument.

This fixes #1980

##### Contributor checklist

- [ ] Included tests for the changes. (Happy to add a test, but not sure which type is preferred).
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
