### PR TITLE
Remove unsupported `system_packages` from RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,4 +26,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: false


### PR DESCRIPTION
- https://blog.readthedocs.com/drop-support-system-packages/
- https://github.com/readthedocs/readthedocs.org/pull/10562

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
