### PR TITLE
Fix ignorance of inverted CLI options in config for `pip-sync`

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -702,8 +702,9 @@ def _invert_negative_bool_options_in_config(
         # Transform config key to its equivalent in the CLI
         long_option = _convert_to_long_option(key)
         new_key = cli_opts[long_option].name if long_option in cli_opts else key
-        if new_key.startswith("no_"):
-            new_key = new_key[3:]
+        negative_option_prefix = "no_"
+        if new_key.startswith(negative_option_prefix):
+            new_key = new_key[len(negative_option_prefix):]
         assert new_key is not None
 
         # Invert negative boolean according to the CLI

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -702,7 +702,7 @@ def _invert_negative_bool_options_in_config(
         # Transform config key to its equivalent in the CLI
         long_option = _convert_to_long_option(key)
         new_key = cli_opts[long_option].name if long_option in cli_opts else key
-        if new_key.startswith('no_'):
+        if new_key.startswith("no_"):
             new_key = new_key[3:]
         assert new_key is not None
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -701,7 +701,7 @@ def _invert_negative_bool_options_in_config(
     for key, value in config.items():
         # Transform config key to its equivalent in the CLI
         long_option = _convert_to_long_option(key)
-        new_key = cli_opts[long_option].name if long_option in cli_opts else key
+        new_key = cli_opts[long_option].name if long_option in cli_opts else key.replace("no_", "")
         assert new_key is not None
 
         # Invert negative boolean according to the CLI

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -701,11 +701,9 @@ def _invert_negative_bool_options_in_config(
     for key, value in config.items():
         # Transform config key to its equivalent in the CLI
         long_option = _convert_to_long_option(key)
-        new_key = (
-            cli_opts[long_option].name
-            if long_option in cli_opts
-            else key.replace("no_", "")
-        )
+        new_key = cli_opts[long_option].name if long_option in cli_opts else key
+        if new_key.startswith('no_'):
+            new_key = new_key[3:]
         assert new_key is not None
 
         # Invert negative boolean according to the CLI

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -703,9 +703,12 @@ def _invert_negative_bool_options_in_config(
         long_option = _convert_to_long_option(key)
         new_key = cli_opts[long_option].name if long_option in cli_opts else key
         negative_option_prefix = "no_"
-        if new_key.startswith(negative_option_prefix):
-            new_key = new_key[len(negative_option_prefix):]
         assert new_key is not None
+        if (
+            new_key.startswith(negative_option_prefix)
+            and long_option not in ONLY_NEGATIVE_OPTIONS
+        ):
+            new_key = new_key[len(negative_option_prefix) :]
 
         # Invert negative boolean according to the CLI
         new_value = (

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -701,7 +701,11 @@ def _invert_negative_bool_options_in_config(
     for key, value in config.items():
         # Transform config key to its equivalent in the CLI
         long_option = _convert_to_long_option(key)
-        new_key = cli_opts[long_option].name if long_option in cli_opts else key.replace("no_", "")
+        new_key = (
+            cli_opts[long_option].name
+            if long_option in cli_opts
+            else key.replace("no_", "")
+        )
         assert new_key is not None
 
         # Invert negative boolean according to the CLI

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3481,7 +3481,7 @@ def test_invalid_cli_boolean_flag_config_option_captured(
     out = runner.invoke(cli, [req_in.as_posix(), "--config", config_file.as_posix()])
 
     assert out.exit_code == 2
-    assert "No such config key 'no_annnotate'." in out.stderr
+    assert "No such config key 'annnotate'." in out.stderr
 
 
 strip_extras_warning = (


### PR DESCRIPTION
<!--- Describe the changes here. --->
Fixes #1988 

I can say I feel quite embarrassed.

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).