### PR TITLE
Run pip-compile in env python rather than pip-tools python

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -3,19 +3,23 @@ from __future__ import annotations
 import itertools
 import os
 import shlex
+import shutil
 import sys
 import tempfile
+import typing
 from pathlib import Path
+from subprocess import run  # nosec
 from typing import IO, Any, BinaryIO, cast
 
 import click
-from build import BuildBackendException
 from build.util import project_wheel_metadata
 from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 from pyproject_hooks import default_subprocess_runner, quiet_subprocess_runner
+
+from build import BuildBackendException
 
 from .._compat import parse_requirements
 from ..cache import DependencyCache
@@ -115,7 +119,65 @@ def _determine_linesep(
 @options.config
 @options.no_config
 @options.constraint
+@typing.no_type_check
 def cli(
+    *args,
+    verbose: int,
+    quiet: int,
+    **kwargs,
+):
+    """
+    Compiles requirements.txt from requirements.in, pyproject.toml, setup.cfg,
+    or setup.py specs.
+    """
+    log.verbosity = verbose - quiet
+    current_python = sys.executable
+    log.debug(f"{current_python=}")
+    env_python = shutil.which("python")
+    log.debug(f"{env_python=}")
+    if current_python != env_python:
+        # pip-tools probably installed globally (e.g. via pipx)
+        # install pip-tools in a venv made by env_python and run it there
+        click.echo("Installing pip-tools in temporary venv...", err=True)
+        with tempfile.TemporaryDirectory(prefix="pip-tools-env-") as venv_path:
+            log.debug(f"Installing venv at {venv_path}")
+            run(  # nosec
+                [
+                    env_python,
+                    "-m",
+                    "venv",
+                    venv_path,
+                ],
+                capture_output=(not log.verbosity),
+                check=True,
+            )
+            temp_python = venv_path + "/bin/python"
+            log.debug(f"{temp_python=}")
+            run(  # nosec
+                [
+                    temp_python,
+                    "-m",
+                    "pip",
+                    "install",
+                    "pip-tools",  # TODO fix to this version of pip-tools?
+                ],
+                capture_output=(not log.verbosity),
+                check=True,
+            )
+            env = {**os.environ, "PATH": f"{venv_path}/bin:{os.environ['PATH']}"}
+            run(  # nosec
+                [
+                    "pip-compile",
+                    *sys.argv[1:],
+                ],
+                env=env,
+            )
+    else:
+        # pip-tools running in current env python
+        cli_runner(*args, verbose, quiet, **kwargs)
+
+
+def cli_runner(
     ctx: click.Context,
     verbose: int,
     quiet: int,
@@ -157,10 +219,6 @@ def cli(
     no_config: bool,
     constraint: tuple[str, ...],
 ) -> None:
-    """
-    Compiles requirements.txt from requirements.in, pyproject.toml, setup.cfg,
-    or setup.py specs.
-    """
     log.verbosity = verbose - quiet
 
     if len(src_files) == 0:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+import venv
 from textwrap import dedent
 from unittest import mock
 
@@ -32,6 +33,12 @@ backtracking_resolver_only = pytest.mark.parametrize(
     ("backtracking",),
     indirect=("current_resolver",),
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_run():
+    with mock.patch("piptools.scripts.compile.run") as mock_run:
+        yield mock_run
 
 
 @pytest.fixture(
@@ -3290,3 +3297,11 @@ def test_do_not_show_warning_on_explicit_strip_extras_option(
 
     assert out.exit_code == 0
     assert strip_extras_warning not in out.stderr
+
+
+@mock.patch("piptools.scripts.compile.cli_runner")
+def test_pip_compile_run_with_env_python(mock_cli_runner, mock_run, runner, tmpdir):
+    venv.EnvBuilder(with_pip=True, symlinks=True).create(tmpdir)
+    runner.invoke(cli, ["--verbose"], env={"PATH": f"{tmpdir}/bin"})
+    mock_run.assert_called()
+    mock_cli_runner.assert_not_called()


### PR DESCRIPTION
Resolves #1087 

Usually pip-tools is installed inside a project env and run from there. So it gets run in the same version of Python that the project is developed with. This doesn't work if pip-tools is installed somewhere else, like when installed with pipx.

The change here detects whether the currently running Python is different to the one on the PATH. Such a mismatch would probably always lead to unexpected behaviour. So in that case it creates a temporary venv with the Env Python, installs pip-tools, and runs it again there.

This approach could also be modified to allow a `python_executable` to be passed explicitly (and falling back to PATH by default), similar to how `pip-sync` is now. One could generated requirements file for multiple versions of Python (of course, you could already do it with tox, but this gives another option).

There are still some TODOs:

- Add similar behaviour to `pip-sync` (it already takes `python_executable` option, but can use env Python if not given),
- Improve the tests. It currently mocks the subprocess calls but doesn't check the calls are correct (in particular the passed env should be checked probably).

Finally, this is technically a breaking change. It's intended to resolve the `pipx` scenario (or even installed with OS package manager). I can't think of any reason why anyone would want pip-tools to run on an interpreter other than the one in the current env, but it will probably still break someone's workflow...

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
