### PR TITLE
Filter out origin ireqs for extra requirements before writing output annotations

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -295,8 +295,11 @@ class OutputWriter:
                 if src_ireq.comes_from
             }
 
-        # Filter out the origin install requirements for extras. See https://github.com/jazzband/pip-tools/issues/2003
-        if ireq.comes_from and (isinstance(ireq.comes_from, str) or ireq.comes_from.name != ireq.name):
+        # Filter out the origin install requirements for extras.
+        # See https://github.com/jazzband/pip-tools/issues/2003
+        if ireq.comes_from and (
+            isinstance(ireq.comes_from, str) or ireq.comes_from.name != ireq.name
+        ):
             required_by.add(_comes_from_as_string(ireq.comes_from))
 
         required_by |= set(getattr(ireq, "_required_by", set()))

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -295,7 +295,8 @@ class OutputWriter:
                 if src_ireq.comes_from
             }
 
-        if ireq.comes_from:
+        # Filter out the origin install requirements for extras. See https://github.com/jazzband/pip-tools/issues/2003
+        if ireq.comes_from and (isinstance(ireq.comes_from, str) or ireq.comes_from.name != ireq.name):
             required_by.add(_comes_from_as_string(ireq.comes_from))
 
         required_by |= set(getattr(ireq, "_required_by", set()))


### PR DESCRIPTION
Resolves #2003, closes #2007 

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
