### PR TITLE
Ensure consistent extras formatting in output

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
 
 from .pip_compat import (
-    PIP_VERSION,
     Distribution,
-    canonicalize_ireq,
     create_wheel_cache,
     get_dev_pkgs,
-    install_req_from_line,
     parse_requirements,
 )
 
 __all__ = [
-    "PIP_VERSION",
     "Distribution",
     "parse_requirements",
-    "install_req_from_line",
     "create_wheel_cache",
     "get_dev_pkgs",
-    "canonicalize_ireq",
 ]

--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from .pip_compat import (
     PIP_VERSION,
     Distribution,
+    canonicalize_ireq,
     create_wheel_cache,
     get_dev_pkgs,
+    install_req_from_line,
     parse_requirements,
 )
 
@@ -12,6 +14,8 @@ __all__ = [
     "PIP_VERSION",
     "Distribution",
     "parse_requirements",
+    "install_req_from_line",
     "create_wheel_cache",
     "get_dev_pkgs",
+    "canonicalize_ireq",
 ]

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import optparse
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Set, cast
+from typing import TYPE_CHECKING, Iterable, Iterator, Set, cast
 
-import pip
 from pip._internal.cache import WheelCache
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import BaseDistribution
@@ -14,15 +13,8 @@ from pip._internal.models.link import Link
 from pip._internal.network.session import PipSession
 from pip._internal.req import InstallRequirement
 from pip._internal.req import parse_requirements as _parse_requirements
-from pip._internal.req.constructors import (
-    install_req_from_line as _install_req_from_line,
-)
 from pip._internal.req.constructors import install_req_from_parsed_requirement
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import Requirement
-
-PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split(".")))
 
 # The Distribution interface has changed between pkg_resources and
 # importlib.metadata, so this compat layer allows for a consistent access
@@ -30,6 +22,8 @@ PIP_VERSION = tuple(map(int, parse_version(pip.__version__).base_version.split("
 # (and later), but is overridable. `select_backend` returns what's being used.
 if TYPE_CHECKING:
     from pip._internal.metadata.importlib import Distribution as _ImportLibDist
+
+from ..utils import PIP_VERSION, canonicalize_ireq
 
 
 @dataclass(frozen=True)
@@ -75,19 +69,6 @@ class FileLink(Link):  # type: ignore[misc]
     def file_path(self) -> str:
         # overriding the actual property to bypass some validation
         return self._url
-
-
-def canonicalize_ireq(ireq: InstallRequirement) -> None:
-    if hasattr(ireq.req, "extras") and ireq.req.extras:
-        ireq.req.extras = set(map(canonicalize_name, ireq.req.extras))
-    if hasattr(ireq, "extras") and ireq.extras:
-        ireq.extras = set(map(canonicalize_name, ireq.extras))
-
-
-def install_req_from_line(*args: Any, **kwargs: Any) -> InstallRequirement:
-    ireq = _install_req_from_line(*args, **kwargs)
-    canonicalize_ireq(ireq)
-    return ireq
 
 
 def parse_requirements(

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -23,7 +23,7 @@ from pip._vendor.pkg_resources import Requirement
 if TYPE_CHECKING:
     from pip._internal.metadata.importlib import Distribution as _ImportLibDist
 
-from ..utils import PIP_VERSION, canonicalize_ireq
+from ..utils import PIP_VERSION, copy_install_requirement
 
 
 @dataclass(frozen=True)
@@ -89,8 +89,7 @@ def parse_requirements(
             file_link = FileLink(install_req.link.url)
             file_link._url = parsed_req.requirement
             install_req.link = file_link
-        canonicalize_ireq(install_req)
-        yield install_req
+        yield copy_install_requirement(install_req)
 
 
 def create_wheel_cache(cache_dir: str, format_control: str | None = None) -> WheelCache:

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -17,7 +17,7 @@ from pip._internal.req.constructors import parse_req_from_line
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
-from .utils import canonicalize_ireq, install_req_from_line
+from .utils import copy_install_requirement, install_req_from_line
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -231,7 +231,7 @@ def _prepare_requirements(
             replaced_package_name = req.replace(package_name, str(package_dir), 1)
             parts = parse_req_from_line(replaced_package_name, comes_from)
 
-        yield canonicalize_ireq(
+        yield copy_install_requirement(
             InstallRequirement(
                 parts.requirement,
                 comes_from,

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -13,9 +13,11 @@ import build
 import build.env
 import pyproject_hooks
 from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_line, parse_req_from_line
+from pip._internal.req.constructors import parse_req_from_line
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
+
+from ._compat import canonicalize_ireq, install_req_from_line
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -229,13 +231,15 @@ def _prepare_requirements(
             replaced_package_name = req.replace(package_name, str(package_dir), 1)
             parts = parse_req_from_line(replaced_package_name, comes_from)
 
-        yield InstallRequirement(
+        ireq = InstallRequirement(
             parts.requirement,
             comes_from,
             link=parts.link,
             markers=parts.markers,
             extras=parts.extras,
         )
+        canonicalize_ireq(ireq)
+        yield ireq
 
 
 def _prepare_build_requirements(

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -17,7 +17,7 @@ from pip._internal.req.constructors import parse_req_from_line
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
-from ._compat import canonicalize_ireq, install_req_from_line
+from .utils import canonicalize_ireq, install_req_from_line
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -231,15 +231,15 @@ def _prepare_requirements(
             replaced_package_name = req.replace(package_name, str(package_dir), 1)
             parts = parse_req_from_line(replaced_package_name, comes_from)
 
-        ireq = InstallRequirement(
-            parts.requirement,
-            comes_from,
-            link=parts.link,
-            markers=parts.markers,
-            extras=parts.extras,
+        yield canonicalize_ireq(
+            InstallRequirement(
+                parts.requirement,
+                comes_from,
+                link=parts.link,
+                markers=parts.markers,
+                extras=parts.extras,
+            )
         )
-        canonicalize_ireq(ireq)
-        yield ireq
 
 
 def _prepare_build_requirements(

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -26,7 +26,7 @@ from pip._vendor.resolvelib.resolvers import ResolutionImpossible, Result
 from piptools.cache import DependencyCache
 from piptools.repositories.base import BaseRepository
 
-from ._compat import create_wheel_cache, install_req_from_line
+from ._compat import create_wheel_cache
 from .exceptions import PipToolsError
 from .logging import log
 from .utils import (
@@ -35,6 +35,7 @@ from .utils import (
     copy_install_requirement,
     format_requirement,
     format_specifier,
+    install_req_from_line,
     is_pinned_requirement,
     is_url_requirement,
     key_from_ireq,

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -14,7 +14,6 @@ from pip._internal.operations.build.build_tracker import (
     update_env_context_manager,
 )
 from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_line
 from pip._internal.resolution.resolvelib.base import Candidate
 from pip._internal.resolution.resolvelib.candidates import ExtrasCandidate
 from pip._internal.resolution.resolvelib.resolver import Resolver
@@ -27,7 +26,7 @@ from pip._vendor.resolvelib.resolvers import ResolutionImpossible, Result
 from piptools.cache import DependencyCache
 from piptools.repositories.base import BaseRepository
 
-from ._compat import create_wheel_cache
+from ._compat import create_wheel_cache, install_req_from_line
 from .exceptions import PipToolsError
 from .logging import log
 from .utils import (

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -14,7 +14,7 @@ from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
 from pip._internal.utils.misc import redact_auth_from_url
 
-from .._compat import install_req_from_line, parse_requirements
+from .._compat import parse_requirements
 from ..build import ProjectMetadata, build_project_metadata
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError
@@ -22,7 +22,13 @@ from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..repositories.base import BaseRepository
 from ..resolver import BacktrackingResolver, LegacyResolver
-from ..utils import dedup, drop_extras, is_pinned_requirement, key_from_ireq
+from ..utils import (
+    dedup,
+    drop_extras,
+    install_req_from_line,
+    is_pinned_requirement,
+    key_from_ireq,
+)
 from ..writer import OutputWriter
 from . import options
 from .options import BuildTargetT

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -12,10 +12,9 @@ import click
 from build import BuildBackendException
 from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 
-from .._compat import parse_requirements
+from .._compat import install_req_from_line, parse_requirements
 from ..build import ProjectMetadata, build_project_metadata
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -22,7 +22,6 @@ else:
 import click
 from click.utils import LazyFile
 from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_line
 from pip._internal.resolution.resolvelib.base import Requirement as PipRequirement
 from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.vcs import is_url
@@ -33,7 +32,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import get_distribution
 
-from piptools._compat import PIP_VERSION
+from piptools._compat import PIP_VERSION, install_req_from_line
 from piptools.locations import DEFAULT_CONFIG_FILE_NAMES
 from piptools.subprocess_utils import run_python_snippet
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -93,20 +93,8 @@ def comment(text: str) -> str:
     return click.style(text, fg="green")
 
 
-def canonicalize_ireq(ireq: InstallRequirement) -> InstallRequirement:
-    """
-    Return a copy of ireq with canonicalized extras strings
-    """
-    ireq = copy_install_requirement(
-        ireq, extras=set(map(canonicalize_name, ireq.extras))
-    )
-    if ireq.req:
-        ireq.req.extras = set(ireq.extras)
-    return ireq
-
-
 def install_req_from_line(*args: Any, **kwargs: Any) -> InstallRequirement:
-    return canonicalize_ireq(_install_req_from_line(*args, **kwargs))
+    return copy_install_requirement(_install_req_from_line(*args, **kwargs))
 
 
 def make_install_requirement(
@@ -535,6 +523,10 @@ def copy_install_requirement(
     # Copy template.req if not specified in extra kwargs.
     if "req" not in kwargs:
         kwargs["req"] = copy.deepcopy(template.req)
+
+    kwargs["extras"] = set(map(canonicalize_name, kwargs["extras"]))
+    if kwargs["req"]:
+        kwargs["req"].extras = set(kwargs["extras"])
 
     ireq = InstallRequirement(**kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from pip._internal.utils.direct_url_helpers import direct_url_from_link
 from pip._vendor.packaging.version import Version
 from pip._vendor.pkg_resources import Requirement
 
-from piptools._compat import PIP_VERSION, Distribution
+from piptools._compat import Distribution
 from piptools.cache import DependencyCache
 from piptools.exceptions import NoCandidateFound
 from piptools.locations import DEFAULT_CONFIG_FILE_NAMES
@@ -37,6 +37,7 @@ from piptools.repositories import PyPIRepository
 from piptools.repositories.base import BaseRepository
 from piptools.resolver import BacktrackingResolver, LegacyResolver
 from piptools.utils import (
+    PIP_VERSION,
     as_tuple,
     is_url_requirement,
     key_from_ireq,


### PR DESCRIPTION
This aims to resolve the discussion in #2004, ~~and is a WIP~~ (all contributions or alternatives are welcome).

<!--- Describe the changes here. --->

~~`_compat`~~ **`utils`** now exports `install_req_from_line` ~~and `canonicalize_ireq`~~ for other modules to use. **This uses our `copy_install_requirement` which is updated to canonicalize extra strings.**

~~As of now, `canonicalize_ireq` only affects the extras attributes, as that's all we need. So it may be poorly named 🤷🏼~~

~~No tests yet.~~

To avoid circular imports, this relocates `PIP_VERSION` from `_compat` to `utils`, as IMO `utils` should be importable by as many other piptools modules as possible.

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
