### PR TITLE
Fix for `src-files` not being used when specified in a config file

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -171,9 +171,9 @@ def cli(
         ctx.color = color
     log.verbosity = verbose - quiet
 
-    # If `src-files` was not provided as input, but rather as config,
-    # it will be part of the click Context `ctx`.
-    # However, is `src_files` is specified, then we want to use that.
+    # If ``src-files` was not provided as an input, but rather as config,
+    # it will be part of the click context ``ctx``.
+    # However, if ``src_files`` is specified, then we want to use that.
     if not src_files and ctx.default_map and "src_files" in ctx.default_map:
         src_files = ctx.default_map["src_files"]
 

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -171,8 +171,10 @@ def cli(
         ctx.color = color
     log.verbosity = verbose - quiet
 
-    # src-files provided in a config file
-    if ctx.default_map and "src_files" in ctx.default_map:
+    # If `src-files` was not provided as input, but rather as config,
+    # it will be part of the click Context `ctx`.
+    # However, is `src_files` is specified, then we want to use that.
+    if not src_files and ctx.default_map and "src_files" in ctx.default_map:
         src_files = ctx.default_map["src_files"]
 
     if all_build_deps and build_deps_targets:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -171,6 +171,10 @@ def cli(
         ctx.color = color
     log.verbosity = verbose - quiet
 
+    # src-files provided in a config file
+    if ctx.default_map and "src_files" in ctx.default_map:
+        src_files = ctx.default_map["src_files"]
+
     if all_build_deps and build_deps_targets:
         raise click.BadParameter(
             "--build-deps-for has no effect when used with --all-build-deps"

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3447,6 +3447,47 @@ def test_allow_in_config_pip_sync_option(pip_conf, runner, tmp_path, make_config
     assert "Using pip-tools configuration defaults found" in out.stderr
 
 
+def test_use_src_files_from_config_if_option_is_not_specified_from_cli(pip_conf, runner, tmp_path, make_config_file):
+    foo_in = tmp_path / "foo.in"
+    req_in = tmp_path / "requirements.in"
+
+    config_file = make_config_file("src-files", [foo_in.as_posix()])
+
+    with open(req_in, "w") as f:
+        f.write("small-fake-a==0.1")
+    
+    with open(foo_in, "w") as f:
+        f.write("small-fake-b==0.1")
+
+    out = runner.invoke(
+        cli, ["--config", config_file.as_posix()]
+    )
+
+    assert out.exit_code == 0
+    assert "small-fake-b" in out.stderr
+    assert "small-fake-a" not in out.stderr
+
+
+def test_use_src_files_from_cli_if_option_is_specified_in_both_config_and_cli(pip_conf, runner, tmp_path, make_config_file):
+    foo_in = tmp_path / "foo.in"
+    req_in = tmp_path / "requirements.in"
+
+    config_file = make_config_file("src-files", [foo_in.as_posix()])
+
+    with open(req_in, "w") as f:
+        f.write("small-fake-a==0.1")
+    
+    with open(foo_in, "w") as f:
+        f.write("small-fake-b==0.1")
+
+    out = runner.invoke(
+        cli, [req_in.as_posix(), "--config", config_file.as_posix()]
+    )
+
+    assert out.exit_code == 0
+    assert "small-fake-a" in out.stderr
+    assert "small-fake-b" not in out.stderr
+
 def test_cli_boolean_flag_config_option_has_valid_context(
     pip_conf, runner, tmp_path, make_config_file
 ):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3447,7 +3447,9 @@ def test_allow_in_config_pip_sync_option(pip_conf, runner, tmp_path, make_config
     assert "Using pip-tools configuration defaults found" in out.stderr
 
 
-def test_use_src_files_from_config_if_option_is_not_specified_from_cli(pip_conf, runner, tmp_path, make_config_file):
+def test_use_src_files_from_config_if_option_is_not_specified_from_cli(
+    pip_conf, runner, tmp_path, make_config_file
+):
     foo_in = tmp_path / "foo.in"
     req_in = tmp_path / "requirements.in"
 
@@ -3455,20 +3457,20 @@ def test_use_src_files_from_config_if_option_is_not_specified_from_cli(pip_conf,
 
     with open(req_in, "w") as f:
         f.write("small-fake-a==0.1")
-    
+
     with open(foo_in, "w") as f:
         f.write("small-fake-b==0.1")
 
-    out = runner.invoke(
-        cli, ["--config", config_file.as_posix()]
-    )
+    out = runner.invoke(cli, ["--config", config_file.as_posix()])
 
     assert out.exit_code == 0
     assert "small-fake-b" in out.stderr
     assert "small-fake-a" not in out.stderr
 
 
-def test_use_src_files_from_cli_if_option_is_specified_in_both_config_and_cli(pip_conf, runner, tmp_path, make_config_file):
+def test_use_src_files_from_cli_if_option_is_specified_in_both_config_and_cli(
+    pip_conf, runner, tmp_path, make_config_file
+):
     foo_in = tmp_path / "foo.in"
     req_in = tmp_path / "requirements.in"
 
@@ -3476,17 +3478,16 @@ def test_use_src_files_from_cli_if_option_is_specified_in_both_config_and_cli(pi
 
     with open(req_in, "w") as f:
         f.write("small-fake-a==0.1")
-    
+
     with open(foo_in, "w") as f:
         f.write("small-fake-b==0.1")
 
-    out = runner.invoke(
-        cli, [req_in.as_posix(), "--config", config_file.as_posix()]
-    )
+    out = runner.invoke(cli, [req_in.as_posix(), "--config", config_file.as_posix()])
 
     assert out.exit_code == 0
     assert "small-fake-a" in out.stderr
     assert "small-fake-b" not in out.stderr
+
 
 def test_cli_boolean_flag_config_option_has_valid_context(
     pip_conf, runner, tmp_path, make_config_file

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3455,15 +3455,12 @@ def test_use_src_files_from_config_if_option_is_not_specified_from_cli(
 
     config_file = make_config_file("src-files", [foo_in.as_posix()])
 
-    with open(req_in, "w") as f:
-        f.write("small-fake-a==0.1")
-
-    with open(foo_in, "w") as f:
-        f.write("small-fake-b==0.1")
+    req_in.write_text("small-fake-a==0.1", encoding="utf-8")
+    foo_in.write_text("small-fake-b==0.1", encoding="utf-8")
 
     out = runner.invoke(cli, ["--config", config_file.as_posix()])
 
-    assert out.exit_code == 0
+    assert out.exit_code == 0, out
     assert "small-fake-b" in out.stderr
     assert "small-fake-a" not in out.stderr
 
@@ -3476,15 +3473,12 @@ def test_use_src_files_from_cli_if_option_is_specified_in_both_config_and_cli(
 
     config_file = make_config_file("src-files", [foo_in.as_posix()])
 
-    with open(req_in, "w") as f:
-        f.write("small-fake-a==0.1")
-
-    with open(foo_in, "w") as f:
-        f.write("small-fake-b==0.1")
+    req_in.write_text("small-fake-a==0.1", encoding="utf-8")
+    foo_in.write_text("small-fake-b==0.1", encoding="utf-8")
 
     out = runner.invoke(cli, [req_in.as_posix(), "--config", config_file.as_posix()])
 
-    assert out.exit_code == 0
+    assert out.exit_code == 0, out
     assert "small-fake-a" in out.stderr
     assert "small-fake-b" not in out.stderr
 


### PR DESCRIPTION
This PR fixes https://github.com/jazzband/pip-tools/issues/2006

`src-files` is found in the click context, `ctx`, but however is not populating the variable `src_files`, so that it is an empty tuple.
For this reason, the tool will then start to select a requirement file, as shown in the linked issue.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
