### PR TITLE
Makes `compile` and `sync` directly runnable as modules

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -521,3 +521,7 @@ def cli(
 
     if dry_run:
         log.info("Dry-run, so nothing updated.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -251,3 +251,7 @@ def _get_installed_distributions(
         skip=[],
     )
     return [Distribution.from_pip_distribution(dist) for dist in dists]
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
<!--- Describe the changes here. --->

Before:

```bash
> python -m piptools.scripts.compile --help
```

After:

```bash
> python -m piptools.scripts.compile --help
Usage: python -m piptools.scripts.compile [OPTIONS] [SRC_FILES]...

  Compiles requirements.txt from requirements.in, pyproject.toml, setup.cfg,
  or setup.py specs.

Options:
  --version                       Show the version and exit.
...
```

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
