### PR TITLE
Absolute imports over relative imports

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -15,18 +15,18 @@ from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import redact_auth_from_url
 
-from .._compat import parse_requirements
-from ..build import build_project_metadata
-from ..cache import DependencyCache
-from ..exceptions import NoCandidateFound, PipToolsError
-from ..logging import log
-from ..repositories import LocalRequirementsRepository, PyPIRepository
-from ..repositories.base import BaseRepository
-from ..resolver import BacktrackingResolver, LegacyResolver
-from ..utils import dedup, drop_extras, is_pinned_requirement, key_from_ireq
-from ..writer import OutputWriter
-from . import options
-from .options import BuildTargetT
+import piptools.scripts.options as options
+from piptools._compat import parse_requirements
+from piptools.build import build_project_metadata
+from piptools.cache import DependencyCache
+from piptools.exceptions import NoCandidateFound, PipToolsError
+from piptools.logging import log
+from piptools.repositories import LocalRequirementsRepository, PyPIRepository
+from piptools.repositories.base import BaseRepository
+from piptools.resolver import BacktrackingResolver, LegacyResolver
+from piptools.scripts.options import BuildTargetT
+from piptools.utils import dedup, drop_extras, is_pinned_requirement, key_from_ireq
+from piptools.writer import OutputWriter
 
 DEFAULT_REQUIREMENTS_FILES = (
     "requirements.in",

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -14,18 +14,18 @@ from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_environment
 
-from .. import sync
-from .._compat import Distribution, parse_requirements
-from ..exceptions import PipToolsError
-from ..logging import log
-from ..repositories import PyPIRepository
-from ..utils import (
+import piptools.scripts.options as options
+import piptools.sync as sync
+from piptools._compat import Distribution, parse_requirements
+from piptools.exceptions import PipToolsError
+from piptools.logging import log
+from piptools.repositories import PyPIRepository
+from piptools.utils import (
     flat_map,
     get_pip_version_for_python_executable,
     get_required_pip_specification,
     get_sys_path_for_python_executable,
 )
-from . import options
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
 


### PR DESCRIPTION
Trying to test `__main__` code per [this comment](https://github.com/jazzband/pip-tools/pull/2022#issuecomment-1821103433), it seems the best way is to use `importlib` as [instructed here](https://stackoverflow.com/a/19011259).

However, `importlib.machinery` doesn't play nice with relative imports.  So this PR moves the internals to use absolute imports.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
