### PR TITLE
Skip constraint path check

### DIFF
--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -343,14 +343,6 @@ no_config = click.option(
 constraint = click.option(
     "-c",
     "--constraint",
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=False,
-        readable=True,
-        allow_dash=False,
-        path_type=str,
-    ),
     multiple=True,
     help="Constrain versions using the given constraints file; may be used more than once.",
 )


### PR DESCRIPTION
<!--- Describe the changes here. --->
`pip` can read constraint file via HTTP so `pip-compile` doesn't need to restrict that to a local file. Removing the option type makes it a plain string so users can pass in an URL. This of course skip local file validation, but the compilation would fail anyway if the file is not readable, no matter local or remote.

Closes #2040

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
