### PR TITLE
Add a test which checks that fifos outputs are not read

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3585,7 +3585,7 @@ def test_stdout_should_not_be_read_when_stdin_is_not_a_plain_file(
     runner,
     tmp_path,
 ):
-    parse_req.side_effect = AssertionError("Must not be called when output is a fifo")
+    parse_req.side_effect = pytest.fail("Must not be called when output is a fifo")
 
     req_in = tmp_path / "requirements.txt"
     req_in.touch()

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3564,7 +3564,6 @@ def test_origin_of_extra_requirement_not_written_to_annotations(
     )
 
 
-
 def test_tool_specific_config_option(pip_conf, runner, tmp_path, make_config_file):
     config_file = make_config_file(
         "dry-run", True, section="pip-tools", subsection="compile"
@@ -3581,11 +3580,10 @@ def test_tool_specific_config_option(pip_conf, runner, tmp_path, make_config_fil
 
 @mock.patch("piptools.scripts.compile.parse_requirements")
 def test_stdout_should_not_be_read_when_stdin_is_not_a_plain_file(
-         parse_req,
-         runner,
-         tmp_path,
-    ):
-
+    parse_req,
+    runner,
+    tmp_path,
+):
     parse_req.side_effect = AssertionError("Must not be called when output is a fifo")
 
     req_in = tmp_path / "requirements.txt"
@@ -3598,4 +3596,3 @@ def test_stdout_should_not_be_read_when_stdin_is_not_a_plain_file(
     out = runner.invoke(cli, [req_in.as_posix(), "--output-file", fifo.as_posix()])
 
     assert out.exit_code == 0, out
-

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3585,7 +3585,9 @@ def test_stdout_should_not_be_read_when_stdin_is_not_a_plain_file(
     runner,
     tmp_path,
 ):
-    parse_req.side_effect = lambda fname, finder, options, session: pytest.fail("Must not be called when output is a fifo")
+    parse_req.side_effect = lambda fname, finder, options, session: pytest.fail(
+        "Must not be called when output is a fifo"
+    )
 
     req_in = tmp_path / "requirements.txt"
     req_in.touch()

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3585,7 +3585,7 @@ def test_stdout_should_not_be_read_when_stdin_is_not_a_plain_file(
     runner,
     tmp_path,
 ):
-    parse_req.side_effect = pytest.fail("Must not be called when output is a fifo")
+    parse_req.side_effect = lambda fname, finder, options, session: pytest.fail("Must not be called when output is a fifo")
 
     req_in = tmp_path / "requirements.txt"
     req_in.touch()

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3578,6 +3578,7 @@ def test_tool_specific_config_option(pip_conf, runner, tmp_path, make_config_fil
     assert "Dry-run, so nothing updated" in out.stderr
 
 
+@pytest.mark.xfail(reason="https://github.com/jazzband/pip-tools/issues/2012")
 @mock.patch("piptools.scripts.compile.parse_requirements")
 def test_stdout_should_not_be_read_when_stdin_is_not_a_plain_file(
     parse_req,


### PR DESCRIPTION


<!--- Describe the changes here. --->

Requested by @webknjaz, here is a test that currently fail for the issue #2012.

##### Contributor checklist

- [X] Included tests for the changes.
- [X] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
