### PR TITLE
Allow force-enabling or force-disabling colorized output

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -74,6 +74,7 @@ def _determine_linesep(
 )
 @click.pass_context
 @options.version
+@options.color
 @options.verbose
 @options.quiet
 @options.dry_run
@@ -118,6 +119,7 @@ def _determine_linesep(
 @options.only_build_deps
 def cli(
     ctx: click.Context,
+    color: bool | None,
     verbose: int,
     quiet: int,
     dry_run: bool,
@@ -165,6 +167,8 @@ def cli(
     Compiles requirements.txt from requirements.in, pyproject.toml, setup.cfg,
     or setup.py specs.
     """
+    if color is not None:
+        ctx.color = color
     log.verbosity = verbose - quiet
 
     if all_build_deps and build_deps_targets:

--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -33,6 +33,12 @@ help_option_names = ("-h", "--help")
 
 version = click.version_option(package_name="pip-tools")
 
+color = click.option(
+    "--color/--no-color",
+    default=None,
+    help="Force output to be colorized or not, instead of auto-detecting color support",
+)
+
 verbose = click.option(
     "-v",
     "--verbose",


### PR DESCRIPTION
<!--- Describe the changes here. --->
`click` allows emitted colored text via `click.style`,
which is used by pip-compile to emit colorized e.g. comments to stderr.
click uses auto-detection to only enable colors when writing to a TTY.

At Lyft, we operate pip-compile as a service:
pip-compile invocations are forwarded to a set of remote machines,
which leverage a shared cache for much faster compiles.
However, they run pip-compile as a subprocess without a TTY attached
meaning the output we stream back to the user is not colorized.

Therefore, add a `--color` and matching `--no-color` argument
to force-enable as well as force-disable color
(the default remains click's auto-detection).
This could also be used for e.g. running pip-compile in CI.

AFAIK pip-sync does not emit colored output,
so I did not add the `--color/--no-color` options there.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
