### PR TITLE
Fix config file search and inclusion in header

### DIFF
--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -245,6 +245,7 @@ max_rounds = click.option(
 src_files = click.argument(
     "src_files",
     nargs=-1,
+    is_eager=True,
     type=click.Path(exists=True, allow_dash=True),
 )
 
@@ -328,7 +329,6 @@ config = click.option(
         f"Read configuration from TOML file. By default, looks for the following "
         f"files in the given order: {', '.join(DEFAULT_CONFIG_FILE_NAMES)}."
     ),
-    is_eager=True,
     callback=override_defaults_from_config_file,
 )
 

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -630,7 +630,7 @@ def select_config_file(src_files: tuple[str, ...]) -> Path | None:
     # NOTE: input.
     working_directory = Path.cwd()
     src_files_as_paths = (
-        (working_directory / src_file).resolve() for src_file in src_files or (".",)
+        (working_directory / src_file).resolve() for src_file in src_files + (".",)
     )
     candidate_dirs = (src if src.is_dir() else src.parent for src in src_files_as_paths)
     config_file_path = next(


### PR DESCRIPTION
Just stumbled over this issue again, so I thought I might as well fix it.

Closes #1902

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
