### PR TITLE
Activate prettier-plugin-toml for pre-commit hooks

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -3,3 +3,5 @@ overrides:
   - files: "CHANGELOG.md"
     options:
       proseWrap: always
+plugins:
+  - "prettier-plugin-toml"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ dynamic = ["dependencies", "optional-dependencies"]
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.in"] }
 optional-dependencies.test = { file = ["requirements-test.txt"] }
-
 ```
 
 If you have a Django application that is packaged using `Hatch`, and you

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "tomli; python_version < '3.11'",
   # indirect dependencies
   "setuptools", # typically needed when pip-tools invokes setup.py
-  "wheel", # pip plugin needed by pip-tools
+  "wheel",      # pip plugin needed by pip-tools
 
 ]
 

--- a/tests/test_data/packages/small_fake_with_build_deps/pyproject.toml
+++ b/tests/test_data/packages/small_fake_with_build_deps/pyproject.toml
@@ -1,4 +1,8 @@
 [build-system]
-requires = ["setuptools==68.1.2", "wheel==0.41.1", "fake_static_build_dep"]
+requires = [ # prettier-ignore
+  "setuptools==68.1.2",
+  "wheel==0.41.1",
+  "fake_static_build_dep",
+]
 build-backend = "backend"
 backend-path = ["backend"]

--- a/tests/test_data/packages/small_fake_with_build_deps/pyproject.toml
+++ b/tests/test_data/packages/small_fake_with_build_deps/pyproject.toml
@@ -1,8 +1,4 @@
 [build-system]
-requires = [
-    "setuptools==68.1.2",
-    "wheel==0.41.1",
-    "fake_static_build_dep"
-]
+requires = ["setuptools==68.1.2", "wheel==0.41.1", "fake_static_build_dep"]
 build-backend = "backend"
 backend-path = ["backend"]


### PR DESCRIPTION
In the pre-commit hook, the plugin prettier-plugin-toml is installed, but not used.
Plugins must be loaded either via CLI command `--plugin` or in the configuration file.
As there is a configuration file in this project anyways, I added the plugin there.

For more information, see [prettier docs](https://prettier.io/docs/en/plugins#using-plugins).

##### Contributor checklist

- [ ] ~Included tests for the changes.~
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
