### PR TITLE
Fix failing test on pip-24.0

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -420,8 +420,9 @@ def test_emit_index_url_option(runner, option, expected_output):
 
 
 @pytest.mark.network
-def test_realistic_complex_sub_dependencies(runner):
-    wheels_dir = "wheels"
+def test_realistic_complex_sub_dependencies(runner, tmp_path):
+    wheels_dir = tmp_path / "wheels"
+    wheels_dir.mkdir()
 
     # make a temporary wheel of a fake package
     subprocess.run(
@@ -439,7 +440,7 @@ def test_realistic_complex_sub_dependencies(runner):
     with open("requirements.in", "w") as req_in:
         req_in.write("fake_with_deps")  # require fake package
 
-    out = runner.invoke(cli, ["-n", "--rebuild", "-f", wheels_dir])
+    out = runner.invoke(cli, ["-n", "--rebuild", "-f", wheels_dir.as_posix()])
 
     assert out.exit_code == 0
 


### PR DESCRIPTION
Proper isolation helps to fix flaky tests.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
