### PR TITLE
Fix `pip-compile` to properly exclude non-relevant options from output header

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -371,9 +371,14 @@ def get_compile_command(click_ctx: click.Context) -> str:
         # Get the latest option name (usually it'll be a long name)
         option_long_name = option.opts[-1]
 
+        negative_option = None
+        if option.is_flag and option.secondary_opts:
+            # get inverse flag --no-{option_long_name}
+            negative_option = option.secondary_opts[-1]
+
         # Exclude one-off options (--upgrade/--upgrade-package/--rebuild/...)
         # or options that don't change compile behaviour (--verbose/--dry-run/...)
-        if option_long_name in COMPILE_EXCLUDE_OPTIONS:
+        if {option_long_name, negative_option} & COMPILE_EXCLUDE_OPTIONS:
             continue
 
         # Exclude config option if it's the default one

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -374,6 +374,8 @@ def test_is_url_requirement_filename(caplog, from_line, line):
         (["--upgrade"], "pip-compile"),
         (["-P", "django"], "pip-compile"),
         (["--upgrade-package", "django"], "pip-compile"),
+        (["--reuse-hashes"], "pip-compile"),
+        (["--no-reuse-hashes"], "pip-compile"),
         # Check options
         (["--max-rounds", "42"], "pip-compile --max-rounds=42"),
         (["--index-url", "https://foo"], "pip-compile --index-url=https://foo"),


### PR DESCRIPTION
Fixes #2065

Click context only had positive --reuse-hashes to loop over, inverse is automatically deduced.

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
