### PR TITLE
Allow build deps as long as at least one setup file is in sources list.

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -332,13 +332,6 @@ def cli(
     setup_file_found = False
     for src_file in src_files:
         is_setup_file = os.path.basename(src_file) in METADATA_FILENAMES
-        if not is_setup_file and build_deps_targets:
-            msg = (
-                "--build-deps-for and --all-build-deps can be used only with the "
-                "setup.py, setup.cfg and pyproject.toml specs."
-            )
-            raise click.BadParameter(msg)
-
         if src_file == "-":
             # pip requires filenames and not files. Since we want to support
             # piping from stdin, we need to briefly save the input from stdin
@@ -428,6 +421,13 @@ def cli(
 
     if extras and not setup_file_found:
         msg = "--extra has effect only with setup.py and PEP-517 input formats"
+        raise click.BadParameter(msg)
+
+    if build_deps_targets and not setup_file_found:
+        msg = (
+            "--build-deps-for and --all-build-deps can be used only with the "
+            "setup.py, setup.cfg and pyproject.toml specs."
+        )
         raise click.BadParameter(msg)
 
     primary_packages = {

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -2964,6 +2964,55 @@ def test_build_deps_fail_without_setup_file(runner, tmpdir, option):
     assert exp in out.stderr
 
 
+@backtracking_resolver_only
+@pytest.mark.parametrize("option", ("--all-build-deps", "--build-deps-for=wheel"))
+def test_build_deps_does_not_error_when_setup_included_with_multiple_source_files(
+    fake_dists_with_build_deps,
+    runner,
+    tmp_path,
+    monkeypatch,
+    current_resolver,
+    option,
+):
+    """
+    Test that passing ``--build-deps-for`` or ``--all-build-deps`` does not emit an
+    error as long as at least one file in the sources list is a setup file.
+    """
+    src_pkg_path = pathlib.Path(PACKAGES_PATH) / "small_fake_with_build_deps"
+    # When used as argument to the runner it is not passed to pip
+    monkeypatch.setenv("PIP_FIND_LINKS", fake_dists_with_build_deps)
+
+    requirements_path = pathlib.Path(tmp_path) / "requirements.in"
+    requirements_path.write_text("\n")
+
+    pyproject_toml_path = pathlib.Path(tmp_path) / "pyproject.toml"
+    pyproject_toml_path.write_text("\n")
+
+    with runner.isolated_filesystem(tmp_path) as tmp_pkg_path:
+        shutil.copytree(src_pkg_path, tmp_pkg_path, dirs_exist_ok=True)
+        out = runner.invoke(
+            cli,
+            [
+                "--allow-unsafe",
+                "--output-file",
+                "-",
+                "--quiet",
+                "--no-emit-options",
+                "--no-header",
+                option,
+                os.fspath(requirements_path),
+                os.fspath(pyproject_toml_path)
+            ],
+        )
+
+    exp = (
+        "--build-deps-for and --all-build-deps can be used only with the "
+        "setup.py, setup.cfg and pyproject.toml specs."
+    )
+    assert exp not in out.stderr
+    assert out.exit_code == 0
+
+
 def test_extras_fail_with_requirements_in(runner, tmpdir):
     """
     Test that passing ``--extra`` with ``requirements.in`` input file fails.

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3050,7 +3050,7 @@ def test_build_deps_does_not_error_when_multiple_setup_included_in_source_files(
                 "--no-header",
                 option,
                 os.fspath(pyproject_toml_path),
-                os.fspath(pyproject_toml_2_path)
+                os.fspath(pyproject_toml_2_path),
             ],
         )
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3001,7 +3001,7 @@ def test_build_deps_does_not_error_when_setup_included_with_multiple_source_file
                 "--no-header",
                 option,
                 os.fspath(requirements_path),
-                os.fspath(pyproject_toml_path)
+                os.fspath(pyproject_toml_path),
             ],
         )
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3025,7 +3025,7 @@ def test_build_deps_does_not_error_when_multiple_setup_included_in_source_files(
 ):
     """
     Test that passing ``--build-deps-for`` or ``--all-build-deps`` does not emit an
-    error as long as at least one file in the sources list is a setup file.
+    error as long when multiple setup files are included in the source files list.
     """
     src_pkg_path = pathlib.Path(PACKAGES_PATH) / "small_fake_with_build_deps"
     # When used as argument to the runner it is not passed to pip
@@ -3050,7 +3050,7 @@ def test_build_deps_does_not_error_when_multiple_setup_included_in_source_files(
                 "--no-header",
                 option,
                 os.fspath(pyproject_toml_path),
-                os.fspath(pyproject_toml_2_path)
+                os.fspath(pyproject_toml_2_path),
             ],
         )
 


### PR DESCRIPTION
Resolves [2076](https://github.com/jazzband/pip-tools/issues/2076).

Passing ``--build-deps-for`` or ``--all-build-deps`` should not emit an error as long as at least one file in the sources list is a setup file.

Using `pip-compile --all-build-deps requirments.in pyproject.toml` gives the error `--build-deps-for and --all-build-deps can be used only with the setup.py, setup.cfg and pyproject.toml specs.`.

According to the help, using multiple source files is valid, so any options that apply to at least one source file should be allowed as long as that option does not cause a conflict.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
