### PR TITLE
Fix ordering of format controls to preserve behavior of pip

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -309,9 +309,7 @@ def test_write_format_controls_all(writer):
 
     # We want to preserve the FormatControl behavior
     # so we emit :all: first before packages.
-    writer.format_control = FormatControl(
-        no_binary=[":all:"], only_binary=["django"]
-    )
+    writer.format_control = FormatControl(no_binary=[":all:"], only_binary=["django"])
     lines = list(writer.write_format_controls())
 
     expected_lines = [
@@ -320,9 +318,7 @@ def test_write_format_controls_all(writer):
     ]
     assert lines == expected_lines
 
-    writer.format_control = FormatControl(
-        no_binary=["django"], only_binary=[":all:"]
-    )
+    writer.format_control = FormatControl(no_binary=["django"], only_binary=[":all:"])
     lines = list(writer.write_format_controls())
 
     expected_lines = [

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -301,30 +301,38 @@ def test_write_format_controls(writer):
     assert lines == expected_lines
 
 
-def test_write_format_controls_all(writer):
+@pytest.mark.parametrize(
+    ["no_binary", "only_binary", "expected_lines"],
+    [
+        (
+            [":all:"],
+            ["django"],
+            [
+                "--no-binary :all:",
+                "--only-binary django",
+            ],
+        ),
+        (
+            ["django"],
+            [":all:"],
+            [
+                "--only-binary :all:",
+                "--no-binary django",
+            ],
+        ),
+    ],
+)
+def test_write_format_controls_all(writer, no_binary, only_binary, expected_lines):
     """
     Tests --no-binary/--only-binary options
-    with the value of :all:
+    with the value of :all:. We want to preserve
+    the FormatControl behavior so we emit :all:
+    first before packages.
     """
 
-    # We want to preserve the FormatControl behavior
-    # so we emit :all: first before packages.
-    writer.format_control = FormatControl(no_binary=[":all:"], only_binary=["django"])
+    writer.format_control = FormatControl(no_binary=no_binary, only_binary=only_binary)
     lines = list(writer.write_format_controls())
 
-    expected_lines = [
-        "--no-binary :all:",
-        "--only-binary django",
-    ]
-    assert lines == expected_lines
-
-    writer.format_control = FormatControl(no_binary=["django"], only_binary=[":all:"])
-    lines = list(writer.write_format_controls())
-
-    expected_lines = [
-        "--only-binary :all:",
-        "--no-binary django",
-    ]
     assert lines == expected_lines
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -302,8 +302,8 @@ def test_write_format_controls(writer):
 
 
 @pytest.mark.parametrize(
-    ["no_binary", "only_binary", "expected_lines"],
-    [
+    ("no_binary", "only_binary", "expected_lines"),
+    (
         (
             [":all:"],
             ["django"],
@@ -320,7 +320,7 @@ def test_write_format_controls(writer):
                 "--no-binary django",
             ],
         ),
-    ],
+    ),
 )
 def test_write_format_controls_all(writer, no_binary, only_binary, expected_lines):
     """

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -301,6 +301,37 @@ def test_write_format_controls(writer):
     assert lines == expected_lines
 
 
+def test_write_format_controls_all(writer):
+    """
+    Tests --no-binary/--only-binary options
+    with the value of :all:
+    """
+
+    # We want to preserve the FormatControl behavior
+    # so we emit :all: first before packages.
+    writer.format_control = FormatControl(
+        no_binary=[":all:"], only_binary=["django"]
+    )
+    lines = list(writer.write_format_controls())
+
+    expected_lines = [
+        "--no-binary :all:",
+        "--only-binary django",
+    ]
+    assert lines == expected_lines
+
+    writer.format_control = FormatControl(
+        no_binary=["django"], only_binary=[":all:"]
+    )
+    lines = list(writer.write_format_controls())
+
+    expected_lines = [
+        "--only-binary :all:",
+        "--no-binary django",
+    ]
+    assert lines == expected_lines
+
+
 @pytest.mark.parametrize(
     ("index_urls", "expected_lines"),
     (


### PR DESCRIPTION
<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Closes #2081 