### PR TITLE
Fixes for failing linting checks

### DIFF
--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -64,7 +64,8 @@ class Distribution:
         return cls(dist._dist.name, dist._dist.version, requires, dist.direct_url)
 
 
-class FileLink(Link):
+class FileLink(Link):  # type: ignore[misc]
+    _url: str
 
     @property
     def file_path(self) -> str:

--- a/tests/test_pip_compat.py
+++ b/tests/test_pip_compat.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-import os
-import tempfile
 from pathlib import Path, PurePosixPath
 
-import pytest
-
 from piptools._compat.pip_compat import parse_requirements
-from piptools.repositories import PyPIRepository
 
 from .constants import PACKAGES_RELATIVE_PATH
 


### PR DESCRIPTION
This fixes lint failures introduced in #2087

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
