### PR TITLE
Run pre-commit for changes to pyproject.toml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
   description: Automatically compile requirements.
   entry: pip-compile
   language: python
-  files: ^requirements\.(in|txt)$
+  files: ^pyproject\.toml|requirements\.(in|txt)$
   pass_filenames: false


### PR DESCRIPTION
The pre-commit hook should run when a git change includes edits to a pyproject.toml file, because that file may be used for listing a project's dependencies.

No tests were updated.