### PR TITLE
Add compat modules for `tomllib` and `importlib.metadata`

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .importlib_metadata import PackageMetadata
 from .pip_compat import (
     Distribution,
     create_wheel_cache,
@@ -12,4 +13,5 @@ __all__ = [
     "parse_requirements",
     "create_wheel_cache",
     "get_dev_pkgs",
+    "PackageMetadata",
 ]

--- a/piptools/_compat/importlib_metadata.py
+++ b/piptools/_compat/importlib_metadata.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import PackageMetadata
+else:
+    from typing import Any, Protocol, TypeVar, overload
+
+    _T = TypeVar("_T")
+
+    class PackageMetadata(Protocol):
+        @overload
+        def get_all(self, name: str, failobj: None = None) -> list[Any] | None: ...
+
+        @overload
+        def get_all(self, name: str, failobj: _T) -> list[Any] | _T: ...

--- a/piptools/_compat/tomllib.py
+++ b/piptools/_compat/tomllib.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from tomllib import TOMLDecodeError, load, loads
+else:
+    from tomli import TOMLDecodeError, load, loads
+
+
+__all__ = ["loads", "load", "TOMLDecodeError"]

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import collections
 import contextlib
 import pathlib
-import sys
 import tempfile
 from dataclasses import dataclass
 from importlib import metadata as importlib_metadata
-from typing import Any, Iterator, Protocol, TypeVar, overload
+from typing import Iterator
 
 import build
 import build.env
@@ -17,28 +16,10 @@ from pip._internal.req.constructors import parse_req_from_line
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
+from ._compat import PackageMetadata, tomllib
 from .utils import copy_install_requirement, install_req_from_line
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
-
 PYPROJECT_TOML = "pyproject.toml"
-
-_T = TypeVar("_T")
-
-
-if sys.version_info >= (3, 10):
-    from importlib.metadata import PackageMetadata
-else:
-
-    class PackageMetadata(Protocol):
-        @overload
-        def get_all(self, name: str, failobj: None = None) -> list[Any] | None: ...
-
-        @overload
-        def get_all(self, name: str, failobj: _T) -> list[Any] | _T: ...
 
 
 @dataclass

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -8,19 +8,12 @@ import json
 import os
 import re
 import shlex
-import sys
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, TypeVar, cast
 
-from click.core import ParameterSource
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
-
 import click
 import pip
+from click.core import ParameterSource
 from click.utils import LazyFile
 from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import (
@@ -39,6 +32,8 @@ from pip._vendor.pkg_resources import get_distribution
 
 from piptools.locations import DEFAULT_CONFIG_FILE_NAMES
 from piptools.subprocess_utils import run_python_snippet
+
+from ._compat import tomllib
 
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")


### PR DESCRIPTION
The conditional backports increased, thus I added two compatibility modules.

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
