### PR TITLE
WIP: Handle broken metadata by discarding package, or give a useful error

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -673,10 +673,12 @@ class BacktrackingResolver(BaseResolver):
 
         except MetadataGenerationFailed as err:
             # Find (part of) broken package name in the error message
-            match = re.search('name\s*=\s*"(\w+)"', str(err.__cause__.context))
+            match = re.search(r'name\s*=\s*"(\w+)"', str(err.__cause__.context))
             if match:
                 partial_name = match.group(1)
-                possible_constraints = [c for c in self.constraints if partial_name in c.name]
+                possible_constraints = [
+                    c for c in self.constraints if partial_name in c.name
+                ]
                 for constraint in possible_constraints:
                     # Remove existing constraint that *might* cause the error
                     log.warning(

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import collections
 import copy
+import re
 from abc import ABCMeta, abstractmethod
 from functools import partial
 from itertools import chain, count, groupby
 from typing import Any, Container, DefaultDict, Iterable, Iterator
 
 import click
-from pip._internal.exceptions import DistributionNotFound
+from pip._internal.exceptions import DistributionNotFound, MetadataGenerationFailed
 from pip._internal.operations.build.build_tracker import (
     get_build_tracker,
     update_env_context_manager,
@@ -669,6 +670,35 @@ class BacktrackingResolver(BaseResolver):
                 del compatible_existing_constraints[cause_ireq_name]
 
             return False
+
+        except MetadataGenerationFailed as err:
+            # Find (part of) broken package name in the error message
+            match = re.search('name\s*=\s*"(\w+)"', str(err.__cause__.context))
+            if match:
+                partial_name = match.group(1)
+                possible_constraints = [c for c in self.constraints if partial_name in c.name]
+                for constraint in possible_constraints:
+                    # Remove existing constraint that *might* cause the error
+                    log.warning(
+                        f"Discarding {constraint} to proceed the resolution.\n"
+                        "It looks like it has a release with broken metadata, causing this resolver to fail.\n"
+                        "You may try to pin that package's version (probably to a recent one), "
+                        "so the resolver doesn't consider the broken release."
+                    )
+                    self.constraints.remove(constraint)
+
+                    # We remove only one constraint at a time.
+                    # If there are multiple candidates, we'll find them in the next round.
+                    return False
+
+            # We also get here if there was a match, but possible_constraints is an empty list.
+            log.error(
+                "A package release has broken metadata, but we can't tell which package it is.\n "
+                "Try reading the error message above to identify the package.\n"
+                "Next, you may try to pin that package's version (probably to a recent one), "
+                "so the resolver doesn't consider the broken release."
+            )
+            raise
 
         return True
 


### PR DESCRIPTION
Fixes #2118, but no tests yet (hence WIP).

After this change, a requirements file is generated by discarding the problematic package.

Now, with this in requirements.txt:

    django-debug-toolbar
    django-geojson
    wagtail>=4.2,<4.3

I get:

    $ env/bin/pip-compile --resolver=backtracking --generate-hashes --allow-unsafe --output-file requirements.txt requirements.in
        error: subprocess-exited-with-error

        × python setup.py egg_info did not run successfully.
        │ exit code: 1
        ╰─> [18 lines of output]
            /home/kees/Projects/pip-tools/env/lib/python3.10/site-packages/setuptools/_distutils/dist.py:268: UserWarning: Unknown distribution option: 'test_suite'
              warnings.warn(msg)
            Traceback (most recent call last):
              File "<string>", line 2, in <module>
              File "<pip-setuptools-caller>", line 34, in <module>
              File "/tmp/pip-resolve-o2r8fhgd/geojson_90f4efbe8a2247f9a1883c03e4988381/setup.py", line 6, in <module>
                setup(name          = "geojson",
              File "/home/kees/Projects/pip-tools/env/lib/python3.10/site-packages/setuptools/__init__.py", line 108, in setup
                return distutils.core.setup(**attrs)
              File "/home/kees/Projects/pip-tools/env/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 146, in setup
                _setup_distribution = dist = klass(attrs)
              File "/home/kees/Projects/pip-tools/env/lib/python3.10/site-packages/setuptools/dist.py", line 289, in __init__
                self.metadata.version = self._normalize_version(self.metadata.version)
              File "/home/kees/Projects/pip-tools/env/lib/python3.10/site-packages/setuptools/dist.py", line 325, in _normalize_version
                normalized = str(Version(version))
              File "/home/kees/Projects/pip-tools/env/lib/python3.10/site-packages/packaging/version.py", line 200, in __init__
                match = self._regex.search(version)
            TypeError: cannot use a string pattern on a bytes-like object
            [end of output]

        note: This error originates from a subprocess, and is likely not a problem with pip.
    Discarding django-geojson (from -r requirements.in (line 11)) to proceed the resolution.
    It looks like it has a release with broken metadata, causing this resolver to fail.
    You may try to pin that package's version (probably to a recent one), so the resolver doesn't consider the broken release.

The exception is still shown. Also we log a warning to tell the user the package was discarded.

The way to find the offending pacakge is crude (regex in error message string).

When the regex search for package name fails, we re-raise the error so no requirements file is generated.

In that case we log an error, which is hopefully helpful.

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
