### PR TITLE
Fix broken test related to wheel package being special

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3443,6 +3443,8 @@ def test_compile_recursive_extras_build_targets(runner, tmp_path, current_resolv
             "dev",
             "--build-deps-for",
             "wheel",
+            "--unsafe-package=wheel",
+            "--unsafe-package=setuptools",
             "--find-links",
             os.fspath(MINIMAL_WHEELS_PATH),
             os.fspath(tmp_path / "pyproject.toml"),
@@ -3455,7 +3457,6 @@ def test_compile_recursive_extras_build_targets(runner, tmp_path, current_resolv
     expected = rf"""foo[footest] @ {tmp_path.as_uri()}
 small-fake-a==0.2
 small-fake-b==0.3
-wheel==0.42.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This should bring the CI to green, so we can start merging other PRs.

Needed-By: #2099

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
