### PR TITLE
Filter dependencies to only include those from a given package

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -44,6 +44,18 @@ DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})
 
 
+def _filter_dependencies(dependencies, only_from_packages):
+    """
+    Filter dependencies to include only those required by the specified packages.
+    """
+    filtered_dependencies = [
+        dep
+        for dep in dependencies
+        if dep.comes_from and dep.comes_from in only_from_packages
+    ]
+    return set(filtered_dependencies)
+
+
 def _determine_linesep(
     strategy: str = "preserve", filenames: tuple[str, ...] = ()
 ) -> str:
@@ -101,6 +113,7 @@ def _determine_linesep(
 @options.upgrade
 @options.upgrade_package
 @options.output_file
+@options.only_from
 @options.newline
 @options.allow_unsafe
 @options.strip_extras
@@ -146,6 +159,7 @@ def cli(
     upgrade: bool,
     upgrade_packages: tuple[str, ...],
     output_file: LazyFile | IO[Any] | None,
+    only_from: list[str] | None,
     newline: str,
     allow_unsafe: bool,
     strip_extras: bool | None,
@@ -504,6 +518,9 @@ def cli(
             "either use --strip-extras to opt into the new default "
             "or use --no-strip-extras to retain the existing behavior."
         )
+
+    if only_from:
+        results = _filter_dependencies(results, only_from_packages=only_from)
 
     ##
     # Output

--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -191,6 +191,12 @@ output_file = click.option(
     ),
 )
 
+only_from = click.option(
+    "--only-from",
+    multiple=True,
+    help="Only include dependencies from given packages; may be used more than once",
+)
+
 newline = click.option(
     "--newline",
     type=click.Choice(("LF", "CRLF", "native", "preserve"), case_sensitive=False),


### PR DESCRIPTION
<!--- Describe the changes here. --->

I want to be able to output only direct dependencies, ie no transitive dependencies. This PR adds the flag `--only-from` like so: 

```
pip-compile pyproject.toml --only-from="my-project (pyproject.toml)"
```

which will yield a requirements.txt file with only dependencies that were directly listed in the toml.

If this is interesting, I can add tests and/or refactor as desired. If not, I can just close this, that's fine too.

##### Contributor checklist

- [ ] Included tests for the changes. (**not yet**)
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
