### PR TITLE
feat: Add macOS 14 ARM 64 runners to the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,14 @@ jobs:
 
   test:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-          - Ubuntu
-          - Windows
-          - macOS
+          - ubuntu-latest
+          - windows-latest
+          - macos-14
         python-version:
           - "3.11"
           - "3.10"
@@ -67,7 +67,7 @@ jobs:
             )
           }}
         include:
-          - os: Ubuntu
+          - os: ubuntu-latest
             python-version: >-
               ${{
                 github.job_workflow_sha
@@ -139,14 +139,14 @@ jobs:
 
   pypy:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-          - Ubuntu
-          - MacOS
-          - Windows
+          - ubuntu-latest
+          - macos-14
+          - windows-latest
         python-version:
           - pypy-3.8
         pip-version:


### PR DESCRIPTION
<!--- Describe the changes here. --->

fix: #2079 

##### Contributor checklist

- [ ] Included tests for the changes.
- [X] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
