### PR TITLE
🧪 Bump MyPy Python to 3.9 @ pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
           - build==1.0.0
           - pyproject_hooks==1.0.0
           - pytest==7.4.2
-        language_version: python3.8
+        language_version: python3.9
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.8
     hooks:


### PR DESCRIPTION
The `pre-commit.ci` service dropped support for Python 3.8 as it's
gone EOL. This change makes the check runnable again. It is suboptimal
as we haven't yet dropped support for Python 3.8. #2144 will address
the underlying issue more thoroughly.

Resolves #2133.

##### Contributor checklist

- [x] Included tests for the changes.
- [X] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
