### PR TITLE
🧪 Only run "lowest" & "supported" pip in tox for PR/push @ CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         pip-version: >-
           ${{
             fromJSON(
-              github.job_workflow_sha
+              inputs.cpython-pip-version
               && inputs.cpython-pip-version
               || '["latest", "previous"]'
             )
@@ -69,7 +69,7 @@ jobs:
     env:
       TOXENV: >-
         pip${{ matrix.pip-version }}${{
-          !github.job_workflow_sha
+          !inputs.cpython-pip-version
           && '-coverage'
           || ''
         }}
@@ -112,7 +112,7 @@ jobs:
         run: tox --skip-pkg-install
       - name: Upload coverage to Codecov
         if: >-
-          !github.job_workflow_sha
+          !inputs.cpython-pip-version
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,6 @@ jobs:
               || '["latest", "previous"]'
             )
           }}
-        include:
-          - os: Ubuntu
-            python-version: >-
-              ${{
-                github.job_workflow_sha
-                && '3.12-dev'
-                || '3.8'
-              }}
-            pip-version: main
     env:
       TOXENV: >-
         pip${{ matrix.pip-version }}${{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             fromJSON(
               inputs.cpython-pip-version
               && inputs.cpython-pip-version
-              || '["latest", "previous"]'
+              || '["latest", "lowest"]'
             )
           }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             fromJSON(
               inputs.cpython-pip-version
               && inputs.cpython-pip-version
-              || '["latest", "lowest"]'
+              || '["supported", "lowest"]'
             )
           }}
     env:
@@ -141,7 +141,7 @@ jobs:
         python-version:
           - pypy-3.8
         pip-version:
-          - latest
+          - supported
     env:
       TOXENV: pip${{ matrix.pip-version }}
     steps:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       cpython-pip-version: >-
-        ["main", "latest", "lowest"]
+        ["main", "latest", "supported", "lowest"]

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       cpython-pip-version: >-
-        ["main", "latest", "previous"]
+        ["main", "latest", "lowest"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
-    py{38,39,310,311,312,py3}-pip{lowest,latest,main}-coverage
-    pip{lowest,latest,main}-coverage
-    pip{lowest,latest,main}
+    py{38,39,310,311,312,py3}-pip{supported,lowest,latest,main}-coverage
+    pip{supported,lowest,latest,main}-coverage
+    pip{supported,lowest,latest,main}
     checkqa
     readme
 skip_missing_interpreters = True
@@ -14,6 +14,7 @@ extras =
     testing
     coverage: coverage
 deps =
+    pipsupported: pip==24.2
     piplowest: pip==22.2.*
     piplatest: pip
     pipmain: https://github.com/pypa/pip/archive/main.zip

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
-    py{38,39,310,311,312,py3}-pip{previous,latest,main}-coverage
-    pip{previous,latest,main}-coverage
-    pip{previous,latest,main}
+    py{38,39,310,311,312,py3}-pip{lowest,latest,main}-coverage
+    pip{lowest,latest,main}-coverage
+    pip{lowest,latest,main}
     checkqa
     readme
 skip_missing_interpreters = True
@@ -14,7 +14,7 @@ extras =
     testing
     coverage: coverage
 deps =
-    pipprevious: pip==22.2.*
+    piplowest: pip==22.2.*
     piplatest: pip
     pipmain: https://github.com/pypa/pip/archive/main.zip
 setenv =


### PR DESCRIPTION
This PR implements "supported" and "lowest" (renamed from "previous") envs in tox. It then integrates both into the CI runs triggered by `push` and `pull_request` events.
It drops running the tests against "latest" and "main" envs in regular PRs, keeping them in
the matrix executed on cron.

This improves reproducibility of the CI that will unblock contribution flows.

It additionally fixes reusable workflow conditionals relying on `${{ github.job_workflow_sha }}` that are broken within GitHub.

Refs:
* #2140
* https://github.com/actions/runner/issues/2417#issuecomment-1741105197
* https://github.com/actions/toolkit/issues/1264


##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
