### PR TITLE
🧪 Bump PyPy to v3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           - MacOS
           - Windows
         python-version:
-          - pypy-3.8
+          - pypy-3.10
         pip-version:
           - latest
     env:


### PR DESCRIPTION
This is necessary because:
* `pypy-3.8` is EOL
* `pypy-3.8` has flaky SEGFAULTs on import [[1]] [[2]] [[3]] due to a bug in their GC that is fixed in `pypy-3.9`
* `pypy-3.9` has a bug that does not have a backport with the fix [[4]]. Furthermore, PyPy maintainers recommend using 3.10 [[5]].

[1]: https://github.com/jazzband/pip-tools/actions/runs/12162197242/job/33918558133?pr=2106#step:8:59
[2]: https://github.com/pytest-dev/pytest/issues/11771#issuecomment-2200528806
[3]: https://pypy.org/posts/2024/03/fixing-bug-incremental-gc.html
[4]: https://github.com/tox-dev/tox/issues/3284
[5]: https://github.com/pypy/pypy/issues/4958#issuecomment-2326969261

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
