### PR TITLE
Use real type instead of typing alias for annotations

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -5,7 +5,7 @@ import copy
 from abc import ABCMeta, abstractmethod
 from functools import partial
 from itertools import chain, count, groupby
-from typing import Any, Container, DefaultDict, Iterable, Iterator
+from typing import Any, Container, Iterable, Iterator
 
 import click
 from pip._internal.exceptions import DistributionNotFound
@@ -532,7 +532,7 @@ class BacktrackingResolver(BaseResolver):
         self.existing_constraints = existing_constraints
 
         # Categorize InstallRequirements into sets by key
-        constraints_sets: DefaultDict[str, set[InstallRequirement]] = (
+        constraints_sets: collections.defaultdict[str, set[InstallRequirement]] = (
             collections.defaultdict(set)
         )
         for ireq in constraints:
@@ -746,7 +746,9 @@ class BacktrackingResolver(BaseResolver):
     def _get_reverse_dependencies(
         resolver_result: Result,
     ) -> dict[str, set[str]]:
-        reverse_dependencies: DefaultDict[str, set[str]] = collections.defaultdict(set)
+        reverse_dependencies: collections.defaultdict[str, set[str]] = (
+            collections.defaultdict(set)
+        )
 
         for candidate in resolver_result.mapping.values():
             stripped_name = strip_extras(canonicalize_name(candidate.name))

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -5,7 +5,7 @@ import os
 import sys
 import tempfile
 from subprocess import run  # nosec
-from typing import Deque, Iterable, Mapping, ValuesView
+from typing import Iterable, Mapping, ValuesView
 
 import click
 from pip._internal.models.direct_url import ArchiveInfo
@@ -54,7 +54,7 @@ def dependency_tree(
     :type root_key: str
     """
     dependencies = set()
-    queue: Deque[Distribution] = collections.deque()
+    queue: collections.deque[Distribution] = collections.deque()
 
     if root_key in installed_keys:
         dep = installed_keys[root_key]


### PR DESCRIPTION
These have been deprecated since Python 3.9, but are usable on 3.8 with when using `from __future__ import annotations`, as these annotations are not evaluated at runtime.

No user facing changes.