### PR TITLE
Fix crash with `pip==25.1`, which changed caching for find_all_candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,6 @@ This will be indicated in the output with one of the following suffixes:
 - [pip-compile-multi](https://pip-compile-multi.readthedocs.io/en/latest/) - pip-compile command wrapper for multiple cross-referencing requirements files.
 - [pipdeptree](https://github.com/tox-dev/pipdeptree) to print the dependency tree of the installed packages.
 - `requirements.in`/`requirements.txt` syntax highlighting:
-
   - [requirements.txt.vim](https://github.com/raimon49/requirements.txt.vim) for Vim.
   - [Python extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for VS Code.
   - [pip-requirements.el](https://github.com/Wilfred/pip-requirements.el) for Emacs.

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -447,9 +447,13 @@ class PyPIRepository(BaseRepository):
         Wheel.support_index_min = _wheel_support_index_min
         self._available_candidates_cache = {}
 
-        # If we don't clear this cache then it can contain results from an
-        # earlier call when allow_all_wheels wasn't active. See GH-1532
-        self.finder.find_all_candidates.cache_clear()
+        # Finder internally caches results, and there is no public method to
+        # clear the cache, so we re-create the object here. If we don't clear
+        # this cache then it can contain results from an earlier call when
+        # allow_all_wheels wasn't active. See GH-1532
+        self._finder = self.command._build_package_finder(
+            options=self.options, session=self.session
+        )
 
         try:
             yield


### PR DESCRIPTION
In `pip==25.1`, the implementation of caching for `find_all_candidates` changed, and it no longer exposes any method in its public interface to clear its cache. This causes `pip-compile --generate-hashes` to crash with an `AttributeError`.

In this PR, I replace the cache clearing with simply constructing a new object. I'm not sufficiently familiar with pip/pip-tools internals to know if that's a bad idea (it's unclear to me how much state lies in the finder object, beyond the cache), but I felt it was potentially cleaner than the alternative approach (catch the `AttributeError` and do `finder._all_candidates.clear()`) suggested in #2176.

 Fixes #2176 

##### Contributor checklist

- [ ] Included tests for the changes.
- [X] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
