### PR TITLE
Restrict dependencies; improve CI reproducibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ keywords = ["pip", "requirements", "packaging"]
 dependencies = [
   # direct dependencies
   "build >= 1.0.0",
-  "click >= 8",
+  "click >= 8 , < 8.2",
   "pip >= 22.2",
   "pyproject_hooks",
   "tomli; python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ keywords = ["pip", "requirements", "packaging"]
 dependencies = [
   # direct dependencies
   "build >= 1.0.0",
-  "click >= 8 , < 8.2",
+  "click >= 8, < 8.2",
   "pip >= 22.2",
   "pyproject_hooks",
   "tomli; python_version < '3.11'",

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ extras =
     coverage: coverage
 deps =
     pipsupported: pip==24.2
+    pipsupported: setuptools<=75.8.2
+
     piplowest: pip==22.2.*
     piplatest: pip
     pipmain: https://github.com/pypa/pip/archive/main.zip

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ extras =
     coverage: coverage
 deps =
     pipsupported: pip==24.2
-    pipsupported: setuptools<=75.8.2
+    pipsupported: setuptools <= 75.8.2
 
     piplowest: pip==22.2.*
     piplatest: pip


### PR DESCRIPTION
`click` v8.2 needs to be handled -- as a follow-up change -- but it's
hard to know if the application itself will work with it yet. Instead
of restricting that in tox.ini, I have chosen to restrict it in the
metadata itself.

`setuptools` on newer versions breaks some of the tests, but
restricting it for package metadata is definitely wrong. Therefore, it
is only restricted for now on the `pipsupported` build.

This should lead to improved CI, but will not result in all tests
passing.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
