### PR TITLE
Combine efforts to fix CI: #2181 + #2183

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ keywords = ["pip", "requirements", "packaging"]
 dependencies = [
   # direct dependencies
   "build >= 1.0.0",
-  "click >= 8",
+  "click >= 8 , < 8.2",
   "pip >= 22.2",
   "pyproject_hooks",
   "tomli; python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ keywords = ["pip", "requirements", "packaging"]
 dependencies = [
   # direct dependencies
   "build >= 1.0.0",
-  "click >= 8 , < 8.2",
+  "click >= 8, < 8.2",
   "pip >= 22.2",
   "pyproject_hooks",
   "tomli; python_version < '3.11'",

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -2664,7 +2665,7 @@ def test_error_in_pyproject_toml(
     captured = capfd.readouterr()
 
     assert (
-        "`project` must contain ['name'] properties" in captured.err
+        bool(re.search(r"`project` must contain \['[^']+'\] properties", captured.err))
     ) is verbose_option
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ extras =
     coverage: coverage
 deps =
     pipsupported: pip==24.2
+    pipsupported: setuptools<=75.8.2
+
     piplowest: pip==22.2.*
     piplatest: pip
     pipmain: https://github.com/pypa/pip/archive/main.zip

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ extras =
     coverage: coverage
 deps =
     pipsupported: pip==24.2
-    pipsupported: setuptools<=75.8.2
+    pipsupported: setuptools <= 75.8.2
 
     piplowest: pip==22.2.*
     piplatest: pip


### PR DESCRIPTION
I've cherry-picked a commit from #2183 onto #2181 to produce what I believe is the truly minimal changeset in order to get *CI* working correctly.

I've done a lot of reading of the past few days to figure out what all needs to be done, and I think most or even all of #2183 will be good to apply.
But right now, it forces a reviewer to reckon with several different topics at once, plus it has a test skip which we need to work around.

I'd like us to get this fix completed in as minimal a manner as possible so that we can take changes like 64606f4a and have clear focus when we look at them.
Right now, Python 3.12 isn't being tested in CI, nor is "piplatest" (from tox config)[^1], so there's a lot of CI cleanup ground to cover.
Healing the currently configured CI matrix takes priority.

[^1]: We don't want to block PRs on `piplatest`, so this is intentional. But it would be good to get that cron CI job working again.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
