### PR TITLE
Make 'isort' consistent about 'build'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ pip-sync = "piptools.scripts.sync:cli"
 
 [tool.isort]
 profile = "black"
+# explicitly mark 'build' as a third-party package
+# otherwise, in some executions, `isort` can mistake `piptools.build` for
+# `build` and treat it as a first-party module name
+known_third_party = ["build"]
 add_imports = "from __future__ import annotations"
 
 [tool.mypy]


### PR DESCRIPTION
This does not seem to reproduce consistently -- `isort` is executing
correctly in pre-commit.ci -- but in some environments and
invocations, `isort` is incorrectly reordering imports of `build`
because it gets confused by the `piptools.build` module.

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [x] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
