### PR TITLE
Remove unnecessary line in README.md before "Update dependencies" header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,6 @@ sqlparse==0.4.3
 And it will produce your `requirements.txt`, with all the Django dependencies
 (and all underlying dependencies) pinned.
 
-(updating-requirements)=
-
 ### Updating requirements
 
 `pip-compile` generates a `requirements.txt` file using the latest versions


### PR DESCRIPTION
The README.md contained an extra line `(updating-requirements)=` before the "Update dependencies" header. This change removes the line. I did check the docs using `tox run -e preview-docs` locally and the link in README.md still worked.

Please do close this if it's required and I missed something.

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
