### PR TITLE
Drop release attestations for Jazzband upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,8 @@ jobs:
           Publish v${{ github.ref_name }} to PyPI
           🔏
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Clean up the publish attestation leftovers
+        run: rm -fv dist/*.publish.attestation
       - name: Upload packages to Jazzband
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/changelog.d/2209.packaging.md
+++ b/changelog.d/2209.packaging.md
@@ -1,0 +1,1 @@
+2149.packaging.md


### PR DESCRIPTION
This patch cleans up the attestation files that the first `pypi-publish` invocation leaves on disk so that the following one would not attempt uploading them to the private package index of Jazzband as it might not support such uploads just yet.

<!--- Describe the changes here. --->

##### Contributor checklist

- [ ] Included tests for the changes.
- [ ] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `skip-changelog` label.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
