### PR TITLE
Bugfix: path normalization applied to URLs

### DIFF
--- a/changelog.d/2223.bugfix.md
+++ b/changelog.d/2223.bugfix.md
@@ -1,0 +1,2 @@
+Fixed a bug which removed slashes from URLs in ``-r`` and ``-c`` in the output
+of ``pip-compile`` -- by {user}`sirosen`.

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -191,7 +191,7 @@ def _is_remote_pip_uri(value: str) -> bool:
     The test is performed by trying a URL parse and reading the scheme.
     """
     scheme = urllib.parse.urlsplit(value).scheme
-    return scheme in ("http", "https", "file")
+    return scheme in {"file", "http", "https"}
 
 
 def create_wheel_cache(cache_dir: str, format_control: str | None = None) -> WheelCache:

--- a/piptools/_compat/pip_compat.py
+++ b/piptools/_compat/pip_compat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import optparse
 import pathlib
+import urllib.parse
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Set, cast
 
@@ -140,6 +141,10 @@ def _relativize_comes_from_location(original_comes_from: str, /) -> str:
     # split on the space
     prefix, space_sep, suffix = original_comes_from.partition(" ")
 
+    # if the value part is a URI, return the original
+    if _is_uri(suffix):
+        return original_comes_from
+
     file_path = pathlib.Path(suffix)
 
     # if the path was not absolute, normalize to posix-style and finish processing
@@ -169,9 +174,32 @@ def _normalize_comes_from_location(original_comes_from: str, /) -> str:
     # split on the space
     prefix, space_sep, suffix = original_comes_from.partition(" ")
 
+    # if the value part is a URI, return the original
+    if _is_uri(suffix):
+        return original_comes_from
+
     # convert to a posix-style path
     suffix = pathlib.Path(suffix).as_posix()
     return f"{prefix}{space_sep}{suffix}"
+
+
+def _is_uri(value: str) -> bool:
+    """
+    Test a string to see if it is a URI.
+
+    The test is performed by trying a URL parse and seeing is a scheme is populated.
+
+    This means that according to this rule, valid URLs such as
+    ``example.com/data/my_pip_constraints.txt`` may fail to count as URIs.
+    However, we cannot safely distinguish such strings from real filesystem paths.
+    e.g., ``./example.com/`` may be a directory.
+
+    Importantly, realistic usage such as
+    ``-c https://example.com/constraints.txt``
+    is properly detected by this technique.
+    """
+    parse_result = urllib.parse.urlparse(value)
+    return parse_result.scheme != ""
 
 
 def create_wheel_cache(cache_dir: str, format_control: str | None = None) -> WheelCache:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -4065,8 +4065,9 @@ def test_url_constraints_are_not_treated_as_file_paths(
     This is a regression test for
     https://github.com/jazzband/pip-tools/issues/2223
     """
-    reqs_in = tmp_path / "requirements.in"
     constraints_url = "https://example.com/files/common_constraints.txt"
+
+    reqs_in = tmp_path / "requirements.in"
     reqs_in.write_text(
         f"""
         small-fake-a
@@ -4094,19 +4095,19 @@ def test_url_constraints_are_not_treated_as_file_paths(
 
     with monkeypatch.context() as revertable_ctx:
         revertable_ctx.chdir(tmp_path)
-        with mock.patch.object(PipSession, "get", mock_get):
-            out = runner.invoke(
-                cli,
-                [
-                    "--output-file",
-                    "-",
-                    "--quiet",
-                    "--no-header",
-                    "--no-emit-options",
-                    "-r",
-                    input_path,
-                ],
-            )
+        revertable_ctx.setattr(PipSession, "get", mock_get)
+        out = runner.invoke(
+            cli,
+            [
+                "--output-file",
+                "-",
+                "--quiet",
+                "--no-header",
+                "--no-emit-options",
+                "-r",
+                input_path,
+            ],
+        )
 
     # sanity check, pip should have tried to fetch the constraints
     mock_get.assert_called_once_with(constraints_url)


### PR DESCRIPTION
Resolves #2223

The `-r` and `-c` path normalization logic did not check if the
requested requirements or constraint files were remote files being
loaded, e.g., via HTTPS. As a result, a usage like
`-c https://example.com/constraints.txt` incorrectly got converted to
a path and normalized, stripping one of the two slashes which
separates the scheme from the netloc.

A regression test is added which reproduces the bug, and the gap in
detection is closed by checking explicitly if inputs can parse as
URIs. Any given URI (including file URIs) will be exempted from the
path rewrites.

The check is implemented by calling `urllib.parse.urlparse()` and
checking the `scheme` attribute of the parse result.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `skip-changelog` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
