### PR TITLE
Update to support click >= 8.3

### DIFF
--- a/changelog.d/2235.bugfix.md
+++ b/changelog.d/2235.bugfix.md
@@ -1,2 +1,2 @@
-Fix an incompatibility with `click>=8.3` which made `pip-compile` display incorrect
+Fix an incompatibility with ``click >= 8.3`` which made ``pip-compile`` display incorrect
 options in the compile command in output headers -- by :user:`sirosen`.

--- a/changelog.d/2235.bugfix.md
+++ b/changelog.d/2235.bugfix.md
@@ -1,0 +1,2 @@
+Fix an incompatibility with `click>=8.3` which made `pip-compile` display incorrect
+options in the compile command in output headers -- by :user:`sirosen`.

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -399,7 +399,7 @@ def get_compile_command(click_ctx: click.Context) -> str:
                 continue
 
         # Skip options without a value
-        if option.default is None and not value:
+        if value is None:
             continue
 
         # Skip options with a default value

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,7 +10,6 @@ def test_indentation(runner):
     log = LogContext(indent_width=2)
 
     with runner.isolation() as streams:
-        stderr = streams[1]
         log.log("Test message 1")
         with log.indentation():
             log.log("Test message 2")
@@ -19,7 +18,9 @@ def test_indentation(runner):
             log.log("Test message 4")
         log.log("Test message 5")
 
-    assert stderr.getvalue().decode().splitlines() == [
+        stderr_bytes = streams[1].getvalue()
+
+    assert stderr_bytes.decode().splitlines() == [
         "Test message 1",
         "  Test message 2",
         "    Test message 3",


### PR DESCRIPTION
Resolves #2235

The latest `click` release makes two changes which are visible in `pip-tools`, one of which is only seen in the testsuite.

1.  The default for `Parameter.default` is now an internal `UNSET` sentinel.

    Because `UNSET` isn't in the public API, checking `Option.default` is not the right way to check if an option has no explicit default value. We could use `Option.to_info_dict()`, but we're *also* checking for a falsy value right now -- the simple fix is to check for a parsed value of `None`.

2.  Changes to EOF handling in `CliRunner.isolation()` result in the stream being closed on exit.

    Between pallets/click#2934 and pallets/click#2940, we now get the intended behavior for `CliRunner.isolation()`, in that it outputs an EOF when the context manager exits. To solve, update a test to read stderr before exiting the context manager.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `skip-changelog` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
