### PR TITLE
Separately control CPython versions in nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ on:
           to test against under CPython.
         required: true
         type: string
+      cpython-versions:
+        description: >-
+          A JSON string with CPython versions
+          to test against.
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -53,12 +59,14 @@ jobs:
           - Ubuntu
           - Windows
           - macOS
-        python-version:
-          - "3.12"
-          - "3.11"
-          - "3.10"
-          - "3.9"
-          - "3.8"
+        python-version: >-
+          ${{
+            fromJSON(
+              inputs.cpython-versions
+              && inputs.cpython-versions
+              || '["3.8", "3.9", "3.10", "3.11", "3.12"]'
+            )
+          }}
         pip-version: >-
           ${{
             fromJSON(

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,5 +10,7 @@ jobs:
     name: CI
     uses: ./.github/workflows/ci.yml
     with:
+      cpython-versions: >-
+        ["3.10", "3.11", "3.12"]
       cpython-pip-version: >-
         ["main", "latest", "supported", "lowest"]

--- a/changelog.d/2226.misc.md
+++ b/changelog.d/2226.misc.md
@@ -1,0 +1,2 @@
+The CPython versions tested in nightly CI runs are now separate from
+branch and PR CI, and don't include very old versions -- by {user}`sirosen`.


### PR DESCRIPTION
The pip versions being tested are controlled via a JSON array passed as
a string. Use the same mechanism to pass CPython versions to test.

This allows PR builds to continue to test 3.8 (EOL) and 3.9 (EOL soon)
while nightly builds will only run on 3.10+ .

Resolves #2226

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `skip-changelog` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
