### PR TITLE
CI: advance the Python version support window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             fromJSON(
               inputs.cpython-versions
               && inputs.cpython-versions
-              || '["3.8", "3.9", "3.10", "3.11", "3.12"]'
+              || '["3.9", "3.10", "3.11", "3.12", "3.13"]'
             )
           }}
         pip-version: >-


### PR DESCRIPTION
- [x] Confirm locally that the testsuite passes (except for two expected failures) using version 3.13 of Python.
- [ ] Confirm that main GitHub Actions continuous integration test workflow passes using the same.
- [ ] Update other GitHub Actions workflows to use py3.13
- [ ] Update package metadata and internal references to indicate support for py3.13
- [ ] Add a changelog entry

##### Contributor checklist

- [ ] ~~Included tests for the changes~~.
- [ ] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `skip-changelog` label.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

Resolves #2138.