### PR TITLE
Fix SyntaxWarning in Python 3.14

### DIFF
--- a/piptools/build.py
+++ b/piptools/build.py
@@ -204,12 +204,11 @@ def _env_var(
     finally:
         if pip_constraint_was_unset:
             del os.environ[env_var_name]
-            return
-
-        # Assert here is necessary because MyPy can't infer type
-        # narrowing in the complex case.
-        assert isinstance(original_pip_constraint, str)
-        os.environ[env_var_name] = original_pip_constraint
+        else:
+            # Assert here is necessary because MyPy can't infer type
+            # narrowing in the complex case.
+            assert isinstance(original_pip_constraint, str)
+            os.environ[env_var_name] = original_pip_constraint
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Seeing this warning on 3.14:

```
/Users/tushar/code/foo/venv/lib/python3.14/site-packages/piptools/build.py:207: SyntaxWarning: 'return' in a 'finally' block
```

This fixes that.