### PR TITLE
📦 Add a `stable` extra for `pip` upper bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Similar to `pip`, `pip-tools` must be installed in each of your project's
 
 ```console
 $ source /path/to/venv/bin/activate
-(venv) $ python -m pip install pip-tools
+(venv) $ python -m pip install 'pip-tools [stable]'
 ```
 
 **Note**: all of the remaining example commands assume you've activated your

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Similar to `pip`, `pip-tools` must be installed in each of your project's
 
 ```console
 $ source /path/to/venv/bin/activate
-(venv) $ python -m pip install pip-tools
+(venv) $ python -m pip install 'pip-tools [stable]'
 ```
 
 **Note**: all of the remaining example commands assume you've activated your

--- a/changelog.d/2257.packaging.md
+++ b/changelog.d/2257.packaging.md
@@ -1,0 +1,10 @@
+The core packaging metadata started exposing a new `stable` extra
+-- by {user}`beruic`, {user}`sirosen` and {user}`webknjaz`.
+
+This new opt-in install-level feature limits the `pip` dependency to
+the latest version we're testing in our CI at the time of release.
+
+<!-- pyml disable-num-lines 2 commands-show-output -->
+```console
+$ pip install 'pip-tools [stable]'
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ repository = "https://github.com/jazzband/pip-tools"
 changelog = "https://github.com/jazzband/pip-tools/releases"
 
 [project.optional-dependencies]
+stable = [
+  "pip <= 25.3",
+]
 testing = [
   "pytest >= 7.2.0",
   "pytest-rerunfailures",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ repository = "https://github.com/jazzband/pip-tools"
 changelog = "https://github.com/jazzband/pip-tools/releases"
 
 [project.optional-dependencies]
+stable = [
+  "pip <= 26.2",
+]
 testing = [
   "pytest >= 7.2.0",
   "pytest-mock >= 3.15.1",

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ skip_missing_interpreters = True
 [testenv]
 description = run the tests with pytest
 extras =
+    pipsupported: stable
+    piplowest: stable
     testing
     coverage: coverage
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ warnings-to-errors = -Werror
 [testenv]
 description = run the tests with pytest
 extras =
+    pipsupported: stable
+    piplowest: stable
     testing
     coverage: coverage
 deps =


### PR DESCRIPTION
It is supposed to correspond to the range of what's tested in our CI.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `skip-changelog` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
