### PR TITLE
Use Python 3.13 for "QA" workflow

### DIFF
--- a/.github/workflows/reusable-qa.yml
+++ b/.github/workflows/reusable-qa.yml
@@ -16,7 +16,7 @@ jobs:
           - linkcheck-docs
           - changelog-draft
         python-version:
-          - "3.x"
+          - "3.13"
     env:
       PY_COLORS: 1
       TOXENV: ${{ matrix.toxenv }}


### PR DESCRIPTION
This job was using "3.x", which has started picking up on Python 3.14.
As a result, builds are exposed to new failures on the new version.

This version should always be bounded to something which pip-tools supports.

---

No changelog needed.

I don't want to try to set a strict policy for when we'll bump this pin (beyond "common sense") because I think we can do more to setup RTD PR builds and such.

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `skip-changelog` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
