### PR TITLE
Add support for builds from 'git archive'

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=v[0-9]*[0-9])$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# fill in placeholders when `git archive` is used, setuptools-scm support
+.git_archival.txt  export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# do not include the `.git_archival.txt` file in sdist builds from repo source
+# this avoids setuptools-scm warnings on development builds
+exclude .git_archival.txt

--- a/changelog.d/2225.packaging.md
+++ b/changelog.d/2225.packaging.md
@@ -1,0 +1,2 @@
+`pip-tools` now supports installation from git archives by providing
+`setuptools-scm` with `.git_archival.txt` data.


### PR DESCRIPTION
Implements / resolves #2225 .
I tested the results by creating a temporary tag and running `git archive -o ... v101.0`, then confirming I could unpack and build from that archive without issue.

---

setuptools-scm needs the git metadata expanded into this file in order to support installation from an archive. Providing the data makes it possible for `setuptools-scm` to build cleanly from an archive.

setuptools-scm docs recommend using the manifest file to explicitly skip `.git_archival.txt` when building sdists, as its inclusion results in build-time warnings during development.

The pattern used in `.git_archival.txt` as a tag match has to be something expressible in glob syntax. Given this restriction, it simply requires a prefix of `v\d` and a suffix of `\d` (in appropriate syntax) with any midfix allowed.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `skip-changelog` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
