### PR TITLE
Add configuration for the change log enforcing bot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,5 +7,5 @@
 
 ##### Maintainer checklist
 
-- [ ] If no changelog is needed, apply the `skip-changelog` label.
+- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
 - [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).

--- a/.github/chronographer.yml
+++ b/.github/chronographer.yml
@@ -8,5 +8,3 @@ action-hints:
     [the changelog contribution docs]: https://pip-tools.rtfd.io/en/latest/contributing/#adding-change-notes-with-prs
 enforce-name:
   suffix: .md
-labels:
-  skip-changelog: skip-changelog

--- a/changelog.d/2201.contrib.md
+++ b/changelog.d/2201.contrib.md
@@ -1,9 +1,9 @@
 The [change log entry bot] has been explicitly configured to stop requiring
-news fragments in pull requests having the [`skip-changelog` label] set
+news fragments in pull requests having the [`bot:chronographer:skip` label] set
 -- by {user}`sirosen` and {user}`webknjaz`.
 
 It was also set up to reference our change log authoring document from the
 GitHub Checks pages. And the reported check name is now set to `Change log entry`.
 
 [change log entry bot]: https://github.com/sanitizers/chronographer-github-app
-[`skip-changelog` label]: https://github.com/jazzband/pip-tools/labels/skip-changelog
+[`bot:chronographer:skip` label]: https://github.com/jazzband/pip-tools/labels/bot:chronographer:skip


### PR DESCRIPTION
This resolves #2201 , as the last outstanding item.
The config is based off of `pip`'s config, adapted to our needs in `pip-tools`.

-----

This initial configuration is mostly fine-tuning based on current state. The only new behavior is that this goes back to using the `skip-changelog` label for skipping changelogs.
(Incidentally, the label name matches the config key.)

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `skip-changelog` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
