### PR TITLE
Add conditional coverage exclusions to trivial places

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,5 +4,7 @@ omit =
     piptools/_compat/*
 
 [report]
+exclude_also =
+    ^\s*@pytest\.mark\.xfail
 include = piptools/*, tests/*
 fail_under = 99

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -20,9 +20,9 @@ from pip._vendor.packaging.requirements import Requirement
 
 from .utils import copy_install_requirement, install_req_from_line
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 PYPROJECT_TOML = "pyproject.toml"
@@ -30,9 +30,9 @@ PYPROJECT_TOML = "pyproject.toml"
 _T = TypeVar("_T")
 
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     from importlib.metadata import PackageMetadata
-else:
+else:  # pragma: <3.10 cover
 
     class PackageMetadata(Protocol):
         @overload

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -14,9 +14,9 @@ from typing import Any, Callable, Iterable, Iterator, TypeVar, cast
 
 from click.core import ParameterSource
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 import click
@@ -510,7 +510,7 @@ def copy_install_requirement(
     }
     kwargs.update(extra_kwargs)
 
-    if PIP_VERSION[:2] <= (23, 0):
+    if PIP_VERSION[:2] <= (23, 0):  # pragma: <3.12 cover
         kwargs["install_options"] = template.install_options
 
     # Original link does not belong to install requirements constructor,
@@ -763,8 +763,8 @@ def is_path_relative_to(path1: Path, path2: Path) -> bool:
     """Return True if ``path1`` is relative to ``path2``."""
     # TODO: remove this function in favor of Path.is_relative_to()
     #       when we drop support for Python 3.8
-    try:
+    try:  # pragma: >=3.9 cover
         path1.relative_to(path2)
-    except ValueError:
+    except ValueError:  # pragma: <3.9 cover
         return False
     return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,7 @@ def base_resolver(depcache):
 @pytest.fixture
 def from_line():
     def _from_line(*args, **kwargs):
-        if PIP_VERSION[:2] <= (23, 0):
+        if PIP_VERSION[:2] <= (23, 0):  # pragma: <3.12 cover
             hash_options = kwargs.pop("hash_options", {})
             options = kwargs.pop("options", {})
             options["hashes"] = hash_options
@@ -228,7 +228,8 @@ def from_editable():
 
 @pytest.fixture
 def runner():
-    if Version(version_of("click")) < Version("8.2"):
+    # Coverage is excluded because we only test with the latest Click
+    if Version(version_of("click")) < Version("8.2"):  # pragma: no cover
         cli_runner = CliRunner(mix_stderr=False)
     else:
         cli_runner = CliRunner()

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3422,9 +3422,9 @@ def test_pass_pip_cache_to_pip_args(tmpdir, runner, current_resolver):
     # TODO: Remove hack once testing only on v23.3+
     pip_current_version = get_pip_version_for_python_executable(sys.executable)
     pip_breaking_version = Version("23.3.dev0")
-    if pip_current_version >= pip_breaking_version:
+    if pip_current_version >= pip_breaking_version:  # pragma: >=3.12 cover
         pip_http_cache_dir = "http-v2"
-    else:
+    else:  # pragma: <3.12 cover
         pip_http_cache_dir = "http"
     assert os.listdir(os.path.join(str(cache_dir), pip_http_cache_dir))
 
@@ -4017,7 +4017,7 @@ def test_second_order_requirements_relative_path_in_separate_dir(
     output_path = test_files_collection.get_path_to("requirements2.in")
 
     # for older pip versions, recompute the output path to be relative to the input path
-    if not pip_produces_absolute_paths:
+    if not pip_produces_absolute_paths:  # FIXME: figure out how to cover piplowest
         # traverse upwards to the root tmp dir, and append the output path to that
         # similar to pathlib.Path.relative_to(..., walk_up=True)
         relative_segments = len(pathlib.Path(input_path).parents) - 1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -175,7 +175,7 @@ def test_diff_should_not_uninstall(fake_dist):
     # on Python 3.12 and above, `ensurepip` and `venv` do not default to installing
     # 'setuptools' -- as such, `pip` changes behavior on many Python 3.12 environments
     # to use isolated builds
-    if sys.version_info < (3, 12):
+    if sys.version_info < (3, 12):  # pragma: <3.12 cover
         ignored += (
             "setuptools==34.0.0",
             "wheel==0.29.0",


### PR DESCRIPTION
The patch adds version-dependent pragmas where no actual coverage can be provided.
They sometimes are applied to conditionals checking the deps versions and won't work perfectly but it's a start.

The change also excludes tests marked as `xfail` from coverage — they are either chronically uncovered up to a certain line or have flaky coverage. Either way, having them in is rather harmful for measurements.

##### Contributor checklist

- [x] Included tests for the changes.
- [ ] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
