### PR TITLE
chore: remove 'v' prefix from github.ref_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ env:
 run-name: >-
   ${{
     github.event.action == 'published'
-    && format('📦 Releasing v{0}...', github.ref_name)
+    && format('📦 Releasing {0}...', github.ref_name)
     || format('🌱 Smoke-testing packaging for commit {0}', github.sha)
   }}
   triggered by: ${{ github.event_name }} of ${{
@@ -61,7 +61,7 @@ run-name: >-
 jobs:
   build:
     name: >-
-      📦 v${{ github.ref_name }}
+      📦 ${{ github.ref_name }}
       [mode: ${{
         github.event.action == 'published'
         && 'release' || 'nightly'
@@ -115,7 +115,7 @@ jobs:
   publish-pypi:
     name: >-
       📦
-      Publish v${{ github.ref_name }} to PyPI
+      Publish ${{ github.ref_name }} to PyPI
     needs:
       - build
     if: >-
@@ -142,7 +142,7 @@ jobs:
           path: dist/
       - name: >-
           📦
-          Publish v${{ github.ref_name }} to PyPI
+          Publish ${{ github.ref_name }} to PyPI
           🔏
         uses: pypa/gh-action-pypi-publish@release/v1
       - name: Clean up the publish attestation leftovers


### PR DESCRIPTION
A simple visual fix is introduced for GH Actions.
Remove `v` from GH tags since they are already being created with it from the current minor version.
This will resolve: https://github.com/jazzband/pip-tools/issues/2271

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
