### PR TITLE
Update the documented release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,21 +21,31 @@ Contributions following these guidelines are always welcomed, encouraged and app
 
 ## Project Release Process
 
-Releases require approval by a member of the `pip-tools-leads` team.
+Releases require approval by a member of the [`pip-tools-leads` team].
+
+Commands given below may assume that your fork is named `origin` in git remotes and the main repo is named `upstream`.
 
 This is the current release process:
 
-- Create a branch for the release. _e.g., `release-3.4.0`_.
+- Create a branch for the release. _e.g., `release/v3.4.0`_.
 - Use `towncrier` to update the [CHANGELOG], _e.g., `towncrier build --version v3.4.0`_.
-- Push the branch to your fork and create a pull request.
+- Push the branch to your fork, _e.g., `git push -u origin release/v3.4.0`_,
+  and create a pull request.
 - Merge the pull request after the changes are approved.
 - Make sure that the tests/CI still pass.
-- Pull the latest changes to `main` locally.
-- Create an unsigned tag with the release version number prefixed with a `v`, _e.g., `git tag v3.4.0`_, and push.
-- Create a GitHub Release, populated with a copy of the changelog. Some of the markdown will need to be reformatted into GFM.
+- Fetch the latest changes to `main` locally.
+- Create an unsigned tag with the release version number prefixed with a `v`,
+  _e.g., `git tag -a v3.4.0 -m v3.4.0`_, and push it to `upstream`.
+- Create a GitHub Release, populated with a copy of the changelog and set to
+  "Create a discussion for this release" in the `Announcements` category.
+  Some of the markdown will need to be reformatted into GFM.
   The release title and tag should be the newly created tag.
-- A GitHub Workflow will trigger off of the release to publish to PyPI. A member of `pip-tools-leads` must approve the publication step.
+- The [GitHub Release Workflow] will trigger off of the release to publish to PyPI.
+  A member of the [`pip-tools-leads` team] must approve the publication step.
 - Once the release to PyPI is confirmed, close the milestone.
-- Publish any release notifications, _e.g., discuss.python.org, social media, pypa Discord_.
+- Publish any release notifications,
+  _e.g., pip-tools matrix channel, discuss.python.org, bluesky, mastodon, pypa Discord_.
 
-[changelog]: https://github.com/jazzband/pip-tools/blob/main/CHANGELOG.md
+[changelog]: ./CHANGELOG.md
+[GitHub Release Workflow]: https://github.com/jazzband/pip-tools/actions/workflows/release.yml
+[`pip-tools-leads` team]: https://github.com/orgs/jazzband/teams/pip-tools-leads


### PR DESCRIPTION
These updates are to "match reality". I considered leaving some of the surrounding text (e.g., "Do not hesitate to ask questions...") alone, but judged that our current maintenance culture makes such text unnecessary.

This PR should resolve [this comment](https://github.com/jazzband/pip-tools/issues/2201#issuecomment-3537044474).

I decided not to add a contrib changelog note for this one. In this particular case it's purely doc and only relevant to the maintainers who do releases.

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] ~Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).~
