### PR TITLE
Remove setup.cfg from cache key hashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,13 +103,13 @@ jobs:
         id: pip-cache
         shell: bash
         run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: Pip cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
+            ${{ runner.os }}-pip-${{
             hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{
             hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
@@ -129,7 +129,7 @@ jobs:
         if: matrix.python-version == '3.8'
         shell: bash
         run: |
-          echo "PYTEST_ADDOPTS=--cov-fail-under=98" >> $GITHUB_ENV
+          echo "PYTEST_ADDOPTS=--cov-fail-under=98" >> "$GITHUB_ENV"
       - name: Test pip ${{ matrix.pip-version }}
         # NOTE: `--parallel-live` is a workaround for the regression in
         # NOTE: the upstream tox project that made the
@@ -208,13 +208,13 @@ jobs:
         id: pip-cache
         shell: bash
         run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: Pip cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
+            ${{ runner.os }}-pip-${{
             hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{
             hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |

--- a/.github/workflows/reusable-qa.yml
+++ b/.github/workflows/reusable-qa.yml
@@ -31,13 +31,13 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: Pip cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: >-
-            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
+            ${{ runner.os }}-pip-${{
             hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{
             hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-
       - name: Prepare cache key
         id: cache-key
-        run: echo "sha-256=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+        run: echo "sha-256=$(python -VV | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit


### PR DESCRIPTION
EDIT: the true cause is https://github.com/actions/runner-images/issues/13341 , but the listing of `setup.cfg` as a file to hash is still a minor fix I think we should make.

In CI builds for #2279, we have failures ~due to this nonexistent file being hashed.~ which I believed were caused by nonexistent `setup.cfg` file hashing.
The `hashFiles` call has been the same for >4 years without issue, even after the file was deleted, but has just started failing.
Although the exact reason is unclear, we don't need to try to hash on `setup.cfg` at this stage anyway.

Also, quote `GITHUB_*` variables to prevent actionlint from failing with errors about unquoted variables & potential word-splitting.
This was also noted in #2279, as in both PRs I've seen local issues with actionlint which are not failing in CI.
Specifically, local runs of actionlint flag shellcheck SC2086: "Double quote to prevent globbing and word splitting".
Although it's safe in this case (GitHub does not produce paths with spaces for these variables), it's simplest to quote the variables to pacify shellcheck.

Because this is a purely internal fix which isn't meant to impact the contributor experience (other than fixing things), I've elected to go without a changelog on this one.

##### Contributor checklist

- ~[x] Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
