### PR TITLE
Update RTD config to remove empty `build.tools`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         files: ^\.github/workflows/[^/]+$
         types:
           - yaml
-      # - id: check-readthedocs  # FIXME: demands non-empty `build.tools`
+      - id: check-readthedocs
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.3.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,6 @@ version: 2
 
 build:
   os: ubuntu-24.04
-  tools: {}
 
   # in order to have RTD use our tox configuration for the build, we take full
   # control over 'build.commands'

--- a/changelog.d/+380ef8d4.contrib.md
+++ b/changelog.d/+380ef8d4.contrib.md
@@ -1,0 +1,1 @@
+The `check-jsonschema` ReadTheDocs hook has been enabled, and the config has been tweaked to pass -- by {user}`sirosen`.


### PR DESCRIPTION
...and enable the RTD config linting hook.

---

This was noted during #2273, so I reached out to RTD for clarification.
Based on [this response](https://github.com/readthedocs/readthedocs.org/issues/12592#issuecomment-3569486129), it seems safe to assume that empty and missing are the same for `build.tools` (that's the logical thing to guess as well).

Regardless of whether or not the schema gets updated -- it probably won't -- we can enable the hook today if we remove `build.tools`.

##### Contributor checklist

- ~[x] Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
