### PR TITLE
Introduce a version of the circular import test

### DIFF
--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -49,7 +49,7 @@ def _discover_path_importables(pkg_pth: Path, pkg_name: str) -> Iterator[str]:
         if pkg_dir_path.parts[-1] == "__pycache__":
             continue
 
-        if all(Path(_).suffix != ".py" for _ in file_names):
+        if all(Path(_).suffix != ".py" for _ in file_names):  # pragma: no cover
             continue
 
         rel_pt = pkg_dir_path.relative_to(pkg_pth)


### PR DESCRIPTION
This test ensures that we don't have circular imports allowed in the project.
(ported from #2286 )

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
