### PR TITLE
refactor: remove redundant str casts for canonicalize_name

### DIFF
--- a/piptools/_compat/__init__.py
+++ b/piptools/_compat/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .pip_compat import (
     Distribution,
+    canonicalize_name,
     create_wheel_cache,
     get_dev_pkgs,
     parse_requirements,
@@ -12,4 +13,5 @@ __all__ = [
     "parse_requirements",
     "create_wheel_cache",
     "get_dev_pkgs",
+    "canonicalize_name",
 ]

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -21,13 +21,12 @@ from pip._internal.resolution.resolvelib.resolver import Resolver
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.temp_dir import TempDirectory, global_tempdir_manager
 from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib.resolvers import ResolutionImpossible, Result
 
 from piptools.cache import DependencyCache
 from piptools.repositories.base import BaseRepository
 
-from ._compat import create_wheel_cache
+from ._compat import canonicalize_name, create_wheel_cache
 from .exceptions import PipToolsError
 from .logging import log
 from .utils import (

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -13,9 +13,8 @@ from build import BuildBackendException
 from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
 from pip._internal.utils.misc import redact_auth_from_url
-from pip._vendor.packaging.utils import canonicalize_name
 
-from .._compat import parse_requirements
+from .._compat import canonicalize_name, parse_requirements
 from ..build import ProjectMetadata, build_project_metadata
 from ..cache import DependencyCache
 from ..exceptions import NoCandidateFound, PipToolsError

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -15,9 +15,8 @@ from pip._internal.utils.direct_url_helpers import (
     direct_url_as_pep440_direct_reference,
     direct_url_from_link,
 )
-from pip._vendor.packaging.utils import canonicalize_name
 
-from ._compat import Distribution, get_dev_pkgs
+from ._compat import Distribution, canonicalize_name, get_dev_pkgs
 from .exceptions import IncompatibleRequirements
 from .logging import log
 from .utils import (

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -33,13 +33,14 @@ from pip._internal.vcs import is_url
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import get_distribution
 
 from piptools.locations import DEFAULT_CONFIG_FILE_NAMES
 from piptools.subprocess_utils import run_python_snippet
+
+from ._compat import canonicalize_name
 
 _KT = _t.TypeVar("_KT")
 _VT = _t.TypeVar("_VT")

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -13,8 +13,8 @@ from click.core import Context
 from pip._internal.models.format_control import FormatControl
 from pip._internal.req.req_install import InstallRequirement
 from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.utils import canonicalize_name
 
+from ._compat import canonicalize_name
 from .logging import log
 from .utils import (
     comment,


### PR DESCRIPTION
The type NormalizedName is just a NewType of str so it's compatible with return-type str. This means casting it to a str is never required.

no changelog needed

##### Contributor checklist

- [x] Included tests for the changes. **No-op refactor, tests not required**
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
