### PR TITLE
docs: add shell completion instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,29 +646,32 @@ This will be indicated in the output with one of the following suffixes:
 
 ### Shell completions
 
-`pip-tools` supports shell completions for `pip-compile` and `pip-sync` via `click`.
+`pip-tools` supports shell completions for `pip-compile` and `pip-sync`.
 
-For Bash:
+For Bash, add this to `~/.bashrc`:
 
-```console
-$ _PIP_COMPILE_COMPLETE=bash_source pip-compile > ~/.pip-tools-complete.bash
-$ _PIP_SYNC_COMPLETE=bash_source pip-sync >> ~/.pip-tools-complete.bash
-$ echo ". ~/.pip-tools-complete.bash" >> ~/.bashrc
+```bash
+eval "$(_PIP_COMPILE_COMPLETE=bash_source pip-compile)"
+eval "$(_PIP_SYNC_COMPLETE=bash_source pip-sync)"
 ```
 
-For Zsh:
+For Zsh, add this to `~/.zshrc`:
 
-```console
-$ _PIP_COMPILE_COMPLETE=zsh_source pip-compile > ~/.pip-tools-complete.zsh
-$ _PIP_SYNC_COMPLETE=zsh_source pip-sync >> ~/.pip-tools-complete.zsh
-$ echo ". ~/.pip-tools-complete.zsh" >> ~/.zshrc
+```bash
+eval "$(_PIP_COMPILE_COMPLETE=zsh_source pip-compile)"
+eval "$(_PIP_SYNC_COMPLETE=zsh_source pip-sync)"
 ```
 
-For Fish:
+For Fish, add this to `~/.config/fish/completions/pip-compile.fish`:
 
-```console
-$ _PIP_COMPILE_COMPLETE=fish_source pip-compile > ~/.config/fish/completions/pip-compile.fish
-$ _PIP_SYNC_COMPLETE=fish_source pip-sync > ~/.config/fish/completions/pip-sync.fish
+```fish
+_PIP_COMPILE_COMPLETE=fish_source pip-compile | source
+```
+
+And this to `~/.config/fish/completions/pip-sync.fish`:
+
+```fish
+_PIP_SYNC_COMPLETE=fish_source pip-sync | source
 ```
 
 ### Deprecations

--- a/changelog.d/+shell_completions.doc.md
+++ b/changelog.d/+shell_completions.doc.md
@@ -1,1 +1,1 @@
-Added documentation for shell completions for `pip-compile` and `pip-sync`.
+Added documentation for shell completions for `pip-compile` and `pip-sync` -- by {user}`Ahmed-AdelB`.


### PR DESCRIPTION
## Summary
- Add documentation for shell completion support via Click
- Include setup instructions for Bash, Zsh, and Fish shells
- Add corresponding changelog entry

## Related Issue
Closes #1702

## Changes
- Added "Shell completions" section to README.md with installation instructions
- Created changelog fragment `changelog.d/+shell_completions.doc.md`

## Test Plan
- [x] Verified `pip-compile` generates completion script with `_PIP_COMPILE_COMPLETE=bash_source`
- [x] Verified `pip-sync` generates completion script with `_PIP_SYNC_COMPLETE=bash_source`
- [x] Instructions follow Click's shell completion documentation

---
Ahmed Adel Bakr Alderai