### PR TITLE
Add the 'network' marker to a test (missing it)

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3615,6 +3615,7 @@ small-fake-b==0.3
 
 
 @backtracking_resolver_only
+@pytest.mark.network
 def test_compile_build_targets_setuptools_no_wheel_dep(
     runner,
     tmp_path,


### PR DESCRIPTION
I noticed some tests failing repeatedly in CI. Upon closer examination, we were missing the network/flaky marker on this one.

No changelog for a trivial test fix.

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
