### PR TITLE
Fix pip-sync --python-executable marker evaluation

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -436,6 +436,26 @@ def get_sys_path_for_python_executable(python_executable: str) -> list[str]:
     return [os.path.abspath(path) for path in paths]
 
 
+def get_environment_for_python_executable(
+    python_executable: str,
+) -> dict[str, str]:
+    """
+    Return the PEP 508 environment markers dict for the given python executable.
+
+    This is used to correctly evaluate environment markers when targeting a
+    different Python environment than the one running pip-tools.
+    """
+    code = (
+        "from pip._vendor.packaging.markers import default_environment;"
+        "import json;"
+        "print(json.dumps(default_environment()))"
+    )
+    result = _subprocess.run_python_snippet(python_executable, code)
+    env = json.loads(result)
+    assert isinstance(env, dict)
+    return env
+
+
 def omit_list_value(lst: list[_T], value: _T) -> list[_T]:
     """Produce a new list with a given value skipped."""
     return [item for item in lst if item != value]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,7 @@ from piptools.utils import (
     format_specifier,
     get_cli_options,
     get_compile_command,
+    get_environment_for_python_executable,
     get_hashes_from_ireq,
     get_sys_path_for_python_executable,
     is_pinned_requirement,
@@ -643,6 +644,35 @@ def test_get_sys_path_for_python_executable():
     # not testing for equality, because pytest adds extra paths into current sys.path
     for path in result:
         assert path in sys.path
+
+
+def test_get_environment_for_python_executable():
+    """
+    Test that get_environment_for_python_executable returns a valid PEP 508 environment.
+    """
+    from pip._vendor.packaging.markers import default_environment
+
+    result = get_environment_for_python_executable(sys.executable)
+
+    # Should return a dictionary with standard PEP 508 keys
+    expected_keys = {
+        "implementation_name",
+        "implementation_version",
+        "os_name",
+        "platform_machine",
+        "platform_release",
+        "platform_system",
+        "platform_version",
+        "python_full_version",
+        "python_version",
+        "sys_platform",
+    }
+    assert expected_keys.issubset(result.keys())
+
+    # Values should match the current environment
+    current_env = default_environment()
+    for key in expected_keys:
+        assert result[key] == current_env[key]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`pip-sync --python-executable` was evaluating environment markers (like `python_version < '3.12'`) against the **current** Python environment instead of the **target** environment specified by `--python-executable`.

### Problem

Running from Python 3.12 and targeting Python 3.11:

```bash
echo 'typing-extensions==4.12.2 ; python_version < "3.12"' > req.txt
pip-sync --python-executable=.venv311/bin/python req.txt
```

Would incorrectly say **'Everything up-to-date'** even though `typing-extensions` should be installed in the Python 3.11 environment.

The marker `python_version < '3.12'` was being evaluated against Python 3.12 (the running environment) returning `False`, rather than against Python 3.11 (the target environment) where it would return `True`.

### Root Cause

The `merge()` and `diff()` functions in `sync.py` use `ireq.match_markers()` which evaluates markers against `pip._vendor.packaging.markers.default_environment()` - the current Python's environment, not the target.

### Fix

**3 source files changed:**

1. **`piptools/utils.py`** - Added `get_environment_for_python_executable()` utility function to retrieve PEP 508 environment markers from the target Python executable

2. **`piptools/sync.py`** - Added `_match_markers()` helper function and modified `merge()` and `diff()` to accept an optional `environment` parameter for marker evaluation

3. **`piptools/scripts/sync.py`** - Obtains target environment using the new utility function and passes it to `merge()` and `diff()` when `--python-executable` is specified

## Test Plan

Added comprehensive tests in:
- `tests/test_sync.py` - Tests for `merge()` and `diff()` with custom environment
- `tests/test_utils.py` - Test for `get_environment_for_python_executable()`

Fixes #2115