### PR TITLE
Fix pip-sync to respect pip-compile's output_file config

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -93,8 +93,10 @@ def cli(
                 compile_output = get_compile_output_file_from_config(discovered_config)
                 if compile_output and os.path.exists(compile_output):
                     src_files = (compile_output,)
-                    log.debug(f"Using pip-compile output_file from discovered config: {compile_output}")
-            
+                    log.debug(
+                        f"Using pip-compile output_file from discovered config: {compile_output}"
+                    )
+
             if not src_files:
                 msg = "No requirement files given and no {} found in the current directory"
                 log.error(msg.format(DEFAULT_REQUIREMENTS_FILE))

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -590,7 +590,6 @@ def get_cli_options(ctx: click.Context) -> dict[str, click.Parameter]:
     return cli_opts
 
 
-
 def get_compile_output_file_from_config(config_file: Path | None) -> str | None:
     """
     Get pip-compile's output_file setting from config, if available.
@@ -619,7 +618,9 @@ def get_compile_output_file_from_config(config_file: Path | None) -> str | None:
     output_file = compile_config.get("output-file") or compile_config.get("output_file")
     if output_file is None:
         # Fall back to general pip-tools config
-        output_file = piptools_config.get("output-file") or piptools_config.get("output_file")
+        output_file = piptools_config.get("output-file") or piptools_config.get(
+            "output_file"
+        )
 
     return output_file
 

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -483,10 +483,10 @@ def test_sync_uses_compile_output_file_from_config(run, runner, tmpdir_cwd):
 
     # Create config with pip-compile output_file
     config_file = tmpdir_cwd / "pyproject.toml"
-    config_file.write_text(dedent(f'''\
+    config_file.write_text(dedent(f"""\
         [tool.pip-tools.compile]
         output-file = "{custom_output_file}"
-    '''))
+    """))
 
     # Run pip-sync without specifying src_files
     # It should read from pip-compile's output_file
@@ -509,10 +509,10 @@ def test_sync_uses_compile_output_file_from_general_config(run, runner, tmpdir_c
 
     # Create config with output_file in general section
     config_file = tmpdir_cwd / "pyproject.toml"
-    config_file.write_text(dedent(f'''\
+    config_file.write_text(dedent(f"""\
         [tool.pip-tools]
         output-file = "{custom_output_file}"
-    '''))
+    """))
 
     # Run pip-sync without specifying src_files
     out = runner.invoke(cli, ["--dry-run"])
@@ -535,10 +535,10 @@ def test_sync_explicit_src_files_overrides_config(run, runner, tmpdir_cwd):
 
     # Create config pointing to one file
     config_file = tmpdir_cwd / "pyproject.toml"
-    config_file.write_text(dedent('''\
+    config_file.write_text(dedent("""\
         [tool.pip-tools.compile]
         output-file = "requirements-config.txt"
-    '''))
+    """))
 
     # Run pip-sync with explicit file - should use CLI arg
     out = runner.invoke(cli, ["--dry-run", "requirements-cli.txt"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -805,10 +805,10 @@ def test_get_compile_output_file_from_config_compile_section(tmpdir_cwd):
     from piptools.utils import get_compile_output_file_from_config
 
     config_file = Path("pyproject.toml")
-    config_file.write_text(dedent('''\
+    config_file.write_text(dedent("""\
         [tool.pip-tools.compile]
         output-file = "requirements-lock.txt"
-    '''))
+    """))
 
     result = get_compile_output_file_from_config(config_file)
     assert result == "requirements-lock.txt"
@@ -819,10 +819,10 @@ def test_get_compile_output_file_from_config_general_section(tmpdir_cwd):
     from piptools.utils import get_compile_output_file_from_config
 
     config_file = Path("pyproject.toml")
-    config_file.write_text(dedent('''\
+    config_file.write_text(dedent("""\
         [tool.pip-tools]
         output-file = "general-requirements.txt"
-    '''))
+    """))
 
     result = get_compile_output_file_from_config(config_file)
     assert result == "general-requirements.txt"
@@ -833,13 +833,13 @@ def test_get_compile_output_file_from_config_compile_overrides_general(tmpdir_cw
     from piptools.utils import get_compile_output_file_from_config
 
     config_file = Path("pyproject.toml")
-    config_file.write_text(dedent('''\
+    config_file.write_text(dedent("""\
         [tool.pip-tools]
         output-file = "general-requirements.txt"
         
         [tool.pip-tools.compile]
         output-file = "compile-requirements.txt"
-    '''))
+    """))
 
     result = get_compile_output_file_from_config(config_file)
     assert result == "compile-requirements.txt"
@@ -858,10 +858,10 @@ def test_get_compile_output_file_from_config_no_output_file(tmpdir_cwd):
     from piptools.utils import get_compile_output_file_from_config
 
     config_file = Path("pyproject.toml")
-    config_file.write_text(dedent('''\
+    config_file.write_text(dedent("""\
         [tool.pip-tools]
         dry-run = true
-    '''))
+    """))
 
     result = get_compile_output_file_from_config(config_file)
     assert result is None


### PR DESCRIPTION
## Summary

`pip-sync` now reads `pip-compile`'s `output_file` configuration to determine the default input file when no `src_files` are specified on the command line.

### Problem

With the current behavior, users who configure `pip-compile` to output to a custom file need to also configure or specify that file for `pip-sync`:

```toml
[tool.pip-tools.compile]
output-file = "requirements-lock.txt"
```

```bash
pip-compile      # outputs to requirements-lock.txt
pip-sync         # ERROR: can't find requirements.txt
pip-sync requirements-lock.txt  # works, but redundant
```

### Solution

pip-sync now checks pip-compile's `output_file` config as a fallback:

```bash
pip-compile      # outputs to requirements-lock.txt  
pip-sync         # automatically reads from requirements-lock.txt
```

### Precedence Order

For pip-sync input file:
1. Command-line `src_files` argument (highest priority)
2. pip-compile's `output_file` from `--config` file (if specified)
3. pip-compile's `output_file` from discovered config
4. Default `requirements.txt`

### Files Changed

**2 source files:**
1. `piptools/utils.py` - Added `get_compile_output_file_from_config()` utility
2. `piptools/scripts/sync.py` - Use the utility to determine default src_files

## Test Plan

Added tests in:
- `tests/test_utils.py` - Unit tests for `get_compile_output_file_from_config()`
- `tests/test_cli_sync.py` - Integration tests for pip-sync using compile config

Fixes #2093