### PR TITLE
fix: filter out self-referencing requirements from compiled output

### DIFF
--- a/changelog.d/2110.bugfix.md
+++ b/changelog.d/2110.bugfix.md
@@ -1,0 +1,1 @@
+Self-referencing requirements (e.g., recursive extra dependencies) are now filtered out from the compiled output to prevent non-portable file:// URLs.

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -47,6 +47,7 @@ else:
 class StaticProjectMetadata:
     extras: tuple[str, ...]
     requirements: tuple[InstallRequirement, ...]
+    source_project_name: str | None = None
 
 
 @dataclass
@@ -54,6 +55,7 @@ class ProjectMetadata:
     extras: tuple[str, ...]
     requirements: tuple[InstallRequirement, ...]
     build_requirements: tuple[InstallRequirement, ...]
+    source_project_name: str | None = None
 
 
 def maybe_statically_parse_project_metadata(
@@ -115,6 +117,7 @@ def maybe_statically_parse_project_metadata(
     return StaticProjectMetadata(
         extras=tuple(extras),
         requirements=tuple(install_requirements),
+        source_project_name=package_name,
     )
 
 
@@ -186,6 +189,7 @@ def build_project_metadata(
             extras=extras,
             requirements=requirements,
             build_requirements=build_requirements,
+            source_project_name=_get_name(metadata),
         )
 
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -4159,8 +4159,13 @@ def test_that_self_referential_pyproject_toml_extra_can_be_compiled(
     Test that a :file:`pyproject.toml` source file can use self-referential extras
     which point back to the original package name.
 
+    Self-referential extras (e.g., ``ext2 = ["foo[ext1]"]``) are resolved but
+    the self-reference should be filtered out from the output file since it
+    would create non-portable file:// URLs.
+
     This is a regression test for:
     https://github.com/jazzband/pip-tools/issues/2215
+    https://github.com/jazzband/pip-tools/issues/2110
     """
     src_file = tmp_path / "pyproject.toml"
     src_file.write_text(dedent("""
@@ -4197,9 +4202,9 @@ def test_that_self_referential_pyproject_toml_extra_can_be_compiled(
         )
 
     assert out.exit_code == 0
-    assert out.stdout == dedent(f"""\
-        foo[ext1] @ {src_file.parent.absolute().as_uri()}
-            # via foo ({input_path})
+    # Self-referential extras should be filtered out from the output
+    # (See https://github.com/jazzband/pip-tools/issues/2110)
+    assert out.stdout == dedent("""\
         small-fake-a==0.2
             # via foo
         """)


### PR DESCRIPTION
## Summary

When a project has recursive extra dependencies that reference itself (e.g., `dev = ["package[test,tools]"]`), the compiled output would include a non-portable `file://` URL reference to the local project.

This change filters out such self-referencing requirements from the output, ensuring the compiled requirements.txt is portable.

## Changes

- Add `source_project_name` field to metadata classes in `build.py`
- Add `is_self_referencing_requirement()` utility function in `utils.py`
- Collect source project names during metadata parsing in `compile.py`
- Filter out self-references before writing to output file

## Test plan

- [x] Added unit tests for `is_self_referencing_requirement()`
- [x] Updated existing test `test_that_self_referential_pyproject_toml_extra_can_be_compiled` to expect filtered output
- [x] All tests pass locally

Fixes #2110