### PR TITLE
Increase the GHA testsuite timeout to 15m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
   test:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 9
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The existing 9m mark can actually be reached on Windows runners, when they are slower than usual.

I observed this recently while trying to get reruns of CI to pass after a GitHub outage:
  https://github.com/jazzband/pip-tools/actions/runs/21367431586/job/62022523913

No changelog for this, as it's purely repo CI config.

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] ~A change note is created in `changelog.d/` (see [`changelog.d/README.md`](https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme) for instructions) or the PR text says "no changelog needed".~

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
