### PR TITLE
Add better self-testing of the local coverage plugin and meta-coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,4 @@ codecov:
 
 comment: false # avoid spamming reviews
 
-ignore:
-  - "tests/_plugins/_coverage/*"
-
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,92 @@ jobs:
             Py-${{ steps.python-install.outputs.python-version }},
             Pip-${{ matrix.pip-version }}
 
+  test-local-coverage-plugin:
+    name: test-coverage-plugin / ${{ matrix.runner-vm }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.runner-vm }}
+    timeout-minutes: 9
+    strategy:
+      fail-fast: false
+      matrix:
+        runner-vm:
+          - ubuntu-24.04
+          - macos-15-intel
+          - windows-2025
+        python-version:
+          - "3.9"
+          - "3.14"
+    env:
+      TOXENV: test-coverage-plugin
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        shell: bash
+        run: |
+          echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
+      - name: Pip cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: >-
+            ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{
+            hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{
+            hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install tox
+        run: pip install tox
+      - name: Prepare test environment
+        run: tox --notest -p auto
+      - name: Run Tests
+        run: tox --skip-pkg-install
+      - name: Re-run the failing tests with maximum verbosity
+        if: >-
+          !cancelled()
+          && failure()
+        run: >-  # `exit 1` makes sure that the job remains red with flaky runs
+          python -Xutf8 -Im
+          tox
+          --parallel=auto
+          --parallel-live
+          --skip-missing-interpreters=false
+          --skip-pkg-install
+          -vvvvv
+          --
+          --continue-on-collection-errors
+          --full-trace
+          --last-failed
+          --numprocesses=0
+          --showlocals
+          --trace-config
+          -rA
+          -vvvvv
+          && exit 1
+        shell: bash
+      - name: Upload coverage to Codecov
+        if: >-
+          !cancelled()
+          && !inputs.cpython-pip-version
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: >-
+            CI-GHA,
+            OS-${{ runner.os }},
+            VM-${{ matrix.runner-vm }},
+            Py-${{ matrix.python-version }},
+            LocalCoveragePlugin
+          name: >-
+            OS-${{ runner.os }},
+            VM-${{ matrix.runner-vm }},
+            Py-${{ matrix.python-version }},
+            LocalCoveragePlugin
+
   pypy:
     name: ${{ matrix.runner-vm }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
     runs-on: ${{ matrix.runner-vm }}
@@ -531,6 +617,7 @@ jobs:
     needs:
       - pre-setup  # transitive, for accessing settings
       - test
+      - test-local-coverage-plugin
     steps:
       - name: Notify Codecov that all coverage reports have been uploaded
         if: >-

--- a/tests/_plugins/_coverage/coveragerc
+++ b/tests/_plugins/_coverage/coveragerc
@@ -1,0 +1,11 @@
+# a customized coverage config for generating coverage data when testing the plugin itself
+[run]
+plugins =
+    covdefaults
+
+[report]
+exclude_also =
+    ^\s*@pytest\.mark\.xfail
+
+include =
+    tests/_plugins/_coverage/*

--- a/tests/_plugins/_coverage/piptools_coverage.py
+++ b/tests/_plugins/_coverage/piptools_coverage.py
@@ -6,9 +6,9 @@ import pathlib
 import sys
 import typing as _t
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 from coverage import CoveragePlugin

--- a/tests/test_local_coverage_plugin.py
+++ b/tests/test_local_coverage_plugin.py
@@ -130,3 +130,91 @@ def test_computed_pragmas_state_no_cover_below_previous_major_version():
     assert nocover_eq_pragma not in computed_pragmas
     assert cover_le_pragma in computed_pragmas
     assert nocover_le_pragma not in computed_pragmas
+
+
+def test_init_registers_plugin_object_as_configurer():
+    # this test basically just runs `coverage_init` without trying to verify
+    # that our usage of `coverage` APIs is correct -- we make sure that the
+    # code can run without error, but not much else
+    mock_registry = mock.Mock()
+    piptools_coverage.coverage_init(mock_registry, {})
+
+    mock_registry.add_configurer.assert_called_once()
+    call_args = mock_registry.add_configurer.call_args[0]
+    assert len(call_args) == 1
+    plugin = call_args[0]
+    assert isinstance(plugin, piptools_coverage.PipVersionPragmas)
+
+
+@pytest.mark.parametrize("prior_exclude_lines", ([], ["NotImplementedError"]))
+def test_plugin_configure_expands_excludes_with_pragmas(prior_exclude_lines):
+    def mock_get_option(optname):
+        if optname == "report:exclude_lines":
+            return prior_exclude_lines
+        elif optname == "report:partial_branches":
+            return []
+        pytest.fail(
+            f"get_option on mock config called with unexpected option name: {optname}"
+        )
+
+    mock_config = mock.Mock()
+    mock_config.get_option = mock_get_option
+
+    plugin = piptools_coverage.PipVersionPragmas()
+    plugin.configure(mock_config)
+
+    mock_config.set_option.assert_any_call("report:exclude_lines", mock.ANY)
+    set_exclude_lines_calls = [
+        c
+        for c in mock_config.set_option.call_args_list
+        if c.args and c.args[0] == "report:exclude_lines"
+    ]
+    assert len(set_exclude_lines_calls) == 1
+    call_args = set_exclude_lines_calls[0].args
+    assert len(call_args) == 2, call_args
+    _optname, excludes = call_args
+    # no prior excludes were lost
+    assert set(excludes) >= set(prior_exclude_lines)
+
+    # check that the current version
+    # goes into excludes under '==', '>=', or '<=' and not under `>` and `<`
+    # this minimally verifies that "it worked"
+    current = ".".join(str(x) for x in _pip_api.PIP_VERSION_MAJOR_MINOR)
+    assert rf"# pragma: pip=={current} no cover\b" in excludes
+    assert rf"# pragma: pip>={current} no cover\b" in excludes
+    assert rf"# pragma: pip<={current} no cover\b" in excludes
+
+    assert rf"# pragma: pip>{current} no cover\b" not in excludes
+    assert rf"# pragma: pip<{current} no cover\b" not in excludes
+
+
+def test_plugin_configure_sets_partial_branches_even_if_no_value():
+    def mock_get_option(optname):
+        if optname == "report:exclude_lines":
+            return []
+        # when partial_branches is retrieved, return None
+        # the plugin must convert this value to an empty list to function correctly
+        elif optname == "report:partial_branches":
+            return None
+        pytest.fail(
+            f"get_option on mock config called with unexpected option name: {optname}"
+        )
+
+    mock_config = mock.Mock()
+    mock_config.get_option = mock_get_option
+
+    plugin = piptools_coverage.PipVersionPragmas()
+    plugin.configure(mock_config)
+
+    mock_config.set_option.assert_any_call("report:partial_branches", mock.ANY)
+    set_partial_branches_calls = [
+        c
+        for c in mock_config.set_option.call_args_list
+        if c.args and c.args[0] == "report:partial_branches"
+    ]
+    assert len(set_partial_branches_calls) == 1
+    call_args = set_partial_branches_calls[0].args
+    assert len(call_args) == 2, call_args
+    _optname, branch_patterns = call_args
+    # the static pragma is present
+    assert piptools_coverage.ANY_PIP_VERSION_PRAGMA in branch_patterns

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,15 @@ passenv =
     PY_COLORS
 pip_pre=True
 
+
+[testenv:test-coverage-plugin]
+description = test the local coverage plugin
+setenv =
+    PYTEST_ADDOPTS=--strict-markers --doctest-modules --cov --cov-report=term-missing --cov-report=xml {env:PYTEST_ADDOPTS:}
+    COVERAGE_RCFILE=./tests/_plugins/_coverage/coveragerc
+commands = pytest tests/test_local_coverage_plugin.py {posargs}
+
+
 [testenv:checkqa]
 description = format the code base and check its quality
 skip_install = True


### PR DESCRIPTION
*This is a draft on top of #2347; see that PR for more context.*

Add a separate tox environment and CI job for doing the testing of the coverage
plugin itself.

Because the plugin uses a separate coverage config for this test, both it and
normal coverage can be maintained at 100%, and codecov can aggregate the two.

---

Because this is a draft right now, I'm not clear on whether or not it should get
a separate changelog? I feel like it should fold into the one for #2347.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [ ] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
