### PR TITLE
🐛 fix(sync): tolerate pip 26.1 DirectUrl shape rename

### DIFF
--- a/changelog.d/2379.feature.md
+++ b/changelog.d/2379.feature.md
@@ -1,0 +1,1 @@
+`pip-tools` is now compatible with `pip` 26.1 -- {user}`gaborbernat`.

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, Mapping, ValuesView
 from subprocess import run  # nosec
 
 import click
-from pip._internal.models.direct_url import ArchiveInfo
+from pip._internal.models.direct_url import ArchiveInfo, DirectUrl
 from pip._internal.req import InstallRequirement
 from pip._internal.utils.compat import stdlib_pkgs
 from pip._internal.utils.direct_url_helpers import (
@@ -146,14 +146,19 @@ def diff_key_from_ireq(ireq: InstallRequirement) -> str:
 def diff_key_from_req(req: Distribution) -> str:
     """Get a unique key for the requirement."""
     key = canonicalize_name(req.key)
-    if (
-        req.direct_url
-        and isinstance(req.direct_url.info, ArchiveInfo)
-        and req.direct_url.info.hash
-    ):
+    if req.direct_url and _direct_url_has_archive_hash(req.direct_url):
         key = direct_url_as_pep440_direct_reference(req.direct_url, key)
     # TODO: Also support VCS and editable installs.
     return key
+
+
+def _direct_url_has_archive_hash(direct_url: DirectUrl) -> bool:
+    info = getattr(direct_url, "archive_info", None) or getattr(
+        direct_url, "info", None
+    )
+    if not isinstance(info, ArchiveInfo):
+        return False
+    return bool(getattr(info, "hashes", None) or getattr(info, "hash", None))
 
 
 def diff(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ changelog = "https://github.com/jazzband/pip-tools/releases"
 [project.optional-dependencies]
 testing = [
   "pytest >= 7.2.0",
+  "pytest-mock >= 3.15.1",
   "pytest-rerunfailures",
   "pytest-xdist",
   "tomli-w",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,10 +8,18 @@ from collections import Counter
 from unittest import mock
 
 import pytest
+from pip._internal.models.direct_url import ArchiveInfo, DirectUrl
 from pip._internal.utils.urls import path_to_url
+from pytest_mock import MockerFixture
 
 from piptools.exceptions import IncompatibleRequirements
-from piptools.sync import dependency_tree, diff, merge, sync
+from piptools.sync import (
+    _direct_url_has_archive_hash,
+    dependency_tree,
+    diff,
+    merge,
+    sync,
+)
 
 from .constants import PACKAGES_PATH
 
@@ -325,6 +333,89 @@ def test_diff_with_unequal_url_hash(fake_dist, from_line):
     to_install, to_uninstall = diff(reqs, installed)
     assert to_install == set(reqs)
     assert to_uninstall == {"example @ file:///example.zip#sha1=abc"}
+
+
+@pytest.fixture
+def archive_info(mocker: MockerFixture) -> ArchiveInfo:
+    info = mocker.create_autospec(ArchiveInfo, instance=True)
+    info.hashes = None
+    info.hash = None
+    return info
+
+
+@pytest.fixture
+def direct_url_new_shape(mocker: MockerFixture) -> DirectUrl:
+    return mocker.create_autospec(DirectUrl, instance=True, spec_set=False)
+
+
+@pytest.fixture
+def direct_url_old_shape(mocker: MockerFixture) -> DirectUrl:
+    return mocker.Mock(spec=["info"])
+
+
+@pytest.mark.parametrize(
+    ("hashes", "hash_", "expected"),
+    (
+        pytest.param({"sha256": "abc"}, None, True, id="hashes-present"),
+        pytest.param({}, None, False, id="hashes-empty"),
+        pytest.param(None, "sha256=abc", True, id="legacy-hash-present-on-new-shape"),
+        pytest.param(None, None, False, id="both-missing"),
+    ),
+)
+def test_direct_url_has_archive_hash_new_shape(
+    direct_url_new_shape: DirectUrl,
+    archive_info: ArchiveInfo,
+    hashes: dict[str, str] | None,
+    hash_: str | None,
+    expected: bool,
+) -> None:
+    archive_info.hashes = hashes
+    archive_info.hash = hash_
+    direct_url_new_shape.archive_info = archive_info
+    assert _direct_url_has_archive_hash(direct_url_new_shape) is expected
+
+
+@pytest.mark.parametrize(
+    ("hashes", "hash_", "expected"),
+    (
+        pytest.param(None, "sha256=abc", True, id="hash-present"),
+        pytest.param(None, None, False, id="hash-missing"),
+        pytest.param({"sha256": "abc"}, None, True, id="hashes-still-honored"),
+    ),
+)
+def test_direct_url_has_archive_hash_old_shape(
+    direct_url_old_shape: DirectUrl,
+    archive_info: ArchiveInfo,
+    hashes: dict[str, str] | None,
+    hash_: str | None,
+    expected: bool,
+) -> None:
+    archive_info.hashes = hashes
+    archive_info.hash = hash_
+    direct_url_old_shape.info = archive_info
+    assert _direct_url_has_archive_hash(direct_url_old_shape) is expected
+
+
+def test_direct_url_has_archive_hash_returns_false_when_archive_info_none(
+    direct_url_new_shape: DirectUrl,
+) -> None:
+    direct_url_new_shape.archive_info = None
+    assert _direct_url_has_archive_hash(direct_url_new_shape) is False
+
+
+def test_direct_url_has_archive_hash_returns_false_when_info_none(
+    direct_url_old_shape: DirectUrl,
+) -> None:
+    direct_url_old_shape.info = None
+    assert _direct_url_has_archive_hash(direct_url_old_shape) is False
+
+
+def test_direct_url_has_archive_hash_returns_false_for_non_archive_info(
+    mocker: MockerFixture,
+) -> None:
+    direct_url = mocker.create_autospec(DirectUrl, instance=True, spec_set=False)
+    direct_url.archive_info = mocker.Mock(spec=[])
+    assert _direct_url_has_archive_hash(direct_url) is False
 
 
 def test_sync_install_temporary_requirement_file(

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,8 @@ extras =
     testing
     coverage: coverage
 deps =
-    pipsupported: pip == 26.0
+    pipsupported: pip == 26.0 ; python_version < "3.10"
+    pipsupported: pip == 26.1 ; python_version >= "3.10"
     pipsupported: setuptools <= 80.0
 
     piplowest: pip == 22.2.* ; python_version < "3.12"


### PR DESCRIPTION
`pip>=26.1` renamed `DirectUrl.info` to `DirectUrl.archive_info` and `ArchiveInfo.hash` to `ArchiveInfo.hashes`. `pip-sync` reads both names when computing the diff key for URL-pinned distributions and crashes with `AttributeError: 'DirectUrl' object has no attribute 'info'` against the new pip. Issue #2379 tracks this as the first of the pip 26.1 regressions.

The patch probes `archive_info`/`hashes` first, falls back to `info`/`hash`, and keeps the existing `isinstance(_, ArchiveInfo)` guard. The dual-shape probe sits in a small helper to keep the diff-key call site readable.

Refs #2379.