### PR TITLE
🐛 fix(compile): redact secrets in --pip-args header capture

### DIFF
--- a/changelog.d/2385.bugfix.md
+++ b/changelog.d/2385.bugfix.md
@@ -1,0 +1,4 @@
+{program}`pip-compile` now redacts credential-bearing tokens (`--cert`,
+`--client-cert`, `--proxy`, `--config-settings`, `-C`, embedded URL
+basic-auth) inside `--pip-args` before recording the command in the
+requirements-file header -- {user}`gaborbernat`.

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -394,11 +394,41 @@ def get_compile_command(click_ctx: click.Context) -> str:
                     # shlex.quote() would produce functional but noisily quoted results,
                     # e.g. --pip-args='--cache-dir='"'"'/tmp/with spaces'"'"''
                     # Instead, we try to get more legible quoting via repr:
-                    left_args.append(f"{option_long_name}={repr(val)}")
+                    left_args.append(
+                        f"{option_long_name}={repr(_redact_pip_args_str(val))}"
+                    )
                 else:
                     left_args.append(f"{option_long_name}={shlex.quote(str(val))}")
 
     return " ".join(["pip-compile", *sorted(left_args), *sorted(right_args)])
+
+
+_REDACTED_PIP_PATH_OPTIONS = frozenset(
+    {"--cert", "--client-cert", "--proxy", "--config-settings", "-C"}
+)
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def _redact_pip_args_str(value: str) -> str:
+    cleaned: list[str] = []
+    skip_next: str | None = None
+    for token in shlex.split(value):
+        if skip_next is not None:
+            if skip_next in {"--config-settings", "-C"} and "=" in token:
+                cleaned.append(f"{token.partition('=')[0]}=<REDACTED>")
+            else:
+                cleaned.append("<REDACTED>")
+            skip_next = None
+            continue
+        if token in _REDACTED_PIP_PATH_OPTIONS:
+            cleaned.append(token)
+            skip_next = token
+            continue
+        if "://" in token:
+            cleaned.append(redact_auth_from_url(token))
+            continue
+        cleaned.append(token)
+    return " ".join(_CONTROL_CHARS.sub("�", token) for token in cleaned)
 
 
 def get_required_pip_specification() -> SpecifierSet:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -426,6 +426,41 @@ def test_is_url_requirement_filename(caplog, from_line, line):
             "pip-compile --find-links='https://username:****@example.com/'",
             id="redact password in link",
         ),
+        pytest.param(
+            ["--pip-args", "--cert /etc/ssl/private.pem"],
+            "pip-compile --pip-args='--cert <REDACTED>'",
+            id="redact pip-args cert path",
+        ),
+        pytest.param(
+            ["--pip-args", "--client-cert /home/me/.pki/client.pem"],
+            "pip-compile --pip-args='--client-cert <REDACTED>'",
+            id="redact pip-args client-cert path",
+        ),
+        pytest.param(
+            ["--pip-args", "--proxy http://user:pw@proxy.local:8080"],
+            "pip-compile --pip-args='--proxy <REDACTED>'",
+            id="redact pip-args proxy",
+        ),
+        pytest.param(
+            ["--pip-args", "--config-settings auth=hunter2"],
+            "pip-compile --pip-args='--config-settings auth=<REDACTED>'",
+            id="redact pip-args config-settings value",
+        ),
+        pytest.param(
+            ["--pip-args", "-C auth=hunter2"],
+            "pip-compile --pip-args='-C auth=<REDACTED>'",
+            id="redact pip-args short config-settings value",
+        ),
+        pytest.param(
+            ["--pip-args", "--config-settings standalone"],
+            "pip-compile --pip-args='--config-settings <REDACTED>'",
+            id="redact pip-args config-settings without equals",
+        ),
+        pytest.param(
+            ["--pip-args", "--extra-index-url https://user:pw@host/simple"],
+            "pip-compile --pip-args='--extra-index-url https://user:****@host/simple'",
+            id="redact pip-args embedded url",
+        ),
     ),
 )
 def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):


### PR DESCRIPTION
`get_compile_command` records the invocation argv in the requirements-file header so reviewers can reproduce the resolution. URL basic-auth on top-level options like `--extra-index-url` already runs through pip's `redact_auth_from_url`, but the contents of `--pip-args` slip through. `pip-compile --pip-args='--cert /etc/ssl/private.pem'` and `pip-compile --pip-args='--config-settings token=hunter2 --extra-index-url https://user:pw@host/simple'` land in the committed `requirements.txt` and leak the contents to anyone with read access to the repository.

The patch walks the `shlex`-split tokens of `pip_args_str` and replaces the value following `--cert`, `--client-cert`, `--proxy`, `--config-settings`, and `-C` with `<REDACTED>`. The flag itself stays so the header documents which knobs were tuned. URL tokens still go through `redact_auth_from_url`, and C0/C1 control characters get normalised to `�` so a malicious filename cannot smuggle a CR that re-orders the rendered header. The redaction lives in a small private helper next to `get_compile_command`; the existing top-level URL redaction path stays unchanged.