### PR TITLE
Recognize the project's _t typing alias in coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,5 +6,10 @@ omit =
 [report]
 include = piptools/*, tests/*
 fail_under = 99
+
+# custom excludes extend baselines from coverage + covdefaults
+# for reference, see
+# coverage: https://coverage.readthedocs.io/en/latest/excluding.html#default-exclusions
+# covdefaults: https://github.com/asottile/covdefaults/blob/8d8712c26ad505f1269851a7c8431b8c1fedaa62/covdefaults.py#L86-L105
 exclude_also =
     ^\s*if _t\.TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,4 @@ omit =
 include = piptools/*, tests/*
 fail_under = 99
 exclude_also =
-    # The covdefaults regex matches `if (t|te|typ|typi|typin|typing)\.TYPE_CHECKING:`
-    # but the project aliases `typing` as `_t`, which falls outside that pattern.
-    # Also exclude it from coverage measurements.
     ^\s*if _t\.TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,8 @@ omit =
 [report]
 include = piptools/*, tests/*
 fail_under = 99
+exclude_also =
+    # The covdefaults regex matches `if (t|te|typ|typi|typin|typing)\.TYPE_CHECKING:`
+    # but the project aliases `typing` as `_t`, which falls outside that pattern.
+    # Also exclude it from coverage measurements.
+    ^\s*if _t\.TYPE_CHECKING:

--- a/changelog.d/2386.contrib.md
+++ b/changelog.d/2386.contrib.md
@@ -1,2 +1,2 @@
-Improve coverage reporting by skipping the project's `_t = typing` alias
-in `TYPE_CHECKING` blocks -- by {user}`gaborbernat`.
+coverage reporting in pip-tools now skips ``_t.TYPE_CHECKING`` blocks -- by
+{user}`gaborbernat`.

--- a/changelog.d/2386.contrib.md
+++ b/changelog.d/2386.contrib.md
@@ -1,0 +1,2 @@
+Improve coverage reporting by skipping the project's `_t = typing` alias
+in `TYPE_CHECKING` blocks -- by {user}`gaborbernat`.

--- a/changelog.d/2386.contrib.md
+++ b/changelog.d/2386.contrib.md
@@ -1,2 +1,2 @@
-coverage reporting in pip-tools now skips ``_t.TYPE_CHECKING`` blocks -- by
+Coverage reporting in `pip-tools` now skips `_t.TYPE_CHECKING` blocks -- by
 {user}`gaborbernat`.

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -27,11 +27,11 @@ PYPROJECT_TOML = "pyproject.toml"
 _T = _t.TypeVar("_T")
 
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     from importlib.metadata import PackageMetadata
-else:
+else:  # pragma: <3.10 cover
 
-    class PackageMetadata(_t.Protocol):
+    class PackageMetadata(_t.Protocol):  # pragma: <3.10 cover
         @_t.overload
         def get_all(self, name: str, failobj: None = None) -> list[_t.Any] | None: ...
 

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -31,7 +31,7 @@ if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     from importlib.metadata import PackageMetadata
 else:  # pragma: <3.10 cover
 
-    class PackageMetadata(_t.Protocol):  # pragma: <3.10 cover
+    class PackageMetadata(_t.Protocol):
         @_t.overload
         def get_all(self, name: str, failobj: None = None) -> list[_t.Any] | None: ...
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -27,10 +27,10 @@ from .utils import (
     strip_extras,
 )
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self as _t_Self
-else:
-    from typing_extensions import Self as _t_Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self as _t_Self  # pragma: <3.11 cover
 
 
 MESSAGE_UNHASHED_PACKAGE = comment(

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -30,7 +30,7 @@ from .utils import (
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self as _t_Self
 else:  # pragma: <3.11 cover
-    from typing_extensions import Self as _t_Self  # pragma: <3.11 cover
+    from typing_extensions import Self as _t_Self
 
 
 MESSAGE_UNHASHED_PACKAGE = comment(


### PR DESCRIPTION
`covdefaults` ships a default `exclude_lines` regex for `if typing.TYPE_CHECKING:` and `if t.TYPE_CHECKING:`, but pip-tools aliases `typing` as `_t` and the default regex misses those blocks. The lines inside are unreachable at runtime, so they show up as missed in the coverage report and noise the diff for any contributor whose change touches a module with a type-only import block.

The `exclude_also` entry covers the project's `_t` convention. The two `sys.version_info`-conditional import branches in `piptools.build` and `piptools.writer` get `# pragma:` markers so `covdefaults` recognises the unreachable side on a given Python version instead of counting it as missing.

Per @webknjaz's review on the prior #2386 scope, the CI workflow rework stays out of this PR; webknjaz will land the GHA changes separately by syncing setup from sibling projects.

---

No changelog fragment: not a user-facing change.