### PR TITLE
♻️ refactor(local): accept any BaseRepository as the proxied repo

### DIFF
--- a/changelog.d/2387.contrib.md
+++ b/changelog.d/2387.contrib.md
@@ -1,4 +1,4 @@
-Widen `proxied_repository` on
-{class}`piptools.repositories.LocalRequirementsRepository` to accept any
-{class}`piptools.repositories.BaseRepository` subclass, not only
-{class}`piptools.repositories.PyPIRepository` -- {user}`gaborbernat`.
+{class}`~piptools.repositories.LocalRequirementsRepository` now accepts any
+{class}`~piptools.repositories.BaseRepository` subclass as its proxied
+repository, not only {class}`~piptools.repositories.PyPIRepository`
+-- by {user}`gaborbernat`.

--- a/changelog.d/2387.contrib.md
+++ b/changelog.d/2387.contrib.md
@@ -1,0 +1,4 @@
+Widen `proxied_repository` on
+{class}`piptools.repositories.LocalRequirementsRepository` to accept any
+{class}`piptools.repositories.BaseRepository` subclass, not only
+{class}`piptools.repositories.PyPIRepository` -- {user}`gaborbernat`.

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -15,7 +15,6 @@ from pip._internal.utils.hashes import FAVORITE_HASH
 from .._internal import _pip_api
 from ..utils import as_tuple, key_from_ireq
 from .base import BaseRepository
-from .pypi import PyPIRepository
 
 
 def ireq_satisfied_by_existing_pin(
@@ -46,7 +45,7 @@ class LocalRequirementsRepository(BaseRepository):
     def __init__(
         self,
         existing_pins: Mapping[str, InstallationCandidate],
-        proxied_repository: PyPIRepository,
+        proxied_repository: BaseRepository,
         reuse_hashes: bool = True,
     ):
         self._reuse_hashes = reuse_hashes


### PR DESCRIPTION
`LocalRequirementsRepository` is annotated to require `PyPIRepository` for the `proxied_repository` argument, but the body only calls members declared on `BaseRepository` itself: `find_best_match`, `get_dependencies`, `get_hashes`, `allow_all_wheels`, and the read-only `options`/`finder`/`session`/`command` properties. The narrower annotation blocks third parties from wrapping a custom `BaseRepository` subclass in the local existing-pin cache without a `type: ignore` at the call site. The internal test suite already exercises the looser contract via `FakeRepository(BaseRepository)`, so no production caller relies on the narrower type.

Widening the parameter to `BaseRepository` and dropping the now-unused `PyPIRepository` import is a no-op for existing `PyPIRepository` callers (it is a `BaseRepository` subclass). The change touches only `piptools/repositories/local.py`; no callers in the codebase need updating because `PyPIRepository` is unchanged.