### PR TITLE
Drop stray whitespace before !s in f-string conversion flags

### DIFF
--- a/changelog.d/2388.contrib.md
+++ b/changelog.d/2388.contrib.md
@@ -1,0 +1,7 @@
+A handful of f-string conversions in :mod:`piptools.utils` and the CLI
+entry points in :mod:`piptools.scripts.compile` and
+:mod:`piptools.scripts.sync` carried a stray space before ``!s`` (e.g.
+``f"...{value !s}..."``). PEP 498 forbids the whitespace before the
+conversion flag and tooling differs on whether the form parses; the
+literals are now in canonical ``{value!s}`` shape -- by
+:user:`gaborbernat` in :pr:`2388`.

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -270,7 +270,7 @@ def cli(
         )
 
     if config:
-        log.debug(f"Using pip-tools configuration defaults found in '{config !s}'.")
+        log.debug(f"Using pip-tools configuration defaults found in '{config!s}'.")
 
     if resolver_name == "legacy":
         log.warning(

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -112,7 +112,7 @@ def cli(
             sys.exit(2)
 
     if config:
-        log.debug(f"Using pip-tools configuration defaults found in '{config !s}'.")
+        log.debug(f"Using pip-tools configuration defaults found in '{config!s}'.")
 
     if python_executable:
         _validate_python_executable(python_executable)

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -591,12 +591,12 @@ def parse_config_file(
     except OSError as os_err:
         raise click.FileError(
             filename=str(config_file),
-            hint=f"Could not read '{config_file !s}': {os_err !s}",
+            hint=f"Could not read '{config_file!s}': {os_err!s}",
         )
     except ValueError as value_err:
         raise click.FileError(
             filename=str(config_file),
-            hint=f"Could not parse '{config_file !s}': {value_err !s}",
+            hint=f"Could not parse '{config_file!s}': {value_err!s}",
         )
 
     # In a TOML file, we expect the config to be under `[tool.pip-tools]`,


### PR DESCRIPTION
A handful of f-strings in `piptools.utils`, `piptools.scripts.compile`, and `piptools.scripts.sync` carry a stray space between the value and the conversion flag (`f"...{value !s}..."`). PEP 498 forbids whitespace before `!s`/`!r`/`!a` and `ruff format` rewrites the form when it normalises a file, so the next time a formatter pass touches one of these modules the contributor's diff would carry an unrelated reformat hunk.

Cleaning the literals up now keeps the files canonical with no behaviour change. The rendered output is identical because Python today still parses the form (it just normalises away the whitespace internally).