### PR TITLE
Clarify pip-compile CLI help for --extra, --upgrade-package, --no-build-isolation

### DIFF
--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -106,14 +106,17 @@ extra = click.option(
     "--extra",
     "extras",
     multiple=True,
-    help="Name of an extras_require group to install; may be used more than once",
+    help=(
+        "Name of an extras_require group to install; may be used more than "
+        "once. Pass ``--all-extras`` to include every declared extra."
+    ),
 )
 
 all_extras = click.option(
     "--all-extras",
     is_flag=True,
     default=False,
-    help="Install all extras_require groups",
+    help="Install all extras_require groups (see also: ``--extra`` for one at a time)",
 )
 
 find_links = click.option(
@@ -214,7 +217,11 @@ upgrade_package = click.option(
     "upgrade_packages",
     nargs=1,
     multiple=True,
-    help="Specify a particular package to upgrade; may be used more than once",
+    help=(
+        "Re-resolve the named package against the index, ignoring any pin "
+        "from the existing requirements file. May be used more than once. "
+        "Other packages keep their seeded pins."
+    ),
 )
 
 output_file = click.option(
@@ -291,9 +298,12 @@ build_isolation = click.option(
     is_flag=True,
     default=True,
     help=(
-        "Enable isolation when building a modern source distribution. "
-        "Build dependencies specified by PEP 518 must be already installed "
-        "if build isolation is disabled."
+        "Enable isolation when building a modern source distribution. With "
+        "``--no-build-isolation`` you must pre-install every PEP 518 build "
+        "dependency (``setuptools``, ``wheel``, ``hatchling``, etc.) into "
+        "the active environment; missing build deps surface as "
+        "import errors during the backend invocation, far from the "
+        "underlying cause."
     ),
 )
 


### PR DESCRIPTION
The CLI help for `--extra`, `--all-extras`, `--upgrade-package`, and `--no-build-isolation` reads as four disconnected single sentences. `--extra` does not mention that `--all-extras` exists, `--upgrade-package` does not explain what happens to the pins of unrelated packages, and `--no-build-isolation` only says build deps "must be already installed" without naming the symptom when a user forgets. The same questions surface on the issue tracker.

The patch cross-references `--extra` and `--all-extras` so each entry points at the other, spells out for `--upgrade-package` that other packages keep their seeded pins, and for `--no-build-isolation` calls out the concrete tools the user must pre-install plus the symptom they see when a build dep is missing.

Pure docs change. The option choices, defaults, parsing, and runtime behaviour stay the same; only the `help=` strings change.

---

No changelog fragment: docs polish, no behaviour change.