### PR TITLE
Neutralize PIP_* environment variables in the runner fixture

### DIFF
--- a/changelog.d/2390.contrib.md
+++ b/changelog.d/2390.contrib.md
@@ -1,0 +1,5 @@
+Drop `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL`, and `PIP_TRUSTED_HOST` from
+the environment in the `runner` test fixture so CLI tests asserting on
+exact pip argument lists no longer flake on contributor machines with a
+corporate index mirror configured at the shell level --
+{user}`gaborbernat`.

--- a/changelog.d/2390.contrib.md
+++ b/changelog.d/2390.contrib.md
@@ -1,5 +1,7 @@
-Drop `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL`, and `PIP_TRUSTED_HOST` from
-the environment in the `runner` test fixture so CLI tests asserting on
-exact pip argument lists no longer flake on contributor machines with a
-corporate index mirror configured at the shell level --
-{user}`gaborbernat`.
+A session-scoped autouse fixture in {file}`tests/conftest.py` now drops every
+`PIP_*` environment variable before any other fixture runs, so the test
+suite no longer flakes on contributor machines whose shell exports
+`PIP_INDEX_URL`, `PIP_FIND_LINKS`, `PIP_TRUSTED_HOST`, and the rest of
+the family for a corporate mirror. Tests that need a specific variable
+keep their function-scoped {meth}`pytest:pytest.MonkeyPatch.setenv` and
+supersede the session-level deletion -- by {user}`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ intersphinx_mapping = {
     "click": ("https://click.palletsprojects.com/en/stable", None),
     "build": ("https://build.pypa.io/en/stable", None),
     "importlib_metadata": ("https://importlib-metadata.readthedocs.io/en/latest", None),
+    "pytest": ("https://docs.pytest.org/en/stable", None),
 }
 
 issues_github_path = "jazzband/pip-tools"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,13 +229,13 @@ def from_editable():
     return install_req_from_editable
 
 
-# _isolate_pip_env is important for direct runs of the testsuite when contributors have
-# pip configurations in their env (e.g., for corporate index servers)
 @pytest.fixture(scope="session", autouse=True)
 def _isolate_pip_env() -> _c.Iterator[None]:
     """
     Automatically drop all ``PIP_*`` environment variables during test execution.
     """
+    # this is important for direct runs of the testsuite when contributors have
+    # pip configurations in their env (e.g., for corporate index servers)
     with pytest.MonkeyPatch.context() as mp:
         for env_var in (name for name in os.environ if name.startswith("PIP_")):
             mp.delenv(env_var)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as _c
 import json
 import os
 import platform
@@ -228,27 +229,28 @@ def from_editable():
     return install_req_from_editable
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_pip_env() -> _c.Iterator[None]:
+    # Drop every ``PIP_*`` environment variable for the duration of the test
+    # session so contributor pip configuration (corporate Artifactory mirror,
+    # find-links, trusted hosts, and so on) cannot leak into CLI tests that
+    # assert on exact pip argument lists. Session-scoped + autouse so the
+    # cleanup fires before any other fixture; subprocesses spawned by session
+    # fixtures (the ``pip download`` in ``setuptools_wheel_path``) also run
+    # with a clean environment. Function-scoped ``monkeypatch.setenv`` in a
+    # specific test still overrides the deletion for that test, so cases like
+    # ``test_find_links_envvar`` keep working.
+    mp = pytest.MonkeyPatch()
+    for env_var in (name for name in os.environ if name.startswith("PIP_")):
+        mp.delenv(env_var)
+    try:
+        yield
+    finally:
+        mp.undo()
+
+
 @pytest.fixture
-def runner(
-    monkeypatch: pytest.MonkeyPatch,
-    minimal_wheels_path: Path,
-) -> _t.Generator[CliRunner, None, None]:
-    # ``minimal_wheels_path`` is a session-scoped fixture that runs
-    # ``pip download setuptools`` via a subprocess on first use. That
-    # subprocess inherits the active environment; if it lazy-inits
-    # while this fixture's ``monkeypatch.delenv`` is in effect, pip
-    # sees no index URL and the download fails. Declaring it as a
-    # dependency forces the session fixture to initialise before the
-    # ``delenv`` below ever fires.
-    del minimal_wheels_path
-    # Pip honours ``PIP_INDEX_URL`` and friends from the contributor's shell;
-    # corporate Artifactory mirrors leak through and break tests that assert
-    # exact pip argument lists. Drop the variables for the duration of the
-    # CLI invocation. ``PIP_CONFIG_FILE`` is intentionally left alone because
-    # the cross-platform ``os.devnull`` device file (``/dev/null`` vs ``nul``)
-    # exposed pip path-resolution flakes on Windows in lowest-pip CI.
-    for env_var in ("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL", "PIP_TRUSTED_HOST"):
-        monkeypatch.delenv(env_var, raising=False)
+def runner():
     if Version(version_of("click")) < Version("8.2"):
         cli_runner = CliRunner(mix_stderr=False)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,26 @@ def from_editable():
 
 
 @pytest.fixture
-def runner():
+def runner(
+    monkeypatch: pytest.MonkeyPatch,
+    minimal_wheels_path: Path,
+) -> _t.Generator[CliRunner, None, None]:
+    # ``minimal_wheels_path`` is a session-scoped fixture that runs
+    # ``pip download setuptools`` via a subprocess on first use. That
+    # subprocess inherits the active environment; if it lazy-inits
+    # while this fixture's ``monkeypatch.delenv`` is in effect, pip
+    # sees no index URL and the download fails. Declaring it as a
+    # dependency forces the session fixture to initialise before the
+    # ``delenv`` below ever fires.
+    del minimal_wheels_path
+    # Pip honours ``PIP_INDEX_URL`` and friends from the contributor's shell;
+    # corporate Artifactory mirrors leak through and break tests that assert
+    # exact pip argument lists. Drop the variables for the duration of the
+    # CLI invocation. ``PIP_CONFIG_FILE`` is intentionally left alone because
+    # the cross-platform ``os.devnull`` device file (``/dev/null`` vs ``nul``)
+    # exposed pip path-resolution flakes on Windows in lowest-pip CI.
+    for env_var in ("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL", "PIP_TRUSTED_HOST"):
+        monkeypatch.delenv(env_var, raising=False)
     if Version(version_of("click")) < Version("8.2"):
         cli_runner = CliRunner(mix_stderr=False)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,24 +229,17 @@ def from_editable():
     return install_req_from_editable
 
 
+# _isolate_pip_env is important for direct runs of the testsuite when contributors have
+# pip configurations in their env (e.g., for corporate index servers)
 @pytest.fixture(scope="session", autouse=True)
 def _isolate_pip_env() -> _c.Iterator[None]:
-    # Drop every ``PIP_*`` environment variable for the duration of the test
-    # session so contributor pip configuration (corporate Artifactory mirror,
-    # find-links, trusted hosts, and so on) cannot leak into CLI tests that
-    # assert on exact pip argument lists. Session-scoped + autouse so the
-    # cleanup fires before any other fixture; subprocesses spawned by session
-    # fixtures (the ``pip download`` in ``setuptools_wheel_path``) also run
-    # with a clean environment. Function-scoped ``monkeypatch.setenv`` in a
-    # specific test still overrides the deletion for that test, so cases like
-    # ``test_find_links_envvar`` keep working.
-    mp = pytest.MonkeyPatch()
-    for env_var in (name for name in os.environ if name.startswith("PIP_")):
-        mp.delenv(env_var)
-    try:
+    """
+    Automatically drop all ``PIP_*`` environment variables during test execution.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        for env_var in (name for name in os.environ if name.startswith("PIP_")):
+            mp.delenv(env_var)
         yield
-    finally:
-        mp.undo()
 
 
 @pytest.fixture


### PR DESCRIPTION
Tests that drive `pip-compile` or `pip-sync` through `click.testing.CliRunner` inherit the contributor's shell environment, including `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL`, and `PIP_TRUSTED_HOST`. On developer machines or self-hosted CI runners with a corporate Artifactory mirror configured at the shell level, those variables leak into the recorded pip argument list and tests asserting on exact pip arguments flake.

The fixture drops the three URL-pointing variables for the duration of each CLI invocation. Production code paths see no difference; the change touches only the test fixture.