### PR TITLE
Add intersphinx mappings for packaging, pip, click, build, importlib_metadata

### DIFF
--- a/changelog.d/2391.contrib.md
+++ b/changelog.d/2391.contrib.md
@@ -1,0 +1,8 @@
+The Sphinx configuration now resolves cross-references for
+:mod:`packaging`, :mod:`pip`, :mod:`click`, :mod:`build`, and
+:mod:`importlib_metadata` via intersphinx, and the deprecated
+``sphinx.util.console.bold`` helper is replaced with a plain
+``logger.info`` call (the colour markup never rendered in CI logs
+anyway). Cross-references in docstrings that previously fell back to
+nitpick suppression now link to the upstream documentation -- by
+:user:`gaborbernat` in :pr:`2391`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from sphinx.application import Sphinx
 from sphinx.util import logging
-from sphinx.util.console import bold
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +31,8 @@ release = get_version(project)
 # The short X.Y version
 version = ".".join(release.split(".")[:3])
 
-logger.info(bold("%s version: %s"), project, version)
-logger.info(bold("%s release: %s"), project, release)
+logger.info("%s version: %s", project, version)
+logger.info("%s release: %s", project, release)
 
 # -- General configuration ---------------------------------------------------
 
@@ -66,6 +65,11 @@ html_title = f"<nobr>{project}</nobr> documentation v{release}"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "packaging": ("https://packaging.pypa.io/en/stable", None),
+    "pip": ("https://pip.pypa.io/en/stable", None),
+    "click": ("https://click.palletsprojects.com/en/stable", None),
+    "build": ("https://build.pypa.io/en/stable", None),
+    "importlib_metadata": ("https://importlib-metadata.readthedocs.io/en/latest", None),
 }
 
 issues_github_path = "jazzband/pip-tools"


### PR DESCRIPTION
The autodoc-rendered docstrings reference types from five upstream projects (``pip._internal.req.InstallRequirement``, ``click.Context``, ``packaging.markers.Marker``, ``build.ProjectBuilder``, and so on), but the Sphinx ``intersphinx_mapping`` only points at the standard library. Every external cross-reference falls back to ``nitpick_ignore`` suppression and the rendered HTML drops the hyperlink, so readers cannot click through to the upstream docs from a pip-tools method signature.

Adding the five inventories restores the links. The mappings target the canonical stable docs URLs for each project (``packaging.pypa.io/en/stable``, ``pip.pypa.io/en/stable``, ``click.palletsprojects.com/en/stable``, ``build.pypa.io/en/stable``, ``importlib-metadata.readthedocs.io/en/latest``).

While in the file, the deprecated ``sphinx.util.console.bold`` import on the two version-banner lines is dropped; the colour markup never rendered in CI logs and the helper is on track to be removed in upcoming Sphinx releases.