### PR TITLE
Let CI completion Codecov notify vote upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,8 @@ jobs:
 
   test:
     name: ${{ matrix.runner-vm }} / ${{ matrix.python-version }} / ${{ matrix.pip-version }}
+    needs:
+    - pre-setup  # transitive, for accessing settings
     runs-on: ${{ matrix.runner-vm }}
     timeout-minutes: 15
     strategy:
@@ -417,6 +419,8 @@ jobs:
           && !inputs.cpython-pip-version
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
+          fail_ci_if_error: >-
+            ${{ fromJSON(needs.pre-setup.outputs.is-upstream-repository) }}
           files: ./coverage.xml
           flags: >-
             CI-GHA,
@@ -519,6 +523,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     needs:
+      - pre-setup  # transitive, for accessing settings
       - test
     steps:
       - name: Notify Codecov that all coverage reports have been uploaded
@@ -526,7 +531,8 @@ jobs:
           !cancelled()
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: >-
+            ${{ fromJSON(needs.pre-setup.outputs.is-upstream-repository) }}
           run_command: send-notifications
 
   zizmor:

--- a/changelog.d/2392.contrib.md
+++ b/changelog.d/2392.contrib.md
@@ -1,0 +1,6 @@
+The `Notify Codecov` CI workflow job now only fails on privilige errors
+in the upstream project repository runs. This fixes a problem
+contributors face when running CI within their forks that are not filed
+as true Codecov-side projects.
+
+-- {user}`gaborbernat` and {user}`webknjaz`


### PR DESCRIPTION
`codecov/codecov-action` used to be called with `fail_ci_if_error: true` in the `Coverage processing` CI job unconditionally. This works well when a project for the repository is created on Codecov but fails in the context of external repositories that aren't (like typical forks).

A contributor could create a Codecov-side project for their fork and the CI calls to Codecov config would work in that context, but most people don't need that.

This patch makes the `fail_ci_if_error` context-aware and only fails the CI job step when the context is the upstream repository (including `pull_request` runs from forks to upstream). This keeps the door open a for forks that might still want to have their own Codecov project instance for whatever reason.

When run in a foreign context, Codecov CLI still logs the `Token required - not valid tokenless upload` error message but sets the successful return code, making the step and job look green.

If this happens upstream, this will still bubble up in CI as a loud failure.

The same treatment is applied to the Codecov action invocation in the test jobs for consistency.