### PR TITLE
Fix pypy+windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,11 +441,14 @@ jobs:
           - ubuntu-24.04
           - macos-26
           - macos-26-intel
-          - windows-2025
         python-version:
           - pypy-3.11
         pip-version:
           - supported
+        include:
+          - runner-vm: windows-2025
+            python-version: pypy-3.11
+            pip-version: lowest  # PR 2400: legacy depresolver fails
     env:
       TOXENV: pip${{ matrix.pip-version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
           - macos-26-intel
           - windows-2025
         python-version:
-          - pypy-3.10
+          - pypy-3.11
         pip-version:
           - supported
     env:

--- a/changelog.d/+96cdce2b.contrib.md
+++ b/changelog.d/+96cdce2b.contrib.md
@@ -1,0 +1,1 @@
+`pip-tools` now tests against PyPy 3.11 -- by {user}`sirosen`.

--- a/changelog.d/+96cdce2b.contrib.md
+++ b/changelog.d/+96cdce2b.contrib.md
@@ -1,1 +1,1 @@
-`pip-tools` now tests against PyPy 3.11 -- by {user}`sirosen`.
+`pip-tools` now tests against PyPy 3.11 -- by {user}`sirosen` and {user}`webknjaz`.


### PR DESCRIPTION
We're seeing pypy test failures in CI which block anything from merging.
~I'm hopeful that it's something which is wrong with the runner image itself, and that downgrading (temporarily?) will fix it.~

**Update**
I figured out that the cause is the click v8.4.0 release, _for some reason_. I don't know precisely why.
I think we should move forward with this tweak, however, because broken CI has such a strong negative impact.

Per #2399, I would actually like to drop pypy entirely.

**Update 2**
It turns out that this was not correct either. See discussion below for details.

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
