### PR TITLE
Fix malformed nitpick ignore rules; add ignores to let doc builds pass

### DIFF
--- a/changelog.d/+fcb3437a.contrib.md
+++ b/changelog.d/+fcb3437a.contrib.md
@@ -1,0 +1,1 @@
+Fixed incorrect nitpick ignore regexes -- by {user}`sirosen`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,16 +95,24 @@ linkcheck_ignore = [
 ]
 
 nitpick_ignore_regex = [
-    ("py:class", "pip.*"),
-    ("py:class", "pathlib.*"),
-    ("py:class", "click.*"),
-    ("py:class", "build.*"),
-    ("py:class", "optparse.*"),
-    ("py:class", "_ImportLibDist"),
-    ("py:class", "PackageMetadata"),
-    ("py:class", "importlib.*"),
+    # FIXME: broken refs inside of pip-tools itself
+    # internal names with leading '_', mostly type vars
+    ("py:.*", r"piptools\..*\._\w+"),
+    # BaseRepository ref is broken?
+    ("py:class", r"piptools\.repositories\.BaseRepository"),
+    # external libraries
+    ("py:.*", r"click\..*"),
+    ("py:.*", r"pip\..*"),
+    ("py:class", "NormalizedName"),
+    ("py:exc", "InvalidName"),
     ("py:class", "IndexContent"),
-    ("py:exc", "click.*"),
+    ("py:class", "PackageMetadata"),
+    ("py:class", "_ImportLibDist"),
+    ("py:class", r"build\..*"),
+    # stdlib
+    ("py:class", r"importlib\..*"),
+    ("py:class", r"optparse\..*"),
+    ("py:class", r"pathlib\..*"),
 ]
 
 suppress_warnings = [

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,6 +16,8 @@ boltons==25.0.0
     # via click-extra
 bracex==2.6
     # via wcmatch
+build==1.5.0
+    # via pip-tools (pyproject.toml)
 certifi==2026.1.4
     # via requests
 charset-normalizer==3.4.4
@@ -24,9 +26,10 @@ click==8.3.1
     # via
     #   click-extra
     #   cloup
+    #   pip-tools (pyproject.toml)
     #   towncrier
 click-extra==7.5.3
-    # via -r requirements.in
+    # via -r docs/requirements.in
 cloup==3.0.8
     # via click-extra
 deepmerge==2.0
@@ -41,7 +44,7 @@ docutils==0.22.4
 extra-platforms==8.0.0
     # via click-extra
 furo==2025.12.19
-    # via -r requirements.in
+    # via -r docs/requirements.in
 idna==3.11
     # via requests
 imagesize==1.4.1
@@ -62,11 +65,13 @@ mdit-py-plugins==0.5.0
 mdurl==0.1.2
     # via markdown-it-py
 myst-parser==5.0.0
-    # via -r requirements.in
+    # via -r docs/requirements.in
 packaging==26.0
     # via
+    #   build
     #   setuptools-scm
     #   sphinx
+    #   wheel
 pbr==7.0.3
     # via sphinxcontrib-apidoc
 pygments==2.20.0
@@ -78,6 +83,10 @@ pygments==2.20.0
     #   sphinx
 pygments-ansi-color==0.3.0
     # via click-extra
+pyproject-hooks==1.2.0
+    # via
+    #   build
+    #   pip-tools (pyproject.toml)
 pyyaml==6.0.3
     # via myst-parser
 requests==2.33.0
@@ -87,14 +96,14 @@ requests==2.33.0
 roman-numerals==4.1.0
     # via sphinx
 setuptools-scm==9.2.2
-    # via -r requirements.in
+    # via -r docs/requirements.in
 snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==9.1.0
     # via
-    #   -r requirements.in
+    #   -r docs/requirements.in
     #   click-extra
     #   furo
     #   myst-parser
@@ -106,9 +115,9 @@ sphinx==9.1.0
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-issues==5.0.1
-    # via -r requirements.in
+    # via -r docs/requirements.in
 sphinxcontrib-apidoc==0.6.0
-    # via -r requirements.in
+    # via -r docs/requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -118,13 +127,13 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-programoutput==0.18
-    # via -r requirements.in
+    # via -r docs/requirements.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-towncrier==0.5.0a0
-    # via -r requirements.in
+    # via -r docs/requirements.in
 tabulate==0.9.0
     # via click-extra
 towncrier==25.8.0
@@ -137,9 +146,14 @@ wcmatch==10.1
     # via click-extra
 wcwidth==0.5.3
     # via tabulate
+wheel==0.47.0
+    # via pip-tools (pyproject.toml)
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==26.1.1
+    # via pip-tools (pyproject.toml)
 setuptools==80.10.2
     # via
     #   pbr
+    #   pip-tools (pyproject.toml)
     #   setuptools-scm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,8 +16,6 @@ boltons==25.0.0
     # via click-extra
 bracex==2.6
     # via wcmatch
-build==1.4.0
-    # via pip-tools (pyproject.toml)
 certifi==2026.1.4
     # via requests
 charset-normalizer==3.4.4
@@ -26,10 +24,9 @@ click==8.3.1
     # via
     #   click-extra
     #   cloup
-    #   pip-tools (pyproject.toml)
     #   towncrier
 click-extra==7.5.3
-    # via -r docs/requirements.in
+    # via -r requirements.in
 cloup==3.0.8
     # via click-extra
 deepmerge==2.0
@@ -44,7 +41,7 @@ docutils==0.22.4
 extra-platforms==8.0.0
     # via click-extra
 furo==2025.12.19
-    # via -r docs/requirements.in
+    # via -r requirements.in
 idna==3.11
     # via requests
 imagesize==1.4.1
@@ -65,13 +62,11 @@ mdit-py-plugins==0.5.0
 mdurl==0.1.2
     # via markdown-it-py
 myst-parser==5.0.0
-    # via -r docs/requirements.in
+    # via -r requirements.in
 packaging==26.0
     # via
-    #   build
     #   setuptools-scm
     #   sphinx
-    #   wheel
 pbr==7.0.3
     # via sphinxcontrib-apidoc
 pygments==2.20.0
@@ -83,10 +78,6 @@ pygments==2.20.0
     #   sphinx
 pygments-ansi-color==0.3.0
     # via click-extra
-pyproject-hooks==1.2.0
-    # via
-    #   build
-    #   pip-tools (pyproject.toml)
 pyyaml==6.0.3
     # via myst-parser
 requests==2.33.0
@@ -96,14 +87,14 @@ requests==2.33.0
 roman-numerals==4.1.0
     # via sphinx
 setuptools-scm==9.2.2
-    # via -r docs/requirements.in
+    # via -r requirements.in
 snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==9.1.0
     # via
-    #   -r docs/requirements.in
+    #   -r requirements.in
     #   click-extra
     #   furo
     #   myst-parser
@@ -115,9 +106,9 @@ sphinx==9.1.0
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-issues==5.0.1
-    # via -r docs/requirements.in
+    # via -r requirements.in
 sphinxcontrib-apidoc==0.6.0
-    # via -r docs/requirements.in
+    # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -127,33 +118,28 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-programoutput==0.18
-    # via -r docs/requirements.in
+    # via -r requirements.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-towncrier==0.5.0a0
-    # via -r docs/requirements.in
+    # via -r requirements.in
 tabulate==0.9.0
     # via click-extra
 towncrier==25.8.0
     # via sphinxcontrib-towncrier
 typing-extensions==4.15.0
     # via beautifulsoup4
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 wcmatch==10.1
     # via click-extra
 wcwidth==0.5.3
     # via tabulate
-wheel==0.46.3
-    # via pip-tools (pyproject.toml)
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0
-    # via pip-tools (pyproject.toml)
 setuptools==80.10.2
     # via
     #   pbr
-    #   pip-tools (pyproject.toml)
     #   setuptools-scm


### PR DESCRIPTION
Based on #2394 , this changeset includes fixes to the nitpick ignore regexes.

---

The nitpick ignore regex list included `pip.*`. Because this is a simple regex match, it matches `piptools...` as well as `pip...`.

Fixing the regex to be correctly scoped reveals many nitpick errors inside of piptools, which are suppressed here in order to make it possible to track them down and fix later.

In addition to generally fixing the regexes,

- `InvalidName` and `NormalizedName`, from within `packaging`, are added to nitpick ignores

- the regexes are sorted and organized into sections

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
