### PR TITLE
Avoid rereading inputs for preserved newlines

### DIFF
--- a/changelog.d/2232.bugfix.md
+++ b/changelog.d/2232.bugfix.md
@@ -1,0 +1,3 @@
+Fixed `pip-compile --newline=preserve` rereading requirement input files while
+choosing the output newline, which could hang when the input was a named pipe
+-- by {user}`marko1olo`.

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import itertools
 import os
 import shlex
@@ -10,7 +11,7 @@ from pathlib import Path
 import click
 from build import BuildBackendException
 from click.utils import LazyFile, safecall
-from pip._internal.req import InstallRequirement
+from pip._internal.req import InstallRequirement, req_file
 from pip._internal.utils.misc import redact_auth_from_url
 
 from .._compat import canonicalize_name, parse_requirements, tempfile_compat
@@ -44,8 +45,25 @@ DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
 METADATA_FILENAMES = frozenset({"setup.py", "setup.cfg", "pyproject.toml"})
 
 
+def _linesep_from_content(content: str | bytes) -> str | None:
+    if isinstance(content, bytes):
+        if b"\r\n" in content:
+            return "CRLF"
+        if b"\n" in content:
+            return "LF"
+        return None
+
+    if "\r\n" in content:
+        return "CRLF"
+    if "\n" in content:
+        return "LF"
+    return None
+
+
 def _determine_linesep(
-    strategy: str = "preserve", filenames: tuple[str, ...] = ()
+    strategy: str = "preserve",
+    filenames: tuple[str, ...] = (),
+    input_contents: tuple[str, ...] = (),
 ) -> str:
     """
     Determine and return linesep string for OutputWriter to use.
@@ -55,23 +73,48 @@ def _determine_linesep(
     """
     if strategy == "preserve":
         for fname in filenames:
-            try:
-                with open(fname, "rb") as existing_file:
-                    existing_text = existing_file.read()
-            except FileNotFoundError:
+            path = Path(fname)
+            if fname == "-" or not path.is_file():
                 continue
-            if b"\r\n" in existing_text:
-                strategy = "CRLF"
+            try:
+                with path.open("rb") as existing_file:
+                    existing_text = existing_file.read()
+            except OSError:
+                continue
+            linesep = _linesep_from_content(existing_text)
+            if linesep is not None:
+                strategy = linesep
                 break
-            elif b"\n" in existing_text:
-                strategy = "LF"
-                break
+        else:
+            for content in input_contents:
+                linesep = _linesep_from_content(content)
+                if linesep is not None:
+                    strategy = linesep
+                    break
     return {
         "native": os.linesep,
         "LF": "\n",
         "CRLF": "\r\n",
         "preserve": "\n",
     }[strategy]
+
+
+@contextlib.contextmanager
+def _capture_requirement_file_contents(
+    collected_contents: list[str],
+) -> _t.Iterator[None]:
+    get_file_content = req_file.get_file_content
+
+    def collecting_get_file_content(url: str, session: _t.Any) -> tuple[str, str]:
+        location, content = get_file_content(url, session)
+        collected_contents.append(content)
+        return location, content
+
+    req_file.get_file_content = collecting_get_file_content
+    try:
+        yield
+    finally:
+        req_file.get_file_content = get_file_content
 
 
 COMPILE_EPILOG = """\b
@@ -368,6 +411,7 @@ def cli(
     ###
 
     constraints: list[InstallRequirement] = []
+    requirement_file_contents: list[str] = []
     setup_file_found = False
     for src_file in src_files:
         is_setup_file = os.path.basename(src_file) in METADATA_FILENAMES
@@ -382,8 +426,10 @@ def cli(
             # pip requires filenames and not files. Since we want to support
             # piping from stdin, we need to briefly save the input from stdin
             # to a temporary file and have pip read that.
+            stdin_content = sys.stdin.read()
+            requirement_file_contents.append(stdin_content)
             with tempfile_compat.named_temp_file() as tmpfile:
-                tmpfile.write(sys.stdin.read())
+                tmpfile.write(stdin_content)
                 tmpfile.flush()
                 reqs = list(
                     parse_requirements(
@@ -419,14 +465,15 @@ def cli(
                 assert isinstance(metadata, ProjectMetadata)
                 constraints.extend(metadata.build_requirements)
         else:
-            constraints.extend(
-                parse_requirements(
-                    src_file,
-                    finder=repository.finder,
-                    session=repository.session,
-                    options=repository.options,
+            with _capture_requirement_file_contents(requirement_file_contents):
+                constraints.extend(
+                    parse_requirements(
+                        src_file,
+                        finder=repository.finder,
+                        session=repository.session,
+                        options=repository.options,
+                    )
                 )
-            )
 
     # Parse all constraints from `--constraint` files
     for filename in constraint:
@@ -525,7 +572,16 @@ def cli(
     log.debug("")
 
     linesep = _determine_linesep(
-        strategy=newline, filenames=(output_file.name, *src_files)
+        strategy=newline,
+        filenames=(
+            output_file.name,
+            *(
+                src_file
+                for src_file in src_files
+                if os.path.basename(src_file) in METADATA_FILENAMES
+            ),
+        ),
+        input_contents=tuple(requirement_file_contents),
     )
 
     if strip_extras is None:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -24,6 +24,7 @@ from pip._vendor.packaging.version import Version
 from piptools._compat import tempfile_compat
 from piptools._internal import _pip_api
 from piptools.build import ProjectMetadata
+from piptools.scripts import compile as compile_module
 from piptools.scripts.compile import cli
 from piptools.utils import COMPILE_EXCLUDE_OPTIONS
 
@@ -1299,6 +1300,83 @@ def test_preserve_newline_from_input(runner, linesep, must_exclude):
     if must_exclude in linesep:
         txt = txt.replace(linesep, "")
     assert must_exclude not in txt
+
+
+def test_preserve_newline_from_parsed_input_without_reopening_source(
+    runner, tmp_path, monkeypatch
+):
+    _mock_resolver_cls(monkeypatch)
+
+    captured_writer_linesep = []
+
+    class CaptureOutputWriter:
+        def __init__(self, *args, linesep, **kwargs):
+            captured_writer_linesep.append(linesep)
+
+        def write(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(compile_module, "OutputWriter", CaptureOutputWriter)
+
+    determine_linesep_calls = []
+    determine_linesep = compile_module._determine_linesep
+
+    def capture_determine_linesep(*args, **kwargs):
+        determine_linesep_calls.append(kwargs)
+        return determine_linesep(*args, **kwargs)
+
+    monkeypatch.setattr(compile_module, "_determine_linesep", capture_determine_linesep)
+
+    req_in = tmp_path / "requirements.in"
+    req_out = tmp_path / "requirements.txt"
+    req_in.write_bytes(b"six\r\n")
+
+    out = runner.invoke(
+        cli,
+        [
+            "--newline=preserve",
+            "--output-file",
+            req_out.as_posix(),
+            req_in.as_posix(),
+        ],
+    )
+
+    assert out.exit_code == 0, out
+    assert captured_writer_linesep == ["\r\n"]
+    assert determine_linesep_calls == [
+        {
+            "strategy": "preserve",
+            "filenames": (req_out.as_posix(),),
+            "input_contents": ("six\r\n",),
+        }
+    ]
+
+
+def test_determine_linesep_skips_non_regular_files(monkeypatch, tmp_path):
+    special_file = tmp_path / "requirements.in"
+    path_is_file = pathlib.Path.is_file
+    path_open = pathlib.Path.open
+
+    def is_file(self):
+        if self == special_file:
+            return False
+        return path_is_file(self)
+
+    def open_file(self, *args, **kwargs):
+        if self == special_file:
+            pytest.fail("non-regular files must not be opened for newline detection")
+        return path_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "is_file", is_file)
+    monkeypatch.setattr(pathlib.Path, "open", open_file)
+
+    linesep = compile_module._determine_linesep(
+        strategy="preserve",
+        filenames=(special_file.as_posix(),),
+        input_contents=("six\r\n",),
+    )
+
+    assert linesep == "\r\n"
 
 
 def test_generate_hashes_with_split_style_annotations(pip_conf, runner, tmpdir_cwd):


### PR DESCRIPTION
Fixes #2232.

This avoids rereading requirement input files when `--newline=preserve` chooses the writer newline. Requirement file contents are captured while pip is already parsing them, then reused as the fallback newline source after the output file and metadata files have been checked. Non-regular files and `-` are skipped in the direct filename pass, so FIFOs/stdout aliases are not opened just for newline detection.

This keeps the existing precedence for an existing output file, preserves metadata-file behavior, and avoids changing requirement parsing paths or relative include semantics.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/`.

Checks run locally:

- `python -m pytest tests\test_cli_compile.py::test_preserve_newline_from_parsed_input_without_reopening_source tests\test_cli_compile.py::test_determine_linesep_skips_non_regular_files -q`
- `python -m pytest tests\test_cli_compile.py -k "newline or linesep" -q`
- `pre-commit run --color=never --files piptools/scripts/compile.py tests/test_cli_compile.py changelog.d/2232.bugfix.md`
- `python -m compileall -q piptools\scripts\compile.py tests\test_cli_compile.py`
- `git diff --check`