### PR TITLE
Update to the latest version of reusable-tox + codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
     needs:
     - pre-setup  # transitive, for accessing settings
 
-    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@617ca35caa695c572377861016677905e58a328c  # yamllint disable-line rule:line-length
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@1bb961580e20073f66ccb9024f248357f8c8fecb  # unstable/v1  # yamllint disable-line rule:line-length
     with:
       cache-key-for-dependency-files: >-
         ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
         if: >-
           !cancelled()
           && !inputs.cpython-pip-version
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           fail_ci_if_error: >-
             ${{ fromJSON(needs.pre-setup.outputs.is-upstream-repository) }}
@@ -532,7 +532,7 @@ jobs:
       - name: Notify Codecov that all coverage reports have been uploaded
         if: >-
           !cancelled()
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           fail_ci_if_error: >-
             ${{ fromJSON(needs.pre-setup.outputs.is-upstream-repository) }}


### PR DESCRIPTION
- Update to the latest version (pinned)
- Note in the comment that we're tracking 'unstable/v1'

---

@webknjaz, I think this is what you were referring to in #2392 ?
I looked at the bump in the reusable-tox workflow and I don't expect we need any other changes.

I don't believe it needs a contrib doc fragment.
