### PR TITLE
Set `persist-credentials: false` in CI for the checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
             && 1 || 0
           }}
         ref: ${{ inputs.release-committish }}
+        persist-credentials: false
     - name: Scan static PEP 621 core packaging metadata
       id: metadata
       run: |
@@ -342,6 +343,8 @@ jobs:
         }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }} from GitHub
         id: python-install
         if: "!endsWith(matrix.python-version, '-dev')"
@@ -457,6 +460,8 @@ jobs:
       TOXENV: pip${{ matrix.pip-version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:

--- a/.github/workflows/reusable-qa.yml
+++ b/.github/workflows/reusable-qa.yml
@@ -24,6 +24,8 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:


### PR DESCRIPTION
As flagged by zizmor! We should set `persist-credentials` explicitly, and default to `false`.

---

I went with no change note for this, but could be persuaded to add one (`contrib` or `misc`?).

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
