### PR TITLE
🧪🚑 Enable `security-events` @ cron+release

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   main:
     name: CI
+
+    permissions:
+      security-events: write  # Needed by the nested Zizmor workflow
+
     uses: ./.github/workflows/ci.yml
     with:
       cpython-versions: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
         github.event.action == 'published'
         && 'release' || 'nightly'
       }}]
+
+    permissions:
+      security-events: write  # Needed by the nested Zizmor workflow
+
     uses: ./.github/workflows/ci.yml
     with:
       release-version: ${{ github.ref_name }}


### PR DESCRIPTION
This patch sets the top-level `security-events: write` privilege in the nightly and release GHA CI/CD workflows where they call `ci.yml`, which in turn calls the upstream Zizmor workflow requiring it.

The change intends to fix the following error [[1]] we've recently started encountering due to internal changes within GH:

```console
Invalid workflow file: .github/workflows/cron.yml#L9
The workflow is not valid. .github/workflows/cron.yml (Line: 9, Col: 3): Error calling workflow 'jazzband/pip-tools/.github/workflows/ci.yml@91636f5a1b49f8ff55b96088e43aa1a3a5dd4b2b'. The nested job 'zizmor' is requesting 'security-events: write', but is only allowed 'security-events: none'.
```

[1]: https://github.com/jazzband/pip-tools/actions/runs/27537892831/workflow

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
