### PR TITLE
Fix typos in test docstrings and comments

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3418,7 +3418,7 @@ def test_resolution_failure(runner):
 
 
 def test_resolver_reaches_max_rounds(runner):
-    """Test resolver reched max rounds and raises error."""
+    """Test resolver reached max rounds and raises error."""
     with open("requirements.in", "w") as reqs_out:
         reqs_out.write("six")
 

--- a/tests/unit/_internal/pip_api/test_cli_options.py
+++ b/tests/unit/_internal/pip_api/test_cli_options.py
@@ -17,7 +17,7 @@ def test_postprocess_cli_options_pre_adds_all_to_release_control_all_releases():
     cmd = create_command("install")
     options, _ = cmd.parse_args(["--pre"])
 
-    # initiall, 'all_releases' is empty
+    # initially, 'all_releases' is empty
     assert not options.release_control.all_releases
 
     _pip_api.postprocess_cli_options(options)


### PR DESCRIPTION
Fix two small typos in test file comments/docstrings found by codespell:

- `reched` → `reached` in `tests/test_cli_compile.py` (docstring for `test_resolver_reaches_max_rounds`)
- `initiall` → `initially` in `tests/unit/_internal/pip_api/test_cli_options.py` (inline comment)

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`] for instructions) or the PR text says "no changelog needed".

No changelog needed.