### PR TITLE
Fix the `fake_with_deps` test package

### DIFF
--- a/tests/test_data/packages/fake_with_deps/pyproject.toml
+++ b/tests/test_data/packages/fake_with_deps/pyproject.toml
@@ -6,9 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "fake_with_deps"
 description = "Fake package with dependencies"
 authors = [{name = "jazzband"}]
-# license = "0BSD"
-# Deprecated license table for Python 3.8's latest setuptools compatibility:
-license = {text = "0BSD"}
+license = "0BSD"
 version = "0.1"
 dependencies = [
   "python-dateutil>=2.4.2,<2.5",
@@ -19,7 +17,7 @@ dependencies = [
   "ipaddress<1.1,>=1.0.16",
   "jsonschema<3.0,>=2.4.0",
   "pyramid<1.6,>=1.5.7",
-  "pyzmq<26.3.0,>=26.2.0",
+  "pyzmq >= 27.1.0",
   "simplejson>=3.5,!=3.8,>3.9",
   "SQLAlchemy!=0.9.5,<2.0.0,>=0.7.8,>=1.0.0",
   "python-memcached>=1.57,<2.0",


### PR DESCRIPTION
One of the local test packages, `fake_with_deps` has a nontrivial suite of dependencies. Among these, `pyzmq` was pinned to an older version which fails to build with the latest `scikit-build-core`, resulting in testsuite failures.

It is not clear what the impacts on testing would be of making more dramatic changes to `fake_with_deps`, so this change is limited to updating `pyzmq` to the latest version. It is given no upper bound because there is no clear value which could be used for one.

Additionally, update the test package license metadata to avoid warnings.

The `fake_with_deps` package used the deprecated `license` style for setuptools, resulting in warnings. This contaminates test output and makes debugging more difficult.

The usage was noted as needed for Python 3.8 test compatibility, but we no longer support 3.8 , so it is safe to remove.

---

Given that this impacts how the testsuite interacts with the network, it could impact repackagers or other downstream testers.

However, I don't feel that a changelog note is needed, as this is purely a testsuite change.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
