### PR TITLE
Fix hash generation from PyPI JSON API failing when --index-url ends with a slash

### DIFF
--- a/changelog.d/1669.bugfix.md
+++ b/changelog.d/1669.bugfix.md
@@ -1,0 +1,4 @@
+Fix `--index-url` values ending with a trailing slash (e.g.
+`https://pypi.org/simple/`) causing hash generation to silently fall
+back to hashing downloaded files instead of fetching hashes from the
+PyPI JSON API, due to a malformed (doubled) API URL being constructed.

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -273,7 +273,15 @@ class PyPIRepository(BaseRepository):
         API reference: https://warehouse.readthedocs.io/api-reference/json/
         """
         package_indexes = (
-            PackageIndex(url=index_url, file_storage_domain="")
+            # Strip trailing slash(es): pip's PackageIndex derives
+            # pypi_url via urllib.parse.urljoin(url, "pypi"), which
+            # produces a different (and, with a trailing slash,
+            # incorrect/nested) result depending on whether url ends
+            # with a slash -- e.g. "https://pypi.org/simple/" yields
+            # ".../simple/pypi" instead of ".../pypi". Normalizing here
+            # ensures a consistent, correct pypi_url regardless of how
+            # the user formatted --index-url. See GH #1669.
+            PackageIndex(url=index_url.rstrip("/"), file_storage_domain="")
             for index_url in self.finder.search_scope.index_urls
         )
         for package_index in package_indexes:

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -429,6 +429,44 @@ def test_get_project__handles_404(from_line, tmpdir, monkeypatch, pypi_repositor
     assert actual_data is None
 
 
+def test_get_project__index_url_trailing_slash(from_line, tmpdir, monkeypatch):
+    """
+    Regression test for
+    https://github.com/jazzband/pip-tools/issues/1669
+
+    An --index-url ending with a trailing slash (e.g.
+    "https://pypi.org/simple/", matching PEP 503's own description of
+    PyPI's base URL) must still produce a correct, non-doubled JSON
+    API URL like "https://pypi.org/pypi/<name>/json" -- not
+    "https://pypi.org/simple/pypi/<name>/json".
+    """
+    pypi_repository = PyPIRepository(
+        [
+            "--index-url",
+            "https://pypi.org/simple/",
+            "--use-deprecated",
+            "legacy-resolver",
+        ],
+        cache_dir=(tmpdir / "pypi-repo"),
+    )
+
+    requested_urls = []
+
+    class MockResponse:
+        status_code = 404
+
+    def mock_get(url, *args, **kwargs):
+        requested_urls.append(url)
+        return MockResponse()
+
+    monkeypatch.setattr(pypi_repository.session, "get", mock_get)
+    ireq = from_line("fake-package==0.1")
+
+    pypi_repository._get_project(ireq)
+
+    assert requested_urls == ["https://pypi.org/pypi/fake-package/json"]
+
+
 def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tmpdir):
     """
     Test to ensure we don't fail if there are multiple URL-based requirements


### PR DESCRIPTION
Fixes #1669.

`PyPIRepository._get_project()` passes each configured index URL to pip's `PackageIndex`, then reads its `.pypi_url` property to build the JSON API request URL. `PackageIndex` derives `pypi_url` via `urllib.parse.urljoin(url, "pypi")`, whose result differs depending on whether `url` ends with a trailing slash:

```
urljoin("https://pypi.org/simple", "pypi")
  -> "https://pypi.org/pypi"            (correct)
urljoin("https://pypi.org/simple/", "pypi")
  -> "https://pypi.org/simple/pypi"      (wrong: doubled path)
```

An index URL with a trailing slash -- which PEP 503 itself uses as the canonical form ("PyPI's base URL is `https://pypi.org/simple/`"), and which e.g. AWS CodeArtifact generates by default -- therefore produces a malformed JSON API URL. The request 404s, and `pip-compile` silently falls back to the much slower path of downloading and hashing each file directly, without any indication to the user of why, exactly as shown in the issue.

**Fix**: strip trailing slash(es) from each index URL before constructing `PackageIndex`, so `urljoin` (and therefore `pypi_url`) behaves consistently and correctly regardless of how the user formatted `--index-url`. This fixes it for any PEP 503-style index, not just pypi.org specifically, without needing changes to pip itself.

**Testing**: verified directly against pip's `PackageIndex` that the fix produces the correct `https://pypi.org/pypi` URL for both trailing-slash and no-trailing-slash inputs, matching the exact `urljoin` behavior difference diagnosed in the issue.

Added a regression test that configures a `PyPIRepository` with a trailing-slash `--index-url` (matching the issue's exact repro command) and asserts the URL actually requested from the mocked session is the correct, non-doubled JSON API URL. I confirmed the test fails with the original code (requests the doubled `.../simple/pypi/...` URL) and passes with the fix. Ran the full existing `test_repository_pypi.py` suite: 29 passed (28 baseline + 1 new), no regressions.
