### PR TITLE
Add missing dependency on typing-extensions

### DIFF
--- a/changelog.d/2424.bugfix.md
+++ b/changelog.d/2424.bugfix.md
@@ -1,0 +1,2 @@
+Added a missing dependency on ``typing-extensions`` for Python 3.9 and 3.10
+-- by {user}`sirosen`.

--- a/changelog.d/2424.bugfix.md
+++ b/changelog.d/2424.bugfix.md
@@ -1,2 +1,2 @@
-Added a missing dependency on ``typing-extensions`` for Python 3.9 and 3.10
+Added a missing dependency on {pypi}`typing-extensions` for Python 3.9 and 3.10
 -- by {user}`sirosen`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "click >= 8",
   "pip >= 22.2",
   "pyproject_hooks",
+  "typing_extensions >= 4.6.0; python_version < '3.11'",
   "tomli; python_version < '3.11'",
   # indirect dependencies
   "setuptools", # typically needed when pip-tools invokes setup.py


### PR DESCRIPTION
fixes #2424

This was present at v4.6.0+ in our testsuite context via

    pytest -> exceptiongroup -> typing-extensions

Adding it to our explicit dependencies prevents failures for users on
3.9 and 3.10 .

A new test scenario cannot be trivially added for this, since any testing
would need to be done without pytest. Automated testing is therefore
considered out-of-scope for this change.

Manual tests show that `pip-compile -h` fails on 3.9 before this change
and pass afterwards.

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
