### PR TITLE
Improve normalization of index URLs for JSON API

### DIFF
--- a/changelog.d/1669.bugfix.md
+++ b/changelog.d/1669.bugfix.md
@@ -1,0 +1,4 @@
+Fix handling of index URLs ending in `/simple/` by improving URL normalization logic.
+These URLs would previously make `pip-compile` fail to use the PyPI JSON API.
+
+-- by {user}`sirosen`

--- a/changelog.d/1669.bugfix.md
+++ b/changelog.d/1669.bugfix.md
@@ -1,4 +1,5 @@
-Fix handling of index URLs ending in `/simple/` by improving URL normalization logic.
+Fixed handling of index URLs ending in `/simple/` by improving URL normalization
+logic.
 These URLs would previously make `pip-compile` fail to use the PyPI JSON API.
 
 -- by {user}`sirosen`

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -6,6 +6,7 @@ import itertools
 import optparse
 import os
 import typing as _t
+import urllib.parse
 from collections.abc import Iterator
 from contextlib import contextmanager
 from shutil import rmtree
@@ -16,7 +17,6 @@ from pip._internal.commands import create_command
 from pip._internal.commands.install import InstallCommand
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.candidate import InstallationCandidate
-from pip._internal.models.index import PackageIndex
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.network.session import PipSession
@@ -272,16 +272,16 @@ class PyPIRepository(BaseRepository):
 
         API reference: https://warehouse.readthedocs.io/api-reference/json/
         """
-        package_indexes = (
-            PackageIndex(url=index_url, file_storage_domain="")
+        index_base_urls = (
+            _get_true_base_from_index_url(index_url)
             for index_url in self.finder.search_scope.index_urls
         )
-        for package_index in package_indexes:
-            url = f"{package_index.pypi_url}/{ireq.name}/json"
+        for index_base_url in index_base_urls:
+            json_url = urllib.parse.urljoin(index_base_url, f"{ireq.name}/json")
             try:
-                response = self.session.get(url)
+                response = self.session.get(json_url)
             except RequestException as e:
-                log.debug(f"Fetch package info from PyPI failed: {url}: {e}")
+                log.debug(f"Fetch package info from PyPI failed: {json_url}: {e}")
                 continue
 
             # Skip this PyPI server, because there is no package
@@ -292,7 +292,7 @@ class PyPIRepository(BaseRepository):
             try:
                 data = response.json()
             except ValueError as e:
-                log.debug(f"Cannot parse JSON response from PyPI: {url}: {e}")
+                log.debug(f"Cannot parse JSON response from PyPI: {json_url}: {e}")
                 continue
             return data
         return None
@@ -520,3 +520,22 @@ def open_local_or_remote_file(link: Link, session: Session) -> Iterator[FileStre
 
 def candidate_version(candidate: InstallationCandidate) -> _BaseVersion:
     return candidate.version
+
+
+def _get_true_base_from_index_url(url: str) -> str:
+    """
+    Given an index URL (which may or may not end in ``/simple``), get the base URL for
+    using the JSON API.
+
+    Even though PyPI's base URL is documented as ``https://pypi.org/simple/``, that is
+    not the "true base URL" for using the JSON API.
+
+    It is not possible to accommodate all users perfectly -- we can ensure proper
+    behavior for pypi.org and test.pypi.org , and try not to break anyone else in the
+    process.
+    """
+    if url.endswith("/simple/"):
+        url = url[: -len("simple/")]
+    elif url.endswith("/simple"):
+        url = url[: -len("simple")]
+    return url

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -535,7 +535,8 @@ def _get_true_base_from_index_url(url: str) -> str:
     process.
     """
     if url.endswith("/simple/"):
-        url = url[: -len("simple/")]
+        return url.removesuffix("simple/")
     elif url.endswith("/simple"):
-        url = url[: -len("simple")]
+        return url.removesuffix("simple")
+
     return url

--- a/tests/unit/repositories/test_pypi_repository.py
+++ b/tests/unit/repositories/test_pypi_repository.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from piptools.repositories.pypi import _get_true_base_from_index_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "https://pypi.org/",
+        "https://test.pypi.org/",
+        "https://my-pypi-mirror.example.org/",
+    ),
+)
+def test_true_base_url_no_change(url: str) -> None:
+    assert _get_true_base_from_index_url(url) == url
+
+
+@pytest.mark.parametrize(
+    ("url", "expect_result"),
+    (
+        ("https://pypi.org/simple", "https://pypi.org/"),
+        ("https://pypi.org/simple/", "https://pypi.org/"),
+        # custom index gets the same treatment
+        (
+            "https://my-pypi-mirror.example.org/simple",
+            "https://my-pypi-mirror.example.org/",
+        ),
+        # an extreme case: pypi.org is being presented via some proxy,
+        # which we want to preserve, *and* simple is used repeatedly in the URL
+        # -- we only strip one copy of "simple", as this provides an escape hatch
+        # for anyone with a particularly weird proxy setup
+        (
+            "https://pypi.org/my-proxy/simple/simple",
+            "https://pypi.org/my-proxy/simple/",
+        ),
+    ),
+)
+def test_true_base_url_strips_simple_suffix(url: str, expect_result: str) -> None:
+    assert _get_true_base_from_index_url(url) == expect_result

--- a/tests/unit/repositories/test_pypi_repository.py
+++ b/tests/unit/repositories/test_pypi_repository.py
@@ -6,34 +6,43 @@ from piptools.repositories.pypi import _get_true_base_from_index_url
 
 
 @pytest.mark.parametrize(
-    "url",
-    (
-        "https://pypi.org/",
-        "https://test.pypi.org/",
-        "https://my-pypi-mirror.example.org/",
-    ),
-)
-def test_true_base_url_no_change(url: str) -> None:
-    assert _get_true_base_from_index_url(url) == url
-
-
-@pytest.mark.parametrize(
     ("url", "expect_result"),
     (
-        ("https://pypi.org/simple", "https://pypi.org/"),
-        ("https://pypi.org/simple/", "https://pypi.org/"),
+        pytest.param(
+            "https://pypi.org/", "https://pypi.org/", id="pypi-base-unchanged"
+        ),
+        pytest.param(
+            "https://test.pypi.org/",
+            "https://test.pypi.org/",
+            id="test-pypi-base-unchanged",
+        ),
+        pytest.param(
+            "https://my-pypi-mirror.example.org/",
+            "https://my-pypi-mirror.example.org/",
+            id="mirror-root-unchanged",
+        ),
+        pytest.param(
+            "https://pypi.org/simple", "https://pypi.org/", id="pypi-simple-stripped"
+        ),
+        pytest.param(
+            "https://pypi.org/simple/",
+            "https://pypi.org/",
+            id="pypi-simple-trailing-slash-stripped",
+        ),
         # custom index gets the same treatment
-        (
+        pytest.param(
             "https://my-pypi-mirror.example.org/simple",
             "https://my-pypi-mirror.example.org/",
+            id="mirror-simple-stripped",
         ),
         # an extreme case: pypi.org is being presented via some proxy,
         # which we want to preserve, *and* simple is used repeatedly in the URL
         # -- we only strip one copy of "simple", as this provides an escape hatch
         # for anyone with a particularly weird proxy setup
-        (
+        pytest.param(
             "https://pypi.org/my-proxy/simple/simple",
             "https://pypi.org/my-proxy/simple/",
+            id="proxy-double-simple-strips-only-one",
         ),
     ),
 )


### PR DESCRIPTION
Given a suite of index URLs in use, when pip-tools wants to call the JSON API, it currently is constructing an internal pip datatype -- meant to represent only 'pypi.org' and 'test.pypi.org' -- and using that to call `urllib.parse.urljoin`.

This has two significant downsides:

1. The code is much harder to understand -- rather than a well-documented stdlib function call, we need to look into pip internals.

2. Any normalization or cleaning of the input data is purely incidental.
   `urljoin()` happens to do some, but the overall effect is inconsistent behavior in resolving these URLs: `/simple` gets cleaned up, but `/simple/` does not (#1669).

By replacing this with a dedicated function, we can simplify the relevant code and add dedicated normalization logic. And because the logic is our own, we have a well-defined function to unit-test.

-----

#2426 is related but deserves no credit. The fix proposed in that PR is incorrect, but I needed to look carefully to confirm it. As a result of the review effort I put in, I understood the problem and worked on a good fix.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
