### PR TITLE
Fix incorrect CI trigger for tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
   workflow_call:
     inputs:
       cpython-pip-version:

--- a/changelog.d/2421.contrib.md
+++ b/changelog.d/2421.contrib.md
@@ -1,0 +1,2 @@
+Fixed CI triggers so that release tags won't create spurious failing runs --
+by {user}`sirosen`.


### PR DESCRIPTION
Resolves #2421

Remove the 'tags' trigger in CI. Our release automation is driven by
GitHub release creation instead.

When this ran, it would result in failures as the built dists did not
match expected names. It was also redundant with the release build and
`main` build.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
