### PR TITLE
fix: do not read non-regular files when preserving newlines

### DIFF
--- a/changelog.d/2232.bugfix.md
+++ b/changelog.d/2232.bugfix.md
@@ -1,0 +1,2 @@
+Stopped `pip-compile --newline=preserve` from hanging forever when an input path
+is a named pipe -- by {user}`Sanjays2402`.

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -56,6 +56,10 @@ def _determine_linesep(
     if strategy == "preserve":
         for fname in filenames:
             try:
+                if not os.path.isfile(fname):
+                    # Skip anything that is not a regular file, such as named
+                    # pipes, which would block forever on read.
+                    continue
                 with open(fname, "rb") as existing_file:
                     existing_text = existing_file.read()
             except FileNotFoundError:

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 import typing as _t
 from textwrap import dedent
 from unittest import mock
@@ -24,7 +25,7 @@ from pip._vendor.packaging.version import Version
 from piptools._compat import tempfile_compat
 from piptools._internal import _pip_api
 from piptools.build import ProjectMetadata
-from piptools.scripts.compile import cli
+from piptools.scripts.compile import _determine_linesep, cli
 from piptools.utils import COMPILE_EXCLUDE_OPTIONS
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
@@ -1299,6 +1300,27 @@ def test_preserve_newline_from_input(runner, linesep, must_exclude):
     if must_exclude in linesep:
         txt = txt.replace(linesep, "")
     assert must_exclude not in txt
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "mkfifo"), reason="named pipes are not supported on this platform"
+)
+def test_determine_linesep_skips_named_pipes(tmp_path):
+    """Non-regular files must not be read, or reading blocks forever."""
+    named_pipe = tmp_path / "named-pipe"
+    os.mkfifo(named_pipe, 0o600)
+
+    result = []
+
+    def read_linesep():
+        result.append(_determine_linesep("preserve", (str(named_pipe),)))
+
+    thread = threading.Thread(target=read_linesep, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive(), "_determine_linesep() blocked on a named pipe"
+    assert result == ["\n"]
 
 
 def test_generate_hashes_with_split_style_annotations(pip_conf, runner, tmpdir_cwd):


### PR DESCRIPTION
Closes #2232.

`pip-compile --newline=preserve` reads each input file to detect its existing line ending. When an input is a named pipe, that second read blocks until something writes to the pipe again, so `pip-compile` hangs after the resolution has already finished. Inputs that are not regular files are now skipped before opening.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
