### PR TITLE
fix: skip non-regular files when detecting the line separator

### DIFF
--- a/changelog.d/2232.bugfix.md
+++ b/changelog.d/2232.bugfix.md
@@ -1,0 +1,3 @@
+Fixed `pip-compile --newline=preserve` hanging when an input path is a named
+pipe, by skipping inputs that are not regular files during line separator
+detection -- by {user}`Sanjays2402`.

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -55,6 +55,10 @@ def _determine_linesep(
     """
     if strategy == "preserve":
         for fname in filenames:
+            if not os.path.isfile(fname):
+                # Skip anything that is not a regular file, such as the ``-``
+                # stdin placeholder or a named pipe, which would block here.
+                continue
             try:
                 with open(fname, "rb") as existing_file:
                     existing_text = existing_file.read()

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -7,6 +7,7 @@ import pathlib
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import typing as _t
@@ -24,7 +25,7 @@ from pip._vendor.packaging.version import Version
 from piptools._compat import tempfile_compat
 from piptools._internal import _pip_api
 from piptools.build import ProjectMetadata
-from piptools.scripts.compile import cli
+from piptools.scripts.compile import _determine_linesep, cli
 from piptools.utils import COMPILE_EXCLUDE_OPTIONS
 
 from .constants import MINIMAL_WHEELS_PATH, PACKAGES_PATH
@@ -1299,6 +1300,25 @@ def test_preserve_newline_from_input(runner, linesep, must_exclude):
     if must_exclude in linesep:
         txt = txt.replace(linesep, "")
     assert must_exclude not in txt
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "mkfifo"), reason="named pipes are not available on this platform"
+)
+def test_preserve_newline_skips_named_pipes(tmpdir_cwd):
+    """A named pipe input must not be read when detecting the line separator."""
+    named_pipe = pathlib.Path(tmpdir_cwd) / "named-pipe"
+    os.mkfifo(named_pipe, 0o600)
+
+    def _fail_on_alarm(*args):
+        raise AssertionError(f"_determine_linesep() blocked reading {named_pipe}")
+
+    signal.signal(signal.SIGALRM, _fail_on_alarm)
+    signal.alarm(5)
+    try:
+        assert _determine_linesep("preserve", (str(named_pipe),)) == "\n"
+    finally:
+        signal.alarm(0)
 
 
 def test_generate_hashes_with_split_style_annotations(pip_conf, runner, tmpdir_cwd):


### PR DESCRIPTION
Closes #2232

`--newline=preserve` re-opens each input file to detect its line separator. A named pipe has already been drained by the resolver at that point, so the second read blocked forever and `pip-compile` hung before writing output. Non-regular paths (the `-` stdin placeholder and named pipes) are now skipped during detection.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
