### PR TITLE
fix(compile): skip non-regular files in _determine_linesep (#2232)

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -56,9 +56,11 @@ def _determine_linesep(
     if strategy == "preserve":
         for fname in filenames:
             try:
+                if not Path(fname).is_file():
+                    continue
                 with open(fname, "rb") as existing_file:
                     existing_text = existing_file.read()
-            except FileNotFoundError:
+            except OSError:
                 continue
             if b"\r\n" in existing_text:
                 strategy = "CRLF"


### PR DESCRIPTION
## Summary

Fixes #2232.

`pip-compile` hangs indefinitely when a named pipe (FIFO) is used as an input file and the output is written to stdout (`-o-` or `-`).

## Root Cause

`_determine_linesep()` with `strategy="preserve"` (the default) loops over output filenames to detect existing line endings by calling `open(fname, "rb").read()`. For regular files this is fine. For named pipes, `open()` succeeds — a FIFO is openable — but `.read()` then **blocks indefinitely** because the pipe was already fully consumed during the initial parse step and there is no new writer:

```
Step 1: pip-compile reads from named-pipe (FIFO) → pipe drained, EOF reached
Step 2: dependency resolution completes
Step 3: _determine_linesep() opens named-pipe again → blocks on .read() forever
```

The regression was introduced in #1652 (v6.10.0).

## Fix

Guard the `open()` with `Path(fname).is_file()`, which returns `True` only for regular files — `False` for FIFOs, sockets, directories, and non-existent paths. `Path` is already imported in `compile.py`.

```diff
 if strategy == "preserve":
     for fname in filenames:
         try:
+            if not Path(fname).is_file():
+                continue
             with open(fname, "rb") as existing_file:
                 existing_text = existing_file.read()
-        except FileNotFoundError:
+        except OSError:
             continue
```

The exception is also broadened from `FileNotFoundError` to `OSError` to handle permission errors, broken symlinks, and other IO failures that could occur despite the `is_file()` pre-check.

## Test Plan

- [ ] `mkfifo named-pipe && echo 'requests' > named-pipe &; pip-compile -o- named-pipe` — no longer hangs
- [ ] Existing tests for `_determine_linesep()` pass
- [ ] `pip-compile requirements.in` (regular file) — unchanged behaviour
