### PR TITLE
Fix inaccurate type annotations for InstallRequirement values

### DIFF
--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -44,7 +44,7 @@ class LocalRequirementsRepository(BaseRepository):
 
     def __init__(
         self,
-        existing_pins: Mapping[str, InstallationCandidate],
+        existing_pins: Mapping[str, InstallRequirement],
         proxied_repository: BaseRepository,
         reuse_hashes: bool = True,
     ):

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -196,7 +196,7 @@ def diff(
 
 def sync(
     to_install: Iterable[InstallRequirement],
-    to_uninstall: Iterable[InstallRequirement],
+    to_uninstall: Iterable[InstallRequirement | str],
     dry_run: bool = False,
     install_flags: list[str] | None = None,
     ask: bool = False,


### PR DESCRIPTION
_Part of #2200._

---

Because the current `mypy` configuration for pip tools is not
meaningfully checking anything to with pip, we have accrued inaccurate
annotations.

This patch fixes two trivially inaccurate annotations which can be
observed when attempting to fix the mypy configuration.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
