### PR TITLE
Replace all use of pytest's tmpdir fixture with tmp_path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,7 +253,10 @@ def runner():
 
 
 @pytest.fixture
-def tmp_path_cwd(tmp_path, monkeypatch):
+def tmp_path_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _t.Iterator[Path]:
+    """Wrap ``tmp_path`` to also chdir into it."""
+    # use an explicit monkeypatch context, rather than calling monkeypatch.chdir, so
+    # that calls to `monkeypatch.undo()` won't accidentally revert
     with monkeypatch.context() as mp:
         mp.chdir(tmp_path)
         yield tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,13 @@ def runner():
 
 
 @pytest.fixture
+def tmp_path_cwd(tmp_path, monkeypatch):
+    with monkeypatch.context() as mp:
+        mp.chdir(tmp_path)
+        yield tmp_path
+
+
+@pytest.fixture
 def tmpdir_cwd(tmpdir):
     with tmpdir.as_cwd():
         yield Path(tmpdir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ def repository():
 
 
 @pytest.fixture
-def pypi_repository(tmpdir):
+def pypi_repository(tmp_path):
     return PyPIRepository(
         [
             "--index-url",
@@ -174,13 +174,13 @@ def pypi_repository(tmpdir):
             "--use-deprecated",
             "legacy-resolver",
         ],
-        cache_dir=(tmpdir / "pypi-repo"),
+        cache_dir=(tmp_path / "pypi-repo"),
     )
 
 
 @pytest.fixture
-def depcache(tmpdir):
-    return DependencyCache(tmpdir / "dep-cache")
+def depcache(tmp_path):
+    return DependencyCache(tmp_path / "dep-cache")
 
 
 @pytest.fixture
@@ -260,26 +260,20 @@ def tmp_path_cwd(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def tmpdir_cwd(tmpdir):
-    with tmpdir.as_cwd():
-        yield Path(tmpdir)
-
-
-@pytest.fixture
-def make_pip_conf(tmpdir, monkeypatch):
+def make_pip_conf(tmp_path, monkeypatch):
     created_paths = []
 
     def _make_pip_conf(content):
         pip_conf_file = "pip.conf" if os.name != "nt" else "pip.ini"
-        path = (tmpdir / pip_conf_file).strpath
+        path = tmp_path / pip_conf_file
+        path.write_text(content)
 
-        with open(path, "w") as f:
-            f.write(content)
+        path_str = str(path)
 
-        monkeypatch.setenv("PIP_CONFIG_FILE", path)
+        monkeypatch.setenv("PIP_CONFIG_FILE", path_str)
 
-        created_paths.append(path)
-        return path
+        created_paths.append(path_str)
+        return path_str
 
     try:
         yield _make_pip_conf
@@ -410,33 +404,30 @@ def make_sdist(run_setup_file):
 
 
 @pytest.fixture
-def make_module(tmpdir):
+def make_module(tmp_path):
     """
     Make a metadata file with the given name and content and a fake module.
     """
 
-    def _make_module(fname, content):
-        path = os.path.join(tmpdir, "sample_lib")
-        os.mkdir(path)
-        path = os.path.join(tmpdir, "sample_lib", "__init__.py")
-        with open(path, "w") as stream:
-            stream.write("'example module'\n__version__ = '1.2.3'")
+    def _make_module(fname, content) -> str:
+        path = tmp_path / "sample_lib"
+        path.mkdir()
+        path = tmp_path / "sample_lib" / "__init__.py"
+        path.write_text("'example module'\n__version__ = '1.2.3'")
         if fname == "setup.cfg":
-            path = os.path.join(tmpdir, "pyproject.toml")
-            with open(path, "w") as stream:
-                stream.write(
-                    "\n".join(
-                        (
-                            "[build-system]",
-                            'requires = ["setuptools"]',
-                            'build-backend = "setuptools.build_meta"',
-                        )
+            path = tmp_path / "pyproject.toml"
+            path.write_text(
+                "\n".join(
+                    (
+                        "[build-system]",
+                        'requires = ["setuptools"]',
+                        'build-backend = "setuptools.build_meta"',
                     )
                 )
-        path = os.path.join(tmpdir, fname)
-        with open(path, "w") as stream:
-            stream.write(dedent(content))
-        return path
+            )
+        path = tmp_path / fname
+        path.write_text(dedent(content))
+        return str(path)
 
     return _make_module
 
@@ -503,7 +494,7 @@ def _reset_log():
 
 
 @pytest.fixture
-def make_config_file(tmpdir_cwd):
+def make_config_file(tmp_path_cwd):
     """
     Make a config file for pip-tools with a given parameter set to a specific
     value, returning a ``pathlib.Path`` to the config file.
@@ -517,18 +508,18 @@ def make_config_file(tmpdir_cwd):
         subsection: str | None = None,
     ) -> Path:
         # Create a nested directory structure if config_file_name includes directories
-        config_dir = (tmpdir_cwd / config_file_name).parent
+        config_dir = (tmp_path_cwd / config_file_name).parent
         config_dir.mkdir(exist_ok=True, parents=True)
 
         # Make a config file with this one config default override
-        config_file = tmpdir_cwd / config_file_name
+        config_file = tmp_path_cwd / config_file_name
 
         nested_config = {pyproject_param: new_default}
         if subsection:
             nested_config = {subsection: nested_config}
         config_to_dump = {"tool": {section: nested_config}}
         config_file.write_text(tomli_w.dumps(config_to_dump))
-        return _t.cast(Path, config_file.relative_to(tmpdir_cwd))
+        return _t.cast(Path, config_file.relative_to(tmp_path_cwd))
 
     return _maker
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -65,26 +65,26 @@ def test_read_cache_file_successful():
         assert "success" == read_cache_file(cache_file_name)
 
 
-def test_read_cache_does_not_exist(tmpdir):
-    cache = DependencyCache(cache_dir=tmpdir)
+def test_read_cache_does_not_exist(tmp_path):
+    cache = DependencyCache(cache_dir=tmp_path)
     assert cache.cache == {}
 
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="os.fchmod() not available on Windows"
 )
-def test_read_cache_permission_error(tmpdir):
-    cache = DependencyCache(cache_dir=tmpdir)
+def test_read_cache_permission_error(tmp_path):
+    cache = DependencyCache(cache_dir=tmp_path)
     with open(cache._cache_file, "w") as fp:
         os.fchmod(fp.fileno(), 0o000)
     with pytest.raises(IOError, match="Permission denied"):
         cache.cache
 
 
-def test_reverse_dependencies(from_line, tmpdir):
+def test_reverse_dependencies(from_line, tmp_path):
     # Create a cache object. The keys are packages, and the values are lists
     # of packages on which the keys depend.
-    cache = DependencyCache(cache_dir=tmpdir)
+    cache = DependencyCache(cache_dir=tmp_path)
     cache[from_line("top==1.2")] = ["middle>=0.3", "bottom>=5.1.2"]
     cache[from_line("top[xtra]==1.2")] = ["middle>=0.3", "bottom>=5.1.2", "bonus==0.4"]
     cache[from_line("middle==0.4")] = ["bottom<6"]
@@ -120,4 +120,4 @@ def test_reverse_dependencies(from_line, tmpdir):
     }
 
     # Clean up our temp directory
-    rmtree(tmpdir)
+    rmtree(tmp_path)

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -48,6 +48,13 @@ skip_if_pip_does_not_support_editables_in_constraints = pytest.mark.skipif(
 )
 
 
+@pytest.fixture
+def tmp_path_cwd(tmp_path, monkeypatch):
+    with monkeypatch.context() as mp:
+        mp.chdir(tmp_path)
+        yield tmp_path
+
+
 @pytest.fixture(scope="session")
 def pip_produces_absolute_paths():
     # in pip v24.3, new normalization will occur because `comes_from` started
@@ -136,8 +143,8 @@ def current_resolver(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _temp_dep_cache(tmpdir, monkeypatch):
-    monkeypatch.setenv("PIP_TOOLS_CACHE_DIR", str(tmpdir / "cache"))
+def _temp_dep_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("PIP_TOOLS_CACHE_DIR", str(tmp_path / "cache"))
 
 
 def test_default_pip_conf_read(pip_with_index_conf, runner):
@@ -247,13 +254,14 @@ def test_command_line_setuptools_output_file(runner, options, expected_output_fi
 
 
 @pytest.mark.network
-def test_command_line_setuptools_nested_output_file(tmpdir, runner):
+def test_command_line_setuptools_nested_output_file(tmp_path, runner):
     """
     Test the output file for setup.py in nested folder as a requirement file.
     """
-    proj_dir = tmpdir.mkdir("proj")
+    proj_dir = tmp_path / "proj"
+    proj_dir.mkdir()
 
-    with open(str(proj_dir / "setup.py"), "w") as package:
+    with open(proj_dir / "setup.py", "w") as package:
         package.write(dedent("""\
                 from setuptools import setup
                 setup(install_requires=[])
@@ -266,14 +274,14 @@ def test_command_line_setuptools_nested_output_file(tmpdir, runner):
 
 @pytest.mark.network
 def test_setuptools_preserves_environment_markers(
-    runner, make_package, make_wheel, make_pip_conf, tmpdir
+    runner, make_package, make_wheel, make_pip_conf, tmp_path
 ):
     make_pip_conf(dedent("""\
             [global]
             disable-pip-version-check = True
             """))
 
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
 
     foo_dir = make_package(name="foo", version="1.0")
     make_wheel(foo_dir, dists_dir)
@@ -708,12 +716,13 @@ def test_compile_cached_vcs_package(runner, venv):
 
 @legacy_resolver_only
 def test_locally_available_editable_package_is_not_archived_in_cache_dir(
-    pip_conf, tmpdir, runner
+    pip_conf, tmp_path, runner
 ):
     """
     piptools will not create an archive for a locally available editable requirement
     """
-    cache_dir = tmpdir.mkdir("cache_dir")
+    cache_dir = tmp_path / "cache_dir"
+    cache_dir.mkdir()
 
     fake_package_dir = os.path.join(PACKAGES_PATH, "small_fake_with_deps")
     fake_package_dir = path_to_url(fake_package_dir)
@@ -1063,7 +1072,7 @@ def test_upgrade_packages_version_option_and_upgrade_no_existing_file(pip_conf, 
     assert "small-fake-b==0.1" in out.stderr
 
 
-def test_upgrade_package_with_extra(runner, make_package, make_sdist, tmpdir):
+def test_upgrade_package_with_extra(runner, make_package, make_sdist, tmp_path):
     """
     piptools ignores extras on --upgrade-package/-P items if already constrained.
     """
@@ -1074,7 +1083,7 @@ def test_upgrade_package_with_extra(runner, make_package, make_sdist, tmpdir):
         "test_package_2",
         version="0.1",
     )
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
     for pkg in (test_package_1, test_package_2):
         make_sdist(pkg, dists_dir)
 
@@ -1301,8 +1310,8 @@ def test_preserve_newline_from_input(runner, linesep, must_exclude):
     assert must_exclude not in txt
 
 
-def test_generate_hashes_with_split_style_annotations(pip_conf, runner, tmpdir_cwd):
-    reqs_in = tmpdir_cwd / "requirements.in"
+def test_generate_hashes_with_split_style_annotations(pip_conf, runner, tmp_path_cwd):
+    reqs_in = tmp_path_cwd / "requirements.in"
     reqs_in.write_text(dedent("""\
             small_fake_with_deps
             small-fake-a
@@ -1334,8 +1343,8 @@ def test_generate_hashes_with_split_style_annotations(pip_conf, runner, tmpdir_c
         """)
 
 
-def test_generate_hashes_with_line_style_annotations(pip_conf, runner, tmpdir_cwd):
-    reqs_in = tmpdir_cwd / "requirements.in"
+def test_generate_hashes_with_line_style_annotations(pip_conf, runner, tmp_path_cwd):
+    reqs_in = tmp_path_cwd / "requirements.in"
     reqs_in.write_text(dedent("""\
             small_fake_with_deps
             small-fake-a
@@ -2342,13 +2351,13 @@ def test_ignore_compiled_unavailable_version(pip_conf, runner, current_resolver)
 
 
 def test_prefer_binary_dist(
-    pip_conf, make_package, make_sdist, make_wheel, tmpdir, runner
+    pip_conf, make_package, make_sdist, make_wheel, tmp_path, runner
 ):
     """
     Test pip-compile chooses a correct version of a package with
     a binary distribution when PIP_PREFER_BINARY environment variable is on.
     """
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
 
     # Make first-package==1.0 and wheels
     first_package_v1 = make_package(name="first-package", version="1.0")
@@ -2380,7 +2389,7 @@ def test_prefer_binary_dist(
 
 @pytest.mark.parametrize("prefer_binary", (True, False))
 def test_prefer_binary_dist_even_there_is_source_dists(
-    pip_conf, make_package, make_sdist, make_wheel, tmpdir, runner, prefer_binary
+    pip_conf, make_package, make_sdist, make_wheel, tmp_path, runner, prefer_binary
 ):
     """
     Test pip-compile chooses a correct version of a package with a binary distribution
@@ -2389,7 +2398,7 @@ def test_prefer_binary_dist_even_there_is_source_dists(
 
     Regression test for issue GH-1118.
     """
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
 
     # Make first version of package with only wheels
     package_v1 = make_package(name="test-package", version="1.0")
@@ -2415,7 +2424,7 @@ def test_prefer_binary_dist_even_there_is_source_dists(
 
 @pytest.mark.parametrize("output_content", ("test-package-1==0.1", ""))
 def test_duplicate_reqs_combined(
-    pip_conf, make_package, make_sdist, tmpdir, runner, output_content
+    pip_conf, make_package, make_sdist, tmp_path, runner, output_content
 ):
     """
     Test pip-compile tracks dependencies properly when install requirements are
@@ -2428,7 +2437,7 @@ def test_duplicate_reqs_combined(
         "test_package_2", version="0.1", install_requires=["test-package-1"]
     )
 
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
 
     for pkg in (test_package_1, test_package_2):
         make_sdist(pkg, dists_dir)
@@ -2509,7 +2518,7 @@ def test_combine_extras(pip_conf, runner, make_package):
 
 
 def test_combine_different_extras_of_the_same_package(
-    pip_conf, runner, tmpdir, make_package, make_wheel
+    pip_conf, runner, tmp_path, make_package, make_wheel
 ):
     """
     Loosely based on the example from https://github.com/jazzband/pip-tools/issues/1511.
@@ -2540,7 +2549,7 @@ def test_combine_different_extras_of_the_same_package(
         ),
     ]
 
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
     for pkg in pkgs:
         make_wheel(pkg, dists_dir)
 
@@ -2661,7 +2670,7 @@ def test_triple_equal_pinned_dependency_is_used(
     runner,
     make_package,
     make_wheel,
-    tmpdir,
+    tmp_path,
     pkg2_install_requires,
     req_in_content,
     out_expected_content,
@@ -2672,7 +2681,7 @@ def test_triple_equal_pinned_dependency_is_used(
     patches (e.g. torch 1.7.1+cu110), we want torch===1.7.1 without patches
     """
 
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
 
     test_package_1 = make_package("test_package_1", version="0.1.0")
     make_wheel(test_package_1, dists_dir)
@@ -3186,12 +3195,12 @@ def test_only_build_deps_fails_with_conflicting_options(runner, option):
 
 @backtracking_resolver_only
 @pytest.mark.parametrize("option", ("--all-build-deps", "--build-deps-for=wheel"))
-def test_build_deps_fail_without_setup_file(runner, tmpdir, option):
+def test_build_deps_fail_without_setup_file(runner, tmp_path, option):
     """
     Test that passing ``--build-deps-for`` or ``--all-build-deps`` fails when used with a
     requirements file as opposed to a setup file.
     """
-    path = pathlib.Path(tmpdir) / "requirements.in"
+    path = tmp_path / "requirements.in"
     path.write_text("\n")
     out = runner.invoke(cli, ["-n", option, os.fspath(path)])
     exp = (
@@ -3202,11 +3211,11 @@ def test_build_deps_fail_without_setup_file(runner, tmpdir, option):
     assert exp in out.stderr
 
 
-def test_extras_fail_with_requirements_in(runner, tmpdir):
+def test_extras_fail_with_requirements_in(runner, tmp_path):
     """
     Test that passing ``--extra`` with ``requirements.in`` input file fails.
     """
-    path = pathlib.Path(tmpdir) / "requirements.in"
+    path = tmp_path / "requirements.in"
     path.write_text("\n")
     out = runner.invoke(cli, ["-n", "--extra", "something", os.fspath(path)])
     assert out.exit_code == 2
@@ -3214,7 +3223,7 @@ def test_extras_fail_with_requirements_in(runner, tmpdir):
     assert exp in out.stderr
 
 
-def test_cli_compile_strip_extras(runner, make_package, make_sdist, tmpdir):
+def test_cli_compile_strip_extras(runner, make_package, make_sdist, tmp_path):
     """
     Assures that ``--strip-extras`` removes mention of extras from output.
     """
@@ -3225,7 +3234,7 @@ def test_cli_compile_strip_extras(runner, make_package, make_sdist, tmpdir):
         "test_package_2",
         version="0.1",
     )
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
 
     for pkg in (test_package_1, test_package_2):
         make_sdist(pkg, dists_dir)
@@ -3241,7 +3250,7 @@ def test_cli_compile_strip_extras(runner, make_package, make_sdist, tmpdir):
 
 
 def test_cli_compile_all_extras_with_multiple_packages(
-    runner, make_package, make_sdist, tmpdir
+    runner, make_package, make_sdist, tmp_path
 ):
     """
     Assures that ``--all-extras`` works when multiple sources are specified.
@@ -3371,7 +3380,7 @@ def test_resolver_drops_existing_conflicting_constraint(
     runner,
     make_package,
     make_sdist,
-    tmpdir,
+    tmp_path,
     package_specs,
     constraints,
     existing_reqs,
@@ -3386,7 +3395,7 @@ def test_resolver_drops_existing_conflicting_constraint(
     or not (cf. `issue #1977 <https://github.com/jazzband/pip-tools/issues/1977>`_).
     """
     expected_requirements = {line.strip() for line in expected_reqs.splitlines()}
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
 
     packages = [make_package(**spec) for spec in package_specs]
     for pkg in packages:
@@ -3469,7 +3478,7 @@ def test_preserve_via_requirements_constrained_dependencies_when_run_twice(
 
 
 def test_failure_of_legacy_resolver_prompts_for_backtracking(
-    pip_conf, runner, tmpdir, make_package, make_wheel, current_resolver
+    pip_conf, runner, tmp_path, make_package, make_wheel, current_resolver
 ):
     """Test that pip-compile prompts to use the backtracking resolver"""
     pkgs = [
@@ -3480,7 +3489,7 @@ def test_failure_of_legacy_resolver_prompts_for_backtracking(
         make_package("c", version="1", install_requires=["b==0.1", "a"]),
     ]
 
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
     for pkg in pkgs:
         make_wheel(pkg, dists_dir)
 
@@ -3545,8 +3554,9 @@ def test_raise_error_when_input_and_output_filenames_are_matched(
 
 @pytest.mark.network
 @backtracking_resolver_only
-def test_pass_pip_cache_to_pip_args(tmpdir, runner, current_resolver):
-    cache_dir = tmpdir.mkdir("cache_dir")
+def test_pass_pip_cache_to_pip_args(tmp_path, runner, current_resolver):
+    cache_dir = tmp_path / "cache_dir"
+    cache_dir.mkdir()
 
     with open("requirements.in", "w") as fp:
         fp.write("six==1.15.0")
@@ -3752,10 +3762,10 @@ def test_config_option(pip_conf, runner, tmp_path, make_config_file):
     assert "Dry-run, so nothing updated" in out.stderr
 
 
-def test_default_config_option(pip_conf, runner, make_config_file, tmpdir_cwd):
+def test_default_config_option(pip_conf, runner, make_config_file, tmp_path_cwd):
     make_config_file("dry-run", True)
 
-    req_in = tmpdir_cwd / "requirements.in"
+    req_in = tmp_path_cwd / "requirements.in"
     req_in.touch()
 
     out = runner.invoke(cli)
@@ -3809,11 +3819,11 @@ def test_raise_error_on_invalid_config_option(
 
 
 @pytest.mark.parametrize("option", ("-c", "--constraint"))
-def test_constraint_option(pip_conf, runner, tmpdir_cwd, make_config_file, option):
-    req_in = tmpdir_cwd / "requirements.in"
+def test_constraint_option(pip_conf, runner, tmp_path_cwd, make_config_file, option):
+    req_in = tmp_path_cwd / "requirements.in"
     req_in.write_text("small-fake-a")
 
-    constraints_txt = tmpdir_cwd / "constraints.txt"
+    constraints_txt = tmp_path_cwd / "constraints.txt"
     constraints_txt.write_text("small-fake-a==0.1")
 
     out = runner.invoke(
@@ -3956,7 +3966,7 @@ def test_do_not_show_warning_on_explicit_strip_extras_option(
 
 
 def test_origin_of_extra_requirement_not_written_to_annotations(
-    pip_conf, runner, make_package, make_wheel, tmp_path, tmpdir
+    pip_conf, runner, make_package, make_wheel, tmp_path
 ):
     req_in = tmp_path / "requirements.in"
     package_with_extras = make_package(
@@ -3968,7 +3978,7 @@ def test_origin_of_extra_requirement_not_written_to_annotations(
         },
     )
 
-    dists_dir = tmpdir / "dists"
+    dists_dir = tmp_path / "dists"
     make_wheel(package_with_extras, dists_dir)
 
     with open(req_in, "w") as req_out:
@@ -4362,7 +4372,7 @@ def test_compile_with_generate_hashes_preserves_extra_index_url(
     pip_with_index_conf,
     minimal_wheels_path,
     runner,
-    tmpdir_cwd,
+    tmp_path_cwd,
 ):
     """
     Regression test for
@@ -4372,7 +4382,7 @@ def test_compile_with_generate_hashes_preserves_extra_index_url(
     cache (``allow_all_wheels()``), and that code incorrectly cleared more information
     than desired, removing extra index URLs in addition to cached package info.
     """
-    reqs_in = tmpdir_cwd / "requirements.in"
+    reqs_in = tmp_path_cwd / "requirements.in"
     reqs_in.write_text(dedent("""\
             --extra-index-url http://extraindex1.com
 

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -48,13 +48,6 @@ skip_if_pip_does_not_support_editables_in_constraints = pytest.mark.skipif(
 )
 
 
-@pytest.fixture
-def tmp_path_cwd(tmp_path, monkeypatch):
-    with monkeypatch.context() as mp:
-        mp.chdir(tmp_path)
-        yield tmp_path
-
-
 @pytest.fixture(scope="session")
 def pip_produces_absolute_paths():
     # in pip v24.3, new normalization will occur because `comes_from` started

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -398,7 +398,7 @@ def test_default_python_executable_option(run, runner):
 
 
 @mock.patch("piptools.sync.run")
-def test_default_config_option(run, runner, make_config_file, tmpdir_cwd):
+def test_default_config_option(run, runner, make_config_file, tmp_path_cwd):
     make_config_file("dry-run", True)
 
     with open(sync.DEFAULT_REQUIREMENTS_FILE, "w") as reqs_txt:

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -98,12 +98,12 @@ def test_open_local_or_remote_file__local_file(tmp_path, content, content_length
         assert file_stream.size == content_length
 
 
-def test_open_local_or_remote_file__directory(tmpdir):
+def test_open_local_or_remote_file__directory(tmp_path):
     """
     Test the `open_local_or_remote_file` raises a ValueError for a given `Link`
     to a directory.
     """
-    link = Link(path_to_url(tmpdir.strpath))
+    link = Link(path_to_url(str(tmp_path)))
     session = Session()
 
     with (
@@ -151,19 +151,19 @@ def test_relative_path_cache_dir_is_normalized(from_line):
     assert pypi_repository._cache_dir.endswith(relative_cache_dir)
 
 
-def test_relative_path_pip_cache_dir_is_normalized(from_line, tmpdir):
+def test_relative_path_pip_cache_dir_is_normalized(from_line, tmp_path):
     relative_cache_dir = "pip-cache"
     pypi_repository = PyPIRepository(
-        ["--cache-dir", relative_cache_dir], cache_dir=(tmpdir / "pypi-repo-cache")
+        ["--cache-dir", relative_cache_dir], cache_dir=(tmp_path / "pypi-repo-cache")
     )
 
     assert os.path.isabs(pypi_repository.options.cache_dir)
     assert pypi_repository.options.cache_dir.endswith(relative_cache_dir)
 
 
-def test_pip_cache_dir_is_empty(from_line, tmpdir):
+def test_pip_cache_dir_is_empty(from_line, tmp_path):
     pypi_repository = PyPIRepository(
-        ["--no-cache-dir"], cache_dir=(tmpdir / "pypi-repo-cache")
+        ["--no-cache-dir"], cache_dir=(tmp_path / "pypi-repo-cache")
     )
 
     assert not pypi_repository.options.cache_dir
@@ -270,7 +270,7 @@ def test_pip_cache_dir_is_empty(from_line, tmpdir):
         ),
     ),
 )
-def test_get_hashes_from_pypi(from_line, tmpdir, project_data, expected_hashes):
+def test_get_hashes_from_pypi(from_line, tmp_path, project_data, expected_hashes):
     """
     Test PyPIRepository._get_hashes_from_pypi() returns expected hashes or None.
     """
@@ -280,7 +280,7 @@ def test_get_hashes_from_pypi(from_line, tmpdir, project_data, expected_hashes):
             return project_data
 
     pypi_repository = MockPyPIRepository(
-        ["--no-cache-dir"], cache_dir=(tmpdir / "pypi-repo-cache")
+        ["--no-cache-dir"], cache_dir=(tmp_path / "pypi-repo-cache")
     )
     ireq = from_line("fake-package==0.1")
 
@@ -288,7 +288,7 @@ def test_get_hashes_from_pypi(from_line, tmpdir, project_data, expected_hashes):
     assert actual_hashes == expected_hashes
 
 
-def test_get_hashes_from_mixed(pip_conf, from_line, tmpdir):
+def test_get_hashes_from_mixed(pip_conf, from_line, tmp_path):
     """
     Test PyPIRepository.get_hashes() returns hashes from both PyPi and extra indexes/links
     """
@@ -335,7 +335,7 @@ def test_get_hashes_from_mixed(pip_conf, from_line, tmpdir):
             return file_hashes[link]
 
     pypi_repository = MockPyPIRepository(
-        ["--no-cache-dir"], cache_dir=(tmpdir / "pypi-repo-cache")
+        ["--no-cache-dir"], cache_dir=(tmp_path / "pypi-repo-cache")
     )
 
     ireq = from_line(f"{package_name}=={package_version}")
@@ -346,7 +346,7 @@ def test_get_hashes_from_mixed(pip_conf, from_line, tmpdir):
     assert actual_hashes == expected_hashes
 
 
-def test_get_project__returns_data(from_line, tmpdir, monkeypatch, pypi_repository):
+def test_get_project__returns_data(from_line, monkeypatch, pypi_repository):
     """
     Test PyPIRepository._get_project() returns expected project data.
     """
@@ -369,9 +369,7 @@ def test_get_project__returns_data(from_line, tmpdir, monkeypatch, pypi_reposito
     assert actual_data == expected_data
 
 
-def test_get_project__handles_http_error(
-    from_line, tmpdir, monkeypatch, pypi_repository
-):
+def test_get_project__handles_http_error(from_line, monkeypatch, pypi_repository):
     """
     Test PyPIRepository._get_project() returns None if HTTP error is raised.
     """
@@ -387,7 +385,7 @@ def test_get_project__handles_http_error(
 
 
 def test_get_project__handles_json_decode_error(
-    from_line, tmpdir, monkeypatch, pypi_repository
+    from_line, monkeypatch, pypi_repository
 ):
     """
     Test PyPIRepository._get_project() returns None if JSON decode error is raised.
@@ -410,7 +408,7 @@ def test_get_project__handles_json_decode_error(
     assert actual_data is None
 
 
-def test_get_project__handles_404(from_line, tmpdir, monkeypatch, pypi_repository):
+def test_get_project__handles_404(from_line, monkeypatch, pypi_repository):
     """
     Test PyPIRepository._get_project() returns None if PyPI
     response's status code is 404.
@@ -429,7 +427,7 @@ def test_get_project__handles_404(from_line, tmpdir, monkeypatch, pypi_repositor
     assert actual_data is None
 
 
-def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tmpdir):
+def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tmp_path):
     """
     Test to ensure we don't fail if there are multiple URL-based requirements
     ending with the same filename where later ones depend on earlier, e.g.
@@ -446,7 +444,7 @@ def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tm
     }
 
     for pkg_name, pkg in packages.items():
-        pkg_path = tmpdir / pkg_name
+        pkg_path = tmp_path / pkg_name
 
         make_sdist(pkg, pkg_path, "--formats=zip")
 
@@ -456,14 +454,14 @@ def test_name_collision(from_line, pypi_repository, make_package, make_sdist, tm
         )
 
     name_collision_1 = "file://{dist_path}#egg=test_package_1".format(
-        dist_path=tmpdir / "test_package_1" / "main.zip"
+        dist_path=tmp_path / "test_package_1" / "main.zip"
     )
     ireq = from_line(name_collision_1)
     deps = pypi_repository.get_dependencies(ireq)
     assert len(deps) == 0
 
     name_collision_2 = "file://{dist_path}#egg=test_package_2".format(
-        dist_path=tmpdir / "test_package_2" / "main.zip"
+        dist_path=tmp_path / "test_package_2" / "main.zip"
     )
     ireq = from_line(name_collision_2)
     deps = pypi_repository.get_dependencies(ireq)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -428,7 +428,7 @@ def test_is_url_requirement_filename(caplog, from_line, line):
         ),
     ),
 )
-def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):
+def test_get_compile_command(tmp_path_cwd, cli_args, expected_command):
     """
     Test general scenarios for the get_compile_command function.
     """
@@ -452,7 +452,7 @@ def test_get_compile_command(tmpdir_cwd, cli_args, expected_command):
         ),
     ),
 )
-def test_get_compile_command_with_config(tmpdir_cwd, config_file, expected_command):
+def test_get_compile_command_with_config(tmp_path_cwd, config_file, expected_command):
     """Test that get_compile_command excludes or includes config file."""
     with open(config_file, "w"):
         pass
@@ -470,7 +470,7 @@ def test_get_compile_command_with_config(tmpdir_cwd, config_file, expected_comma
     ),
 )
 def test_get_compile_command_does_not_include_default_config_if_reqs_file_in_subdir(
-    tmpdir_cwd, config_file, config_file_content
+    tmp_path_cwd, config_file, config_file_content
 ):
     """
     Test that ``get_compile_command`` does not include default config file
@@ -480,7 +480,7 @@ def test_get_compile_command_does_not_include_default_config_if_reqs_file_in_sub
     default_config_file = Path(config_file)
     default_config_file.write_text(config_file_content)
 
-    (tmpdir_cwd / "subdir").mkdir()
+    (tmp_path_cwd / "subdir").mkdir()
     req_file = Path("subdir/requirements.in")
     req_file.touch()
     req_file.write_bytes(b"")
@@ -490,7 +490,7 @@ def test_get_compile_command_does_not_include_default_config_if_reqs_file_in_sub
         assert get_compile_command(ctx) == f"pip-compile {req_file.as_posix()}"
 
 
-def test_get_compile_command_escaped_filenames(tmpdir_cwd):
+def test_get_compile_command_escaped_filenames(tmp_path_cwd):
     """
     Test that get_compile_command output (re-)escapes ' -- '-escaped filenames.
     """
@@ -503,7 +503,7 @@ def test_get_compile_command_escaped_filenames(tmpdir_cwd):
 @pytest.mark.parametrize(
     "filename", ("requirements.in", "my requirements.in", "απαιτήσεις.txt")
 )
-def test_get_compile_command_with_files(tmpdir_cwd, filename):
+def test_get_compile_command_with_files(tmp_path_cwd, filename):
     """
     Test that get_compile_command returns a command with correct
     and sanitized file names.
@@ -522,7 +522,7 @@ def test_get_compile_command_with_files(tmpdir_cwd, filename):
         )
 
 
-def test_get_compile_command_sort_args(tmpdir_cwd):
+def test_get_compile_command_sort_args(tmp_path_cwd):
     """
     Test that get_compile_command correctly sorts arguments.
 
@@ -755,7 +755,7 @@ def test_callback_config_file_defaults_unreadable_toml(make_config_file):
         )
 
 
-def test_select_config_file_no_files(tmpdir_cwd):
+def test_select_config_file_no_files(tmp_path_cwd):
     assert select_config_file(()) is None
 
 
@@ -765,19 +765,19 @@ def test_select_config_file_returns_config_in_cwd(make_config_file, filename):
     assert select_config_file(()) == config_file
 
 
-def test_select_config_file_returns_empty_config_file_in_cwd(tmpdir_cwd):
+def test_select_config_file_returns_empty_config_file_in_cwd(tmp_path_cwd):
     config_file = Path(".pip-tools.toml")
     config_file.touch()
 
     assert select_config_file(()) == config_file
 
 
-def test_select_config_file_cannot_find_config_in_cwd(tmpdir_cwd, make_config_file):
+def test_select_config_file_cannot_find_config_in_cwd(tmp_path_cwd, make_config_file):
     make_config_file("dry-run", True, "subdir/pyproject.toml")
     assert select_config_file(()) is None
 
 
-def test_select_config_file_with_config_file_in_subdir(tmpdir_cwd, make_config_file):
+def test_select_config_file_with_config_file_in_subdir(tmp_path_cwd, make_config_file):
     config_file = make_config_file("dry-run", True, "subdir/.pip-tools.toml")
 
     requirement_file = Path("subdir/requirements.in")
@@ -786,7 +786,7 @@ def test_select_config_file_with_config_file_in_subdir(tmpdir_cwd, make_config_f
     assert select_config_file((requirement_file.as_posix(),)) == config_file
 
 
-def test_select_config_file_prefers_pip_tools_toml_over_pyproject_toml(tmpdir_cwd):
+def test_select_config_file_prefers_pip_tools_toml_over_pyproject_toml(tmp_path_cwd):
     pip_tools_file = Path(".pip-tools.toml")
     pip_tools_file.touch()
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -17,7 +17,7 @@ from piptools.writer import (
 
 
 @pytest.fixture
-def writer(tmpdir_cwd):
+def writer(tmp_path_cwd):
     with open("src_file", "w"), open("src_file2", "w"):
         pass
 


### PR DESCRIPTION
This change is broken down into commits as an option for review, however the total scope of work is relatively simple.
`tmpdir` is a fixture which provides a `py.path`. `tmp_path` is newer and provides a pathlib `Path`.
Make the switch for a more uniform API within the testsuite.

For the helper fixture which does a `chdir`, there are several options for effecting it -- `monkeypatch` and `contextlib`, among others.
This PR chooses `monkeypatch`, but this can easily be changed.

This is test runtime infrastructure; no changelog is needed.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] ~Included tests for the changes.~
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
