### PR TITLE
Update changelog for v7.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 <!-- towncrier release notes start -->
 
+## v7.6.1
+
+*2026-08-11*
+
+### Bug fixes
+
+- Fixed handling of index URLs ending in `/simple/` by improving URL normalization
+  logic.
+  These URLs would previously make `pip-compile` fail to use the PyPI JSON API.
+
+  -- by {user}`sirosen`
+
+  *PRs and issues:* {issue}`1669`
+
+- Added a missing dependency on {pypi}`typing-extensions` for Python 3.9 and 3.10
+  -- by {user}`sirosen`.
+
+  *PRs and issues:* {issue}`2424`
+
+### Features
+
+- pip-tools is now compatible with pip version 26.2 -- by {user}`sirosen`.
+
+  *PRs and issues:* {issue}`2436`, {issue}`2437`
+
+### Improved documentation
+
+- `pip-tools` documentation now features a how-to section, featuring initial
+  docs which cover controlling output file headers and configuring completion
+  -- by {user}`sirosen`.
+
+
+### Contributor-facing changes
+
+- Fixed CI triggers so that release tags won't create spurious failing runs --
+  by {user}`sirosen`.
+
+  *PRs and issues:* {issue}`2421`
+
+- Refactored the bug report template for better reporting -- by {user}`psthindal`.
+
+
 ## v7.6.0
 
 *2026-07-13*

--- a/changelog.d/+3148a12a.contrib.md
+++ b/changelog.d/+3148a12a.contrib.md
@@ -1,1 +1,0 @@
-Refactored the bug report template for better reporting -- by {user}`psthindal`.

--- a/changelog.d/+e80f21b6.doc.md
+++ b/changelog.d/+e80f21b6.doc.md
@@ -1,3 +1,0 @@
-`pip-tools` documentation now features a how-to section, featuring initial
-docs which cover controlling output file headers and configuring completion
--- by {user}`sirosen`.

--- a/changelog.d/1669.bugfix.md
+++ b/changelog.d/1669.bugfix.md
@@ -1,5 +1,0 @@
-Fixed handling of index URLs ending in `/simple/` by improving URL normalization
-logic.
-These URLs would previously make `pip-compile` fail to use the PyPI JSON API.
-
--- by {user}`sirosen`

--- a/changelog.d/2421.contrib.md
+++ b/changelog.d/2421.contrib.md
@@ -1,2 +1,0 @@
-Fixed CI triggers so that release tags won't create spurious failing runs --
-by {user}`sirosen`.

--- a/changelog.d/2424.bugfix.md
+++ b/changelog.d/2424.bugfix.md
@@ -1,2 +1,0 @@
-Added a missing dependency on {pypi}`typing-extensions` for Python 3.9 and 3.10
--- by {user}`sirosen`.

--- a/changelog.d/2436.feature.md
+++ b/changelog.d/2436.feature.md
@@ -1,1 +1,0 @@
-2437.feature.md

--- a/changelog.d/2437.feature.md
+++ b/changelog.d/2437.feature.md
@@ -1,1 +1,0 @@
-pip-tools is now compatible with pip version 26.2 -- by {user}`sirosen`.


### PR DESCRIPTION
Updates applied via `towncrier build --version v7.6.1`

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
