### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
               inputs.cpython-versions
               && inputs.cpython-versions
               ||
-              '["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]'
+              '["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]'
             )
           }}
         pip-version: >-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 26.5.1
     hooks:
       - id: black
-        args: [--target-version=py39]
+        args: [--target-version=py310]
   - repo: https://github.com/PyCQA/isort
     rev: 9.0.0b2
     hooks:
@@ -12,7 +12,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema.git
     rev: 0.38.0

--- a/changelog.d/2439.packaging.md
+++ b/changelog.d/2439.packaging.md
@@ -1,0 +1,1 @@
+Removed support for Python 3.9 -- by {user}`sirosen`.

--- a/piptools/_internal/_environment_variables.py
+++ b/piptools/_internal/_environment_variables.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import contextlib
+import enum
+import os
+import typing as _t
+from collections.abc import Iterator
+
+
+class _Sentinel(enum.Enum):
+    _SENTINEL = object()
+
+
+_SENTINEL = _Sentinel._SENTINEL
+
+
+@contextlib.contextmanager
+def setenv_context(
+    env_var_name: str,
+    env_var_value: str,
+    /,
+) -> Iterator[None]:
+    """
+    A context manager which sets an environment variable and resets on exit.
+
+    It is robust to interruptions and exceptions, so long as its ``finally`` block is
+    allowed to run to completion.
+    """
+    original_value: str | _t.Literal[_Sentinel._SENTINEL] = os.getenv(
+        env_var_name, _SENTINEL
+    )
+
+    try:
+        os.environ[env_var_name] = env_var_value
+        yield
+    finally:
+        # if the variable was not set, delete it and suppress any exception
+        # if setting it (in the try block above) failed or was interrupted
+        if original_value is _SENTINEL:
+            try:
+                del os.environ[env_var_name]
+            except KeyError:
+                pass
+        # otherwise, we got a value when we called getenv(), and we should reset it
+        else:
+            os.environ[env_var_name] = original_value

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -4,7 +4,6 @@ import collections
 import contextlib
 import os
 import pathlib
-import sys
 import tempfile
 import typing as _t
 from collections.abc import Iterator
@@ -25,18 +24,6 @@ from ._internal import _environment_variables, _pip_api
 PYPROJECT_TOML = "pyproject.toml"
 
 _T = _t.TypeVar("_T")
-
-
-if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
-    from importlib.metadata import PackageMetadata
-else:  # pragma: <3.10 cover
-
-    class PackageMetadata(_t.Protocol):
-        @_t.overload
-        def get_all(self, name: str, failobj: None = None) -> list[_t.Any] | None: ...
-
-        @_t.overload
-        def get_all(self, name: str, failobj: _T) -> list[_t.Any] | _T: ...
 
 
 @dataclass
@@ -260,20 +247,20 @@ def _create_project_builder(
 
 def _build_project_wheel_metadata(
     builder: build.ProjectBuilder,
-) -> PackageMetadata:
+) -> importlib_metadata.PackageMetadata:
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
         return importlib_metadata.PathDistribution(path).metadata
 
 
-def _get_name(metadata: PackageMetadata) -> str:
+def _get_name(metadata: importlib_metadata.PackageMetadata) -> str:
     retval = metadata.get_all("Name")[0]  # type: ignore[index]
     assert isinstance(retval, str)
     return retval
 
 
 def _prepare_requirements(
-    metadata: PackageMetadata, src_file: pathlib.Path
+    metadata: importlib_metadata.PackageMetadata, src_file: pathlib.Path
 ) -> Iterator[InstallRequirement]:
     package_name = _get_name(metadata)
     comes_from = f"{package_name} ({src_file.as_posix()})"

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -20,7 +20,7 @@ from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
 from ._compat import _tomllib_compat
-from ._internal import _pip_api
+from ._internal import _environment_variables, _pip_api
 
 PYPROJECT_TOML = "pyproject.toml"
 
@@ -186,29 +186,6 @@ def build_project_metadata(
 
 
 @contextlib.contextmanager
-def _env_var(
-    env_var_name: str,
-    env_var_value: str,
-    /,
-) -> Iterator[None]:
-    sentinel = object()
-    original_pip_constraint = os.getenv(env_var_name, sentinel)
-    pip_constraint_was_unset = original_pip_constraint is sentinel
-
-    os.environ[env_var_name] = env_var_value
-    try:
-        yield
-    finally:
-        if pip_constraint_was_unset:
-            del os.environ[env_var_name]
-        else:
-            # Assert here is necessary because MyPy can't infer type
-            # narrowing in the complex case.
-            assert isinstance(original_pip_constraint, str)
-            os.environ[env_var_name] = original_pip_constraint
-
-
-@contextlib.contextmanager
 def _temporary_constraints_file_set_for_pip(
     upgrade_packages: tuple[str, ...],
 ) -> Iterator[None]:
@@ -243,7 +220,7 @@ def _temporary_constraints_file_set_for_pip(
         tmpfile.close()
 
         try:
-            with _env_var("PIP_CONSTRAINT", tmpfile.name):
+            with _environment_variables.setenv_context("PIP_CONSTRAINT", tmpfile.name):
                 yield
         finally:
             # FIXME: replace `delete` with `delete_on_close` in Python 3.12+

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -144,7 +144,6 @@ Examples:
 @options.only_build_deps
 def cli(
     ctx: click.Context,
-    color: bool | None,
     verbose: int,
     quiet: int,
     dry_run: bool,
@@ -195,8 +194,6 @@ def cli(
     Valid sources are requirements.in, pyproject.toml, setup.cfg,
     or setup.py specs.
     """
-    if color is not None:
-        ctx.color = color
     log.verbosity = verbose - quiet
 
     # If ``src-files` was not provided as an input, but rather as config,

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -196,10 +196,12 @@ def cli(
     """
     log.verbosity = verbose - quiet
 
-    # If ``src-files` was not provided as an input, but rather as config,
-    # it will be part of the click context ``ctx``.
-    # However, if ``src_files`` is specified, then we want to use that.
-    if not src_files and ctx.default_map and "src_files" in ctx.default_map:
+    # NOTE: On older `click` versions, `src_files` is not populated automatically from
+    # NOTE: config, so it has to be done explicitly here. These align with older Python
+    # NOTE: support, so the entire block is marked with a version pragma.
+    if (
+        not src_files and ctx.default_map and "src_files" in ctx.default_map
+    ):  # pragma: <=3.9 cover
         src_files = ctx.default_map["src_files"]
 
     if all_build_deps and build_deps_targets:

--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -61,9 +61,19 @@ def _get_default_option(option_name: str) -> _t.Any:
 
 version = click.version_option(package_name="pip-tools")
 
+
+def _color_callback(
+    ctx: click.Context, param: click.Parameter, value: bool | None
+) -> None:
+    if value is not None:
+        ctx.color = value
+
+
 color = click.option(
     "--color/--no-color",
     default=None,
+    callback=_color_callback,
+    expose_value=False,
     help="Force output to be colorized or not, instead of auto-detecting color support",
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 # https://peps.python.org/pep-0621/#readme
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dynamic = ["version"]
 name = "pip-tools"
 description = "pip-tools keeps your pinned dependencies fresh."
@@ -20,7 +20,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/tests/unit/_internal/pip_api/test_cli_options.py
+++ b/tests/unit/_internal/pip_api/test_cli_options.py
@@ -9,7 +9,7 @@ from piptools._internal import _pip_api
 @pytest.mark.skipif(
     _pip_api.PIP_VERSION_MAJOR_MINOR < (26, 0), reason="test requires pip>=26.0"
 )
-def test_postprocess_cli_options_pre_adds_all_to_release_control_all_releases():
+def test_postprocess_cli_options_pre_adds_all_to_release_control_all_releases():  # pragma: pip>=26.0 cover  # noqa: E501
     """
     Test that ``--pre`` gets transformed into ``--all-releases :all:``
     """

--- a/tests/unit/_internal/test_environment_variables.py
+++ b/tests/unit/_internal/test_environment_variables.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from piptools._internal import _environment_variables
+
+
+def test_setenv_context_does_simple_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPAM_VAR", "1")
+    with _environment_variables.setenv_context("SPAM_VAR", "spam"):
+        assert os.environ["SPAM_VAR"] == "spam"
+    assert os.environ["SPAM_VAR"] == "1"
+
+
+@pytest.mark.parametrize("value_was_previously_set", (True, False))
+@pytest.mark.parametrize("successfully_sets_value", (True, False))
+def test_setenv_context_does_reset_even_if_setitem_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    value_was_previously_set: bool,
+    successfully_sets_value: bool,
+) -> None:
+    if value_was_previously_set:
+        monkeypatch.setenv("SPAM_VAR", "1")
+    else:
+        monkeypatch.delenv("SPAM_VAR", raising=False)
+
+    # we will inject an error on `__setitem__` to simulate an interruption *right after*
+    # the setitem succeeds
+    original_setitem = os.environ.__setitem__
+
+    def setitem_and_raise(self, key, value):
+        if successfully_sets_value:
+            original_setitem(key, value)
+        raise KeyboardInterrupt("injected interrupt")
+
+    with mock.patch.object(os.environ.__class__, "__setitem__", setitem_and_raise):
+        # PT012 flags any use of pytest.raises() which contains more than a single
+        # simple statement. This is not appropriate to testing the behavior of a context
+        # manager with an error injected into the middle of execution, so it is ignored.
+        with pytest.raises(  # noqa: PT012
+            KeyboardInterrupt,
+            match="injected interrupt",
+        ):
+            with _environment_variables.setenv_context("SPAM_VAR", "spam"):
+                pytest.fail(
+                    "unreachable statement inside of context manager was reached"
+                )
+
+        if value_was_previously_set:
+            assert os.environ["SPAM_VAR"] == "1"
+        else:
+            assert "SPAM_VAR" not in os.environ

--- a/tests/unit/repositories/test_pypi_repository.py
+++ b/tests/unit/repositories/test_pypi_repository.py
@@ -48,3 +48,20 @@ from piptools.repositories.pypi import _get_true_base_from_index_url
 )
 def test_true_base_url_strips_simple_suffix(url: str, expect_result: str) -> None:
     assert _get_true_base_from_index_url(url) == expect_result
+
+
+@pytest.mark.parametrize(
+    "requirement_string",
+    (
+        pytest.param("django", id="unbound"),
+        pytest.param("django > 1", id="lower-bound"),
+    ),
+)
+def test_get_dependencies_helper_rejects_unpinned_reqs(
+    pypi_repository, from_line, requirement_string
+):
+    ireq = from_line(requirement_string)
+    with pytest.raises(
+        TypeError, match="Expected url, pinned or editable InstallRequirement"
+    ):
+        pypi_repository.get_dependencies(ireq)

--- a/tests/unit/scripts/test_options.py
+++ b/tests/unit/scripts/test_options.py
@@ -4,7 +4,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from piptools.scripts.options import help_option
+from piptools.scripts.options import color, help_option
 
 
 def test_help_opt_no_epilog(runner: CliRunner) -> None:
@@ -40,3 +40,27 @@ def test_help_opt_with_epilog(runner: CliRunner) -> None:
     assert result.stdout.startswith("Usage: my-command")
     # the epilog should be last, whitespace aside
     assert result.stdout.rstrip().endswith("hello there")
+
+
+@pytest.mark.parametrize(
+    ("args", "expect_setting"),
+    (
+        ([], None),
+        (["--color"], True),
+        (["--no-color"], False),
+        # last one wins semantics
+        (["--color", "--no-color"], False),
+        (["--no-color", "--color"], True),
+    ),
+)
+def test_color_opt_sets_context_color(
+    runner: CliRunner, args: list[str], expect_setting: bool | None
+) -> None:
+    @click.command("my-command")
+    @color
+    @click.pass_context
+    def my_command(ctx: click.Context) -> None:
+        assert ctx.color == expect_setting
+
+    result = runner.invoke(my_command, args)
+    assert result.exit_code == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # NOTE: keep this in sync with the env list in .github/workflows/ci.yml.
-    py{39,310,311,312,313,314,314t,py3}-pip{supported,lowest,latest,main}-coverage
+    py{310,311,312,313,314,314t,py3}-pip{supported,lowest,latest,main}-coverage
     pip{supported,lowest,latest,main}-coverage
     pip{supported,lowest,latest,main}
     checkqa


### PR DESCRIPTION
- Update CI, tox, and pre-commit configs
- Update package metadata (classifier and lower bound)
- Various conditional coverage pragmas were phrased incorrectly in terms of Python 3.9 -- these pragmas are all removed
- importlib.metadata.PackageMetadata had a conditional definition, now removed (as it is available in 3.10+)

---

I have tried to keep this changeset minimal. It was tempting to include the addition of 3.15, but it's better to have tighter scope.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`] for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version (following Semantic Versioning).