### PR TITLE
Move and make the "_env_var" wrapper testable

### DIFF
--- a/piptools/_internal/_environment_variables.py
+++ b/piptools/_internal/_environment_variables.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import contextlib
+import enum
+import os
+import typing as _t
+from collections.abc import Iterator
+
+
+class _Sentinel(enum.Enum):
+    _SENTINEL = object()
+
+
+_SENTINEL = _Sentinel._SENTINEL
+
+
+@contextlib.contextmanager
+def setenv_context(
+    env_var_name: str,
+    env_var_value: str,
+    /,
+) -> Iterator[None]:
+    """
+    A context manager which sets an environment variable and resets on exit.
+
+    It is robust to interruptions and exceptions, so long as its ``finally`` block is
+    allowed to run to completion.
+    """
+    original_value: str | _t.Literal[_Sentinel._SENTINEL] = os.getenv(
+        env_var_name, _SENTINEL
+    )
+
+    try:
+        os.environ[env_var_name] = env_var_value
+        yield
+    finally:
+        # if the variable was not set, delete it and suppress any exception
+        # if setting it (in the try block above) failed or was interrupted
+        if original_value is _SENTINEL:
+            try:
+                del os.environ[env_var_name]
+            except KeyError:
+                pass
+        # otherwise, we got a value when we called getenv(), and we should reset it
+        else:
+            os.environ[env_var_name] = original_value

--- a/piptools/build.py
+++ b/piptools/build.py
@@ -20,7 +20,7 @@ from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
 from ._compat import _tomllib_compat
-from ._internal import _pip_api
+from ._internal import _environment_variables, _pip_api
 
 PYPROJECT_TOML = "pyproject.toml"
 
@@ -186,29 +186,6 @@ def build_project_metadata(
 
 
 @contextlib.contextmanager
-def _env_var(
-    env_var_name: str,
-    env_var_value: str,
-    /,
-) -> Iterator[None]:
-    sentinel = object()
-    original_pip_constraint = os.getenv(env_var_name, sentinel)
-    pip_constraint_was_unset = original_pip_constraint is sentinel
-
-    os.environ[env_var_name] = env_var_value
-    try:
-        yield
-    finally:
-        if pip_constraint_was_unset:
-            del os.environ[env_var_name]
-        else:
-            # Assert here is necessary because MyPy can't infer type
-            # narrowing in the complex case.
-            assert isinstance(original_pip_constraint, str)
-            os.environ[env_var_name] = original_pip_constraint
-
-
-@contextlib.contextmanager
 def _temporary_constraints_file_set_for_pip(
     upgrade_packages: tuple[str, ...],
 ) -> Iterator[None]:
@@ -243,7 +220,7 @@ def _temporary_constraints_file_set_for_pip(
         tmpfile.close()
 
         try:
-            with _env_var("PIP_CONSTRAINT", tmpfile.name):
+            with _environment_variables.setenv_context("PIP_CONSTRAINT", tmpfile.name):
                 yield
         finally:
             # FIXME: replace `delete` with `delete_on_close` in Python 3.12+

--- a/tests/unit/_internal/test_environment_variables.py
+++ b/tests/unit/_internal/test_environment_variables.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from piptools._internal import _environment_variables
+
+
+def test_setenv_context_does_simple_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPAM_VAR", "1")
+    with _environment_variables.setenv_context("SPAM_VAR", "spam"):
+        assert os.environ["SPAM_VAR"] == "spam"
+    assert os.environ["SPAM_VAR"] == "1"
+
+
+@pytest.mark.parametrize("value_was_previously_set", (True, False))
+@pytest.mark.parametrize("successfully_sets_value", (True, False))
+def test_setenv_context_does_reset_even_if_setitem_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    value_was_previously_set: bool,
+    successfully_sets_value: bool,
+) -> None:
+    if value_was_previously_set:
+        monkeypatch.setenv("SPAM_VAR", "1")
+    else:
+        monkeypatch.delenv("SPAM_VAR", raising=False)
+
+    # we will inject an error on `__setitem__` to simulate an interruption *right after*
+    # the setitem succeeds
+    original_setitem = os.environ.__setitem__
+
+    def setitem_and_raise(self, key, value):
+        if successfully_sets_value:
+            original_setitem(key, value)
+        raise KeyboardInterrupt("injected interrupt")
+
+    with mock.patch.object(os.environ.__class__, "__setitem__", setitem_and_raise):
+        # PT012 flags any use of pytest.raises() which contains more than a single
+        # simple statement. This is not appropriate to testing the behavior of a context
+        # manager with an error injected into the middle of execution, so it is ignored.
+        with pytest.raises(  # noqa: PT012
+            KeyboardInterrupt,
+            match="injected interrupt",
+        ):
+            with _environment_variables.setenv_context("SPAM_VAR", "spam"):
+                pytest.fail(
+                    "unreachable statement inside of context manager was reached"
+                )
+
+        if value_was_previously_set:
+            assert os.environ["SPAM_VAR"] == "1"
+        else:
+            assert "SPAM_VAR" not in os.environ


### PR DESCRIPTION
This helper was not given thorough testing, and appears in the gaps in our code coverage.

In addition to giving it better testing, move it to a dedicated `_environment_variables` module for any manipulations of `os.environ`.
The `setenv_context()` context manager, a rename of `_env_var`, is the only member of this module.

A new set of parametrized unit tests explore the various behaviors of the context manager, and it is enhanced to handle the possibility of an exception (namely an interrupt) happening immediately *before* setitem is called.

-----

No changelog is needed for this kind of internal refactor.

This is part of a suite of many small changes needed for us to close coverage gaps which currently cause pain and friction.
(e.g.: removing Python 3.9 support is stuck on a spurious change in coverage numbers. Either we need more lenient coverage configuration or we need to close these gaps.)

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
