### PR TITLE
Add a missing test for config loading utilities

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -755,6 +755,24 @@ def test_callback_config_file_defaults_unreadable_toml(make_config_file):
         )
 
 
+def test_config_file_loading_overwrites_prior_default_map(make_config_file):
+    # any config value work for this test -- for simplicity, use `verbose=True/False`
+
+    # it's set in the config to True
+    piptools_config_file = make_config_file("verbose", True)
+
+    # the context already has a loaded default of False
+    ctx = Context(compile_cli)
+    ctx.default_map = {"verbose": False}
+
+    # when we load the config...
+    found_config_file = override_defaults_from_config_file(ctx, "config", None)
+    assert found_config_file == piptools_config_file
+
+    # the True value should win out
+    assert ctx.default_map["verbose"] is True
+
+
 def test_select_config_file_no_files(tmp_path_cwd):
     assert select_config_file(()) is None
 


### PR DESCRIPTION
This helps us move towards 100% coverage. The test itself is relatively simple and low-value, but ensures that we exercise the codepath in which the click Context is partially populated before a config file is loaded.
The code in the src tree already accounts for this, but is untested.

-----

No changelog is needed. Relates to #2453 and #2347 .

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
