### PR TITLE
Omit `pytest.fail` from coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
 
 [report]
 exclude_also =
+    ^\s*pytest\.fail\(
     ^\s*@pytest\.mark\.xfail
     ^\s*if _t\.TYPE_CHECKING:
 include = piptools/*, tests/*


### PR DESCRIPTION
Exclude lines which are invocations of `pytest.fail()`. Such lines are not meant to be hit by the testsuite -- they're there to provide useful diagnostics when a test breaks.

-----

No changelog needed. This is an element of the work being carried out in #2347 which needs to happen to stabilize CI.
In particular, this handles a case in #2453 in which coverage reports that we aren't hitting a `pytest.fail(...)` line.

Note: In #2347 , this needs to be inserted in a different location in the `.coveragerc` because these lines are moved around. I'll handle the conflict resolution after this merges.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
