### PR TITLE
Remove macos-{15,26}-intel from the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,6 @@ jobs:
           - ubuntu-24.04
           - windows-2025
           - macos-26
-          - macos-15-intel
         python-version: >-
           ${{
             fromJSON(
@@ -445,7 +444,6 @@ jobs:
         runner-vm:
           - ubuntu-24.04
           - macos-26
-          - macos-26-intel
         python-version:
           - pypy-3.11
         pip-version:

--- a/changelog.d/+a06a0565.contrib.md
+++ b/changelog.d/+a06a0565.contrib.md
@@ -1,0 +1,2 @@
+`pip-tools`'s CI testing no longer runs on Intel macOS runners
+-- by {user}`sirosen`.


### PR DESCRIPTION
This is intentionally a bit of a nudge, and is phrased as a PR and not an issue/discussion.

Our CI matrix is significantly oversized, and the combinations we're testing aren't all equal value.
CI wall clock times, combined with instability, pose a real problem.
Merges are frequently kicked from the merge queue spuriously, and I've even had this happen during releases -- including the last one, v7.6.1 .
The long clock times mean that re-queuing when things fail is a significant cost to pay: I need to monitor the job for a long period to make sure it succeeds.

`pip` is not testing on Intel macOS.
We are not building an extension or otherwise doing work in `pip-tools` which we should expect to be sensitive to the architecture.

I do not believe that we are getting value from doing this extra testing, and we are incurring costs.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
