### PR TITLE
Add missing unit tests for custom help_option

### DIFF
--- a/tests/unit/scripts/test_options.py
+++ b/tests/unit/scripts/test_options.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from piptools.scripts.options import help_option
+
+
+def test_help_opt_no_epilog(runner: CliRunner) -> None:
+    @click.command("my-command")
+    @help_option()
+    def my_command() -> None:
+        pytest.fail("command ran unexpectedly")
+
+    result = runner.invoke(my_command, ["--help"])
+    assert result.exit_code == 0
+    assert result.stdout.startswith("Usage: my-command")
+    # --help option helptext should be last, whitespace aside
+    assert result.stdout.rstrip().endswith("Show this message and exit.")
+
+
+def test_help_opt_with_epilog(runner: CliRunner) -> None:
+    @click.command("my-command")
+    @help_option(epilog="hello there")
+    def my_command() -> None:
+        pytest.fail("command ran unexpectedly")
+
+    result = runner.invoke(my_command, ["--help"])
+    assert result.exit_code == 0
+    assert result.stdout.startswith("Usage: my-command")
+    # the epilog should be last, whitespace aside
+    assert result.stdout.rstrip().endswith("hello there")

--- a/tests/unit/scripts/test_options.py
+++ b/tests/unit/scripts/test_options.py
@@ -8,6 +8,10 @@ from piptools.scripts.options import help_option
 
 
 def test_help_opt_no_epilog(runner: CliRunner) -> None:
+    """
+    Test that the customized ``--help`` option can be used without an epilog declared.
+    """
+
     @click.command("my-command")
     @help_option()
     def my_command() -> None:
@@ -21,6 +25,11 @@ def test_help_opt_no_epilog(runner: CliRunner) -> None:
 
 
 def test_help_opt_with_epilog(runner: CliRunner) -> None:
+    """
+    Test that the ``epilog`` option for customized ``--help`` test appends the given
+    text to the end of the helptext.
+    """
+
     @click.command("my-command")
     @help_option(epilog="hello there")
     def my_command() -> None:


### PR DESCRIPTION
This decorator for a help opt with an epilog attached was missing tests to ensure it behaved properly.

------

No changelog needed. This is another step in the overall testing and coverage improvements.
(See also: #2347 and #2264 .)

EDIT: temporarily marked as draft because this fails codecov for a silly reason. It needs `pytest.fail` excluded from coverage reports ( #2455 ).

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
