### PR TITLE
Refactor the `--color` option implementation and add unit tests

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -144,7 +144,6 @@ Examples:
 @options.only_build_deps
 def cli(
     ctx: click.Context,
-    color: bool | None,
     verbose: int,
     quiet: int,
     dry_run: bool,
@@ -195,8 +194,6 @@ def cli(
     Valid sources are requirements.in, pyproject.toml, setup.cfg,
     or setup.py specs.
     """
-    if color is not None:
-        ctx.color = color
     log.verbosity = verbose - quiet
 
     # If ``src-files` was not provided as an input, but rather as config,

--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -61,9 +61,19 @@ def _get_default_option(option_name: str) -> _t.Any:
 
 version = click.version_option(package_name="pip-tools")
 
+
+def _color_callback(
+    ctx: click.Context, param: click.Parameter, value: bool | None
+) -> None:
+    if value is not None:
+        ctx.color = value
+
+
 color = click.option(
     "--color/--no-color",
     default=None,
+    callback=_color_callback,
+    expose_value=False,
     help="Force output to be colorized or not, instead of auto-detecting color support",
 )
 

--- a/tests/unit/scripts/test_options.py
+++ b/tests/unit/scripts/test_options.py
@@ -4,7 +4,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from piptools.scripts.options import help_option
+from piptools.scripts.options import color, help_option
 
 
 def test_help_opt_no_epilog(runner: CliRunner) -> None:
@@ -40,3 +40,27 @@ def test_help_opt_with_epilog(runner: CliRunner) -> None:
     assert result.stdout.startswith("Usage: my-command")
     # the epilog should be last, whitespace aside
     assert result.stdout.rstrip().endswith("hello there")
+
+
+@pytest.mark.parametrize(
+    ("args", "expect_setting"),
+    (
+        ([], None),
+        (["--color"], True),
+        (["--no-color"], False),
+        # last one wins semantics
+        (["--color", "--no-color"], False),
+        (["--no-color", "--color"], True),
+    ),
+)
+def test_color_opt_sets_context_color(
+    runner: CliRunner, args: list[str], expect_setting: bool | None
+) -> None:
+    @click.command("my-command")
+    @color
+    @click.pass_context
+    def my_command(ctx: click.Context) -> None:
+        assert ctx.color == expect_setting
+
+    result = runner.invoke(my_command, args)
+    assert result.exit_code == 0


### PR DESCRIPTION
1.  Set `expose_value=False` so that `pip-compile` is not responsible for handling the logic which more naturally belongs inside of the flag implementation itself.

2.  Implement that logic using a callback.

3.  Add unit tests for the flag, in isolation from `pip-compile`.


------

No changelog needed. Yet another step towards complete test coverage. (See #2347 and #2264 for context.)

~This is open as a draft because it modifies the same test file as #2457, and is therefore blocked on that PR.~
It's also a good checkpoint for this body of work and will be the last one I open for today. I did as many as I could, implementing a series of isolated changes, and this was the first naturally occurring collision between two of these improvements (they both need a unit test module for the CLI options).

Update: this should now be ready. :smile: 

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
