### PR TITLE
Add a missing `pragma: cover` for a pip 26.0+ test

### DIFF
--- a/tests/unit/_internal/pip_api/test_cli_options.py
+++ b/tests/unit/_internal/pip_api/test_cli_options.py
@@ -9,7 +9,7 @@ from piptools._internal import _pip_api
 @pytest.mark.skipif(
     _pip_api.PIP_VERSION_MAJOR_MINOR < (26, 0), reason="test requires pip>=26.0"
 )
-def test_postprocess_cli_options_pre_adds_all_to_release_control_all_releases():
+def test_postprocess_cli_options_pre_adds_all_to_release_control_all_releases():  # pragma: pip>=26.0 cover  # noqa: E501
     """
     Test that ``--pre`` gets transformed into ``--all-releases :all:``
     """


### PR DESCRIPTION
This test was added in parallel with the new coverage plugin, and therefore did not get a pragma applied.

In addition to the pragma, there's a noqa comment -- autoformatting forces everything onto a single over-long line.

No changelog for this trivial internal tweak.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
