### PR TITLE
Place unreachable src_files logic under pragma

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -199,10 +199,12 @@ def cli(
         ctx.color = color
     log.verbosity = verbose - quiet
 
-    # If ``src-files` was not provided as an input, but rather as config,
-    # it will be part of the click context ``ctx``.
-    # However, if ``src_files`` is specified, then we want to use that.
-    if not src_files and ctx.default_map and "src_files" in ctx.default_map:
+    # NOTE: On older `click` versions, `src_files` is not populated automatically from
+    # NOTE: config, so it has to be done explicitly here. These align with older Python
+    # NOTE: support, so the entire block is marked with a version pragma.
+    if (
+        not src_files and ctx.default_map and "src_files" in ctx.default_map
+    ):  # pragma: <=3.9 cover
         src_files = ctx.default_map["src_files"]
 
     if all_build_deps and build_deps_targets:


### PR DESCRIPTION
Introduced in #2015, this logic is meant to handle `src_files` being unset, and loading the config value as a default. However, under modern versions of click, the the `src_files` are consistently populated before this point, making the relevant code unreachable.

On older click versions, this check was necessary, and we only need older `click` version support for Python 3.9 . As such, a version pragma works to describe when this does and does not run.

-----

As this is a minor internal testing change, no changelog is provided here.

Initially, I intended to remove the unreachable lines. Testing various python versions and `click` versions revealed that they are used on older `click` versions and Python 3.9 .
Finishing 3.9 removal and setting a higher lower bound for `click` will make them unnecessary.

<!--- Describe the changes here. --->

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
