### PR TITLE
Fix typos in test docstring and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -565,7 +565,7 @@
   annotations ({pr}`2011`) -- by {user}`chrysle`.
 - Make BacktrackingResolver ignore extras when dropping existing constraints ({pr}`1984`)
   -- by {user}`chludwig-haufe`.
-- Display `pyproject.toml`'s metatada parsing errors in verbose mode ({pr}`1979`)
+- Display `pyproject.toml`'s metadata parsing errors in verbose mode ({pr}`1979`)
   -- by {user}`szobov`.
 
 ### Other Changes

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -3424,7 +3424,7 @@ def test_resolution_failure(runner):
 
 
 def test_resolver_reaches_max_rounds(runner):
-    """Test resolver reched max rounds and raises error."""
+    """Test resolver reached max rounds and raises error."""
     with open("requirements.in", "w") as reqs_out:
         reqs_out.write("six")
 


### PR DESCRIPTION
Fixes two typos: \eched\ → \eached\ in \	ests/test_cli_compile.py\ and \metatada\ → \metadata\ in \CHANGELOG.md\.