### PR TITLE
Add a missing unit tests for PyPIRepository

### DIFF
--- a/tests/unit/repositories/test_pypi_repository.py
+++ b/tests/unit/repositories/test_pypi_repository.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
-import pytest
+import pathlib
+import typing as _t
+from unittest import mock
 
-from piptools.repositories.pypi import _get_true_base_from_index_url
+import pytest
+from pip._internal.req import InstallRequirement
+
+from piptools.repositories.pypi import PyPIRepository, _get_true_base_from_index_url
+from tests.constants import PACKAGES_PATH
 
 
 @pytest.mark.parametrize(
@@ -58,10 +64,28 @@ def test_true_base_url_strips_simple_suffix(url: str, expect_result: str) -> Non
     ),
 )
 def test_get_dependencies_helper_rejects_unpinned_reqs(
-    pypi_repository, from_line, requirement_string
-):
+    pypi_repository: PyPIRepository,
+    from_line: _t.Callable[[str], InstallRequirement],
+    requirement_string: str,
+) -> None:
     ireq = from_line(requirement_string)
     with pytest.raises(
         TypeError, match="Expected url, pinned or editable InstallRequirement"
     ):
         pypi_repository.get_dependencies(ireq)
+
+
+def test_find_best_match_short_circuits_on_editables(
+    pypi_repository: PyPIRepository,
+    from_editable: _t.Callable[[str], InstallRequirement],
+) -> None:
+    package_path = pathlib.Path(PACKAGES_PATH) / "small_fake_a"
+    ireq = from_editable(str(package_path))
+    with mock.patch.object(
+        pypi_repository,
+        "find_all_candidates",
+        wraps=pypi_repository.find_all_candidates,
+    ) as mock_find_all_candidates:
+        assert pypi_repository.find_best_match(ireq) is ireq
+
+        mock_find_all_candidates.assert_not_called()

--- a/tests/unit/repositories/test_pypi_repository.py
+++ b/tests/unit/repositories/test_pypi_repository.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pathlib
 import typing as _t
-from unittest import mock
 
 import pytest
 from pip._internal.req import InstallRequirement
+from pytest_mock import MockerFixture
 
 from piptools.repositories.pypi import PyPIRepository, _get_true_base_from_index_url
 from tests.constants import PACKAGES_PATH
@@ -76,16 +76,18 @@ def test_get_dependencies_helper_rejects_unpinned_reqs(
 
 
 def test_find_best_match_short_circuits_on_editables(
+    mocker: MockerFixture,
     pypi_repository: PyPIRepository,
     from_editable: _t.Callable[[str], InstallRequirement],
 ) -> None:
     package_path = pathlib.Path(PACKAGES_PATH) / "small_fake_a"
     ireq = from_editable(str(package_path))
-    with mock.patch.object(
+
+    mock_find_all_candidates = mocker.patch.object(
         pypi_repository,
         "find_all_candidates",
         wraps=pypi_repository.find_all_candidates,
-    ) as mock_find_all_candidates:
-        assert pypi_repository.find_best_match(ireq) is ireq
+    )
 
-        mock_find_all_candidates.assert_not_called()
+    assert pypi_repository.find_best_match(ireq) is ireq
+    mock_find_all_candidates.assert_not_called()

--- a/tests/unit/repositories/test_pypi_repository.py
+++ b/tests/unit/repositories/test_pypi_repository.py
@@ -48,3 +48,20 @@ from piptools.repositories.pypi import _get_true_base_from_index_url
 )
 def test_true_base_url_strips_simple_suffix(url: str, expect_result: str) -> None:
     assert _get_true_base_from_index_url(url) == expect_result
+
+
+@pytest.mark.parametrize(
+    "requirement_string",
+    (
+        pytest.param("django", id="unbound"),
+        pytest.param("django > 1", id="lower-bound"),
+    ),
+)
+def test_get_dependencies_helper_rejects_unpinned_reqs(
+    pypi_repository, from_line, requirement_string
+):
+    ireq = from_line(requirement_string)
+    with pytest.raises(
+        TypeError, match="Expected url, pinned or editable InstallRequirement"
+    ):
+        pypi_repository.get_dependencies(ireq)


### PR DESCRIPTION
The `get_dependencies` helper validates its input, raising a TypeError if its contract is violated, but internally all usage is correct and does not trigger this error. A small new unit test feeds in bad inputs and confirms that the error is raised.

`PyPIRepository.find_best_match` has handling for editables, and it is similarly unreachable. A dedicated unit test exercises that handling path and minimally verifies that it short-circuits evaluation. (It is difficult to verify that a function call doesn't do extra work, so the test is imperfect.)

-----

More test additions in pursuit of better coverage; no changelog needed.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
