### PR TITLE
Add missing tests for `--generate-hashes` as an update of existing pinned dependencies

### DIFF
--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -847,7 +847,7 @@ def test_url_package(runner, line, dependency, generate_hashes):
         ),
     ),
 )
-@pytest.mark.parametrize("generate_hashes", ((True,), (False,)))
+@pytest.mark.parametrize("generate_hashes", (True, False, "update"))
 def test_local_file_uri_package(
     pip_conf, runner, line, dependency, rewritten_line, generate_hashes
 ):
@@ -855,6 +855,9 @@ def test_local_file_uri_package(
         rewritten_line = line
     with open("requirements.in", "w") as req_in:
         req_in.write(line)
+    if generate_hashes == "update":
+        with open("requirements.txt", "w") as fp:
+            fp.write(rewritten_line)
     out = runner.invoke(
         cli, ["-n", "--rebuild"] + (["--generate-hashes"] if generate_hashes else [])
     )
@@ -1208,6 +1211,30 @@ def test_generate_hashes_with_annotations(runner):
         ],
     )
     assert out.stdout == dedent("""\
+        six==1.15.0 \\
+            --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \\
+            --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+            # via -r requirements.in
+        """)
+
+
+@pytest.mark.network
+def test_generate_hashes_with_existing_pins(runner, tmp_path_cwd):
+    (tmp_path_cwd / "requirements.in").write_text("six\n")
+    (tmp_path_cwd / "requirements.txt").write_text("six==1.15.0\n")
+
+    out = runner.invoke(
+        cli,
+        [
+            "--quiet",
+            "--no-header",
+            "--generate-hashes",
+        ],
+    )
+    assert out.exit_code == 0
+
+    result = (tmp_path_cwd / "requirements.txt").read_text()
+    assert result == dedent("""\
         six==1.15.0 \\
             --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \\
             --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced


### PR DESCRIPTION
These tests cover previously untested scenarios in which `--generate-hashes` is used when there's already an existing `requirements.txt` which pins/constrains requirements.

Two new effective new test cases are added:

- For tests of `pip-compile` on local URI dependencies, the options for "generate hashes" were previously `True/False`. They are expanded to `True/False/"update"`.

- A dedicated test for `--generate-hashes` on an existing pinned package   (copied from an existing test which used `six`) is added.

These new tests cover untested codepaths in the LocalRepository object.

----

No changelog, as this is yet-another coverage improvement PR.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
