### PR TITLE
Single hash generation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,10 @@ sqlparse==0.4.3 \
     # via django
 ```
 
+By default, this will include a hash for every release file available for the
+given version. This behavior can be changed to only include a hash for the best
+match file for the current environment with the `--single-hash` flag.
+
 ### Output File
 
 To output the pinned requirements in a filename other than

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ sqlparse==0.4.3 \
 
 By default, this will include a hash for every release file available for the
 given version. This behavior can be changed to only include a hash for the best
-match file for the current environment with the `--single-hash` flag.
+matching file for the current environment with the `--single-hash` flag.
 
 ### Output File
 

--- a/changelog.d/1330.feature.md
+++ b/changelog.d/1330.feature.md
@@ -1,1 +1,2 @@
-Option to restrict generated hashes to the single best matching file -- by {user} `plannigan` `kamplianitis`
+Added a new CLI option to restrict generated hashes to the single best
+matching file -- by {user} `plannigan` and {user}`kamplianitis`.

--- a/changelog.d/1330.feature.md
+++ b/changelog.d/1330.feature.md
@@ -1,0 +1,1 @@
+Option to restrict generated hashes to the single best matching file -- by {user} `plannigan` `kamplianitis`

--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -36,11 +36,18 @@ class BaseRepository(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def get_hashes(self, ireq: InstallRequirement) -> set[str]:
+    def get_hashes(
+        self, ireq: InstallRequirement, single_hash: bool = False
+    ) -> set[str]:
         """
-        Given a pinned InstallRequirement, returns a set of hashes that represent
-        all of the files for a given requirement. It is not acceptable for an
-        editable or unpinned requirement to be passed to this function.
+        Given a pinned InstallRequirement, return a set of hashes that can be used to verify the
+        file to install for the requirement. If single_hash is True, the set will only have the
+        hash for the best match file to install based on the current execution environment. When
+        False (the default), included hashes for all of the files for a given requirement.
+
+        Files that are unhashable are excluded from the returned set.
+
+        A TypeError is raied if the given requirement is editable or unpinned.
         """
 
     @abstractmethod

--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -42,7 +42,7 @@ class BaseRepository(metaclass=ABCMeta):
         """
         Given a pinned ``InstallRequirement``, return a set of hashes that can be used to verify the
         file to install for the requirement. If single_hash is True, the set will only have the
-        hash for the best match file to install based on the current execution environment. When
+        hash for the best matching file to install based on the current execution environment. When
         False (the default), include hashes for all of the files for a given requirement.
 
         Files that are unhashable are excluded from the returned set.

--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -30,7 +30,7 @@ class BaseRepository(metaclass=ABCMeta):
     @abstractmethod
     def get_dependencies(self, ireq: InstallRequirement) -> set[InstallRequirement]:
         """
-        Given a pinned, URL, or editable InstallRequirement, returns a set of
+        Given a pinned, URL, or editable ``InstallRequirement``, returns a set of
         dependencies (also InstallRequirements, but not necessarily pinned).
         They indicate the secondary dependencies for the given requirement.
         """
@@ -40,7 +40,7 @@ class BaseRepository(metaclass=ABCMeta):
         self, ireq: InstallRequirement, single_hash: bool = False
     ) -> set[str]:
         """
-        Given a pinned InstallRequirement, return a set of hashes that can be used to verify the
+        Given a pinned ``InstallRequirement``, return a set of hashes that can be used to verify the
         file to install for the requirement. If single_hash is True, the set will only have the
         hash for the best match file to install based on the current execution environment. When
         False (the default), included hashes for all of the files for a given requirement.

--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -43,11 +43,11 @@ class BaseRepository(metaclass=ABCMeta):
         Given a pinned ``InstallRequirement``, return a set of hashes that can be used to verify the
         file to install for the requirement. If single_hash is True, the set will only have the
         hash for the best match file to install based on the current execution environment. When
-        False (the default), included hashes for all of the files for a given requirement.
+        False (the default), include hashes for all of the files for a given requirement.
 
         Files that are unhashable are excluded from the returned set.
 
-        A TypeError is raied if the given requirement is editable or unpinned.
+        A TypeError is raised if the given requirement is editable or unpinned.
         """
 
     @abstractmethod

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -95,7 +95,8 @@ class LocalRequirementsRepository(BaseRepository):
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             hashes = existing_pin.hash_options
             hexdigests = hashes.get(FAVORITE_HASH)
-            if hexdigests:
+            # ignore multiple hashes from existing pip when doing single hash
+            if hexdigests and (not single_hash or len(hexdigests) == 1):
                 return {
                     ":".join([FAVORITE_HASH, hexdigest]) for hexdigest in hexdigests
                 }

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -86,7 +86,9 @@ class LocalRequirementsRepository(BaseRepository):
     def get_dependencies(self, ireq: InstallRequirement) -> set[InstallRequirement]:
         return self.repository.get_dependencies(ireq)
 
-    def get_hashes(self, ireq: InstallRequirement) -> set[str]:
+    def get_hashes(
+        self, ireq: InstallRequirement, single_hash: bool = False
+    ) -> set[str]:
         existing_pin = self._reuse_hashes and self.existing_pins.get(
             key_from_ireq(ireq)
         )
@@ -97,7 +99,7 @@ class LocalRequirementsRepository(BaseRepository):
                 return {
                     ":".join([FAVORITE_HASH, hexdigest]) for hexdigest in hexdigests
                 }
-        return self.repository.get_hashes(ireq)
+        return self.repository.get_hashes(ireq, single_hash)
 
     @contextmanager
     def allow_all_wheels(self) -> Iterator[None]:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -171,12 +171,15 @@ class PyPIRepository(BaseRepository):
         best_candidate_result = evaluator.compute_best_candidate(matching_candidates)
         best_candidate = best_candidate_result.best_candidate
 
-        # Turn the candidate into a pinned InstallRequirement
-        return _pip_api.create_install_requirement(
+        # Turn the candidate into a pinned InstallRequirement.
+        requirement = _pip_api.create_install_requirement(
             best_candidate.name,
             best_candidate.version,
             ireq,
         )
+        # retain copy of link to best candidate (useful when generating a single hash)
+        requirement.link = best_candidate.link
+        return requirement
 
     def resolve_reqs(
         self,
@@ -321,11 +324,18 @@ class PyPIRepository(BaseRepository):
         else:
             return self._download_dir
 
-    def get_hashes(self, ireq: InstallRequirement) -> set[str]:
+    def get_hashes(
+        self, ireq: InstallRequirement, single_hash: bool = False
+    ) -> set[str]:
         """
-        Given an InstallRequirement, return a set of hashes that represent all
-        of the files for a given requirement. Unhashable requirements return an
-        empty set. Unpinned requirements raise a TypeError.
+        Given a pinned InstallRequirement, return a set of hashes that can be used to verify the
+        file to install for the requirement. If single_hash is True, the set will only have the
+        hash for the best match file to install based on the current execution environment. When
+        False (the default), included hashes for all of the files for a given requirement.
+
+        Files that are unhashable are excluded from the returned set.
+
+        A TypeError is raised if the given requirement is editable or unpinned.
         """
 
         if ireq.link:
@@ -354,15 +364,26 @@ class PyPIRepository(BaseRepository):
         log.debug(ireq.name)
 
         with log.indentation():
-            return self._get_req_hashes(ireq)
+            return self._get_req_hashes(ireq, single_hash=single_hash)
 
-    def _get_req_hashes(self, ireq: InstallRequirement) -> set[str]:
+    def _get_req_hashes(
+        self, ireq: InstallRequirement, single_hash: bool = False
+    ) -> set[str]:
         """
         Collects the hashes for all candidates satisfying the given InstallRequirement. Computes
         the hashes for the candidates that don't have one reported by their index.
         """
-        matching_candidates = self._get_matching_candidates(ireq)
         pypi_hashes_by_link = self._get_hashes_from_pypi(ireq)
+        if single_hash:
+            log.debug("Filtering down to the best file")
+            best_candidate_link = self._best_candidate_link(ireq)
+            return {
+                pypi_hashes_by_link[best_candidate_link.url]
+                if best_candidate_link.url in pypi_hashes_by_link
+                else self._get_file_hash(best_candidate_link)
+            }
+
+        matching_candidates = self._get_matching_candidates(ireq)
         pypi_hashes = {
             pypi_hashes_by_link[candidate.link.url]
             for candidate in matching_candidates
@@ -449,6 +470,16 @@ class PyPIRepository(BaseRepository):
                 for chunk in bar:
                     h.update(chunk)
         return ":".join([FAVORITE_HASH, h.hexdigest()])
+
+    def _best_candidate_link(self, ireq: InstallRequirement) -> Link:
+        # link for best candidate is available if requirement was resolved. However, it needs to be
+        # retrieved if the version was pinned by the original constraints.
+        if ireq.link is None:
+            # find_best_match() returns InstallRequirement doesn't guarantee that link is set,
+            # but the function sets link. The early return cases (editable & url) would already
+            # have link set.
+            return _t.cast(Link, self.find_best_match(ireq).link)
+        return ireq.link
 
     @contextmanager
     def allow_all_wheels(self) -> Iterator[None]:

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -330,7 +330,7 @@ class PyPIRepository(BaseRepository):
         """
         Given a pinned InstallRequirement, return a set of hashes that can be used to verify the
         file to install for the requirement. If single_hash is True, the set will only have the
-        hash for the best match file to install based on the current execution environment. When
+        hash for the best matching file to install based on the current execution environment. When
         False (the default), include hashes for all of the files for a given requirement.
 
         Files that are unhashable are excluded from the returned set.

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -331,7 +331,7 @@ class PyPIRepository(BaseRepository):
         Given a pinned InstallRequirement, return a set of hashes that can be used to verify the
         file to install for the requirement. If single_hash is True, the set will only have the
         hash for the best match file to install based on the current execution environment. When
-        False (the default), included hashes for all of the files for a given requirement.
+        False (the default), include hashes for all of the files for a given requirement.
 
         Files that are unhashable are excluded from the returned set.
 

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -378,9 +378,11 @@ class PyPIRepository(BaseRepository):
             log.debug("Filtering down to the best file")
             best_candidate_link = self._best_candidate_link(ireq)
             return {
-                pypi_hashes_by_link[best_candidate_link.url]
-                if best_candidate_link.url in pypi_hashes_by_link
-                else self._get_file_hash(best_candidate_link)
+                (
+                    pypi_hashes_by_link[best_candidate_link.url]
+                    if best_candidate_link.url in pypi_hashes_by_link
+                    else self._get_file_hash(best_candidate_link)
+                )
             }
 
         matching_candidates = self._get_matching_candidates(ireq)

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -524,7 +524,7 @@ class BacktrackingResolver(BaseResolver):
         repository: BaseRepository,
         allow_unsafe: bool = False,
         unsafe_packages: set[str] | None = None,
-        **kwargs: _t.Any,
+        **kwargs: object,
     ) -> None:
         self.constraints = list(constraints)
         self.repository = repository

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import collections
 import copy
-import typing as _t
 from abc import ABCMeta, abstractmethod
 from collections.abc import Container, Iterable, Iterator
+from contextlib import nullcontext
 from functools import partial
 from itertools import chain, count, groupby
 
@@ -158,15 +158,24 @@ class BaseResolver(metaclass=ABCMeta):
         """
 
     def resolve_hashes(
-        self, ireqs: set[InstallRequirement]
+        self, ireqs: set[InstallRequirement], single_hash: bool
     ) -> dict[InstallRequirement, set[str]]:
         r"""
         Find acceptable hashes for all of the given ``InstallRequirement``\ s.
+
+        If single_hash is True, the set for each given  requirement will only have the hash for the
+        best match file to install based on the current execution environment. When False, hashes
+        for all release files wil included for a given requirement.
         """
         log.debug("")
         log.debug("Generating hashes:")
-        with self.repository.allow_all_wheels(), log.indentation():
-            return {ireq: self.repository.get_hashes(ireq) for ireq in ireqs}
+        allow_all_wheels = (
+            nullcontext() if single_hash else self.repository.allow_all_wheels()
+        )
+        with allow_all_wheels, log.indentation():
+            return {
+                ireq: self.repository.get_hashes(ireq, single_hash) for ireq in ireqs
+            }
 
     def _filter_out_unsafe_constraints(
         self,

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -163,9 +163,9 @@ class BaseResolver(metaclass=ABCMeta):
         r"""
         Find acceptable hashes for all of the given ``InstallRequirement``\ s.
 
-        If single_hash is True, the set for each given  requirement will only have the hash for the
-        best match file to install based on the current execution environment. When False, hashes
-        for all release files wil included for a given requirement.
+        If single_hash is True, the set for each given requirement will only have the hash for the
+        best matching file to install based on the current execution environment. When False,
+        hashes for all release files will be included for a given requirement.
         """
         log.debug("")
         log.debug("Generating hashes:")

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -125,6 +125,7 @@ Examples:
 @options.allow_unsafe
 @options.strip_extras
 @options.generate_hashes
+@options.single_hash
 @options.reuse_hashes
 @options.max_rounds
 @options.src_files
@@ -171,6 +172,7 @@ def cli(
     allow_unsafe: bool,
     strip_extras: bool | None,
     generate_hashes: bool,
+    single_hash: bool,
     reuse_hashes: bool,
     src_files: tuple[str, ...],
     max_rounds: int,
@@ -509,7 +511,11 @@ def cli(
             unsafe_packages=set(unsafe_package),
         )
         results = resolver.resolve(max_rounds=max_rounds)
-        hashes = resolver.resolve_hashes(results) if generate_hashes else None
+        hashes = (
+            resolver.resolve_hashes(results, single_hash=single_hash)
+            if generate_hashes
+            else None
+        )
     except NoCandidateFound as e:
         if resolver_cls == LegacyResolver:  # pragma: no branch
             log.error(

--- a/piptools/scripts/options.py
+++ b/piptools/scripts/options.py
@@ -271,6 +271,17 @@ generate_hashes = click.option(
     help="Generate pip 8 style hashes in the resulting requirements file.",
 )
 
+single_hash = click.option(
+    "--single-hash/--no-single-hash",
+    is_flag=True,
+    default=False,
+    help=(
+        "When generating hashes only include a hash for the best match file "
+        "for the current environment instead of hashes for every release file "
+        "for the matching version."
+    ),
+)
+
 reuse_hashes = click.option(
     "--reuse-hashes/--no-reuse-hashes",
     is_flag=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,12 +68,14 @@ class FakeRepository(BaseRepository):
         with open(os.path.join(TEST_DATA_PATH, "fake-editables.json")) as f:
             self.editables = json.load(f)
 
-    def get_hashes(self, ireq):
+    def get_hashes(self, ireq, single_hash):
         # Some fake hashes
-        return {
-            "test:123",
+        hashes = {
             "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         }
+        if not single_hash:
+            hashes.add("test:123")
+        return hashes
 
     def find_best_match(self, ireq, prereleases=False):
         if ireq.editable:

--- a/tests/test_fake_index.py
+++ b/tests/test_fake_index.py
@@ -89,3 +89,8 @@ def test_get_hashes(from_line, repository):
         "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     }
     assert repository.get_hashes(ireq, single_hash=False) == expected
+
+    expected = {
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    }
+    assert repository.get_hashes(ireq, single_hash=True) == expected

--- a/tests/test_fake_index.py
+++ b/tests/test_fake_index.py
@@ -88,4 +88,4 @@ def test_get_hashes(from_line, repository):
         "test:123",
         "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     }
-    assert repository.get_hashes(ireq) == expected
+    assert repository.get_hashes(ireq, single_hash=False) == expected

--- a/tests/test_repository_local.py
+++ b/tests/test_repository_local.py
@@ -56,3 +56,30 @@ def test_toggle_reuse_hashes_local_repository(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    ("single_hash", "expected"),
+    ((True, EXPECTED), (False, NONSENSE | {"sha256:NONSENSE2"})),
+)
+def test_single_hash__previous_multiple_hashes__ignore_previous(
+    capsys, pip_conf, from_line, pypi_repository, single_hash, expected
+):
+    # Create an install requirement with the hashes included in its options
+    hash_options = {"sha256": ["NONSENSE", "NONSENSE2"]}
+    req = from_line("small-fake-a==0.1", hash_options=hash_options)
+    existing_pins = {key_from_ireq(req): req}
+
+    local_repository = LocalRequirementsRepository(
+        existing_pins, pypi_repository, reuse_hashes=True
+    )
+    with local_repository.allow_all_wheels():
+        assert (
+            local_repository.get_hashes(
+                from_line("small-fake-a==0.1"), single_hash=single_hash
+            )
+            == expected
+        )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.link import Link
+from pip._internal.models.target_python import TargetPython
 from pip._internal.utils.urls import path_to_url
 from pip._vendor.requests import HTTPError, Session
 
@@ -30,6 +31,26 @@ def test_generate_hashes_all_platforms(capsys, pip_conf, from_line, pypi_reposit
 
     with pypi_repository.allow_all_wheels():
         assert pypi_repository.get_hashes(ireq) == expected
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_generate_hashes_single_hash_filter(
+    capsys, tmpdir, monkeypatch, pip_conf, from_line, pypi_repository
+):
+    expected = {
+        "sha256:24afa5b317b302f356fd3fc3b1cfb0aad114d509cf635ea9566052424191b944",
+    }
+    # force a single platform so test case doesn't depend on the host platform
+    monkeypatch.setattr(
+        pypi_repository._finder,
+        "_target_python",
+        TargetPython(platforms=["manylinux1_x86_64"]),
+    )
+
+    ireq = from_line("small-fake-multi-arch==0.1")
+    assert pypi_repository.get_hashes(ireq, single_hash=True) == expected
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
@@ -344,6 +365,55 @@ def test_get_hashes_from_mixed(pip_conf, from_line, tmp_path):
 
     actual_hashes = pypi_repository.get_hashes(ireq)
     assert actual_hashes == expected_hashes
+
+
+def test_get_hashes_from_mixed_single_hash(pip_conf, from_line, tmp_path):
+    """
+    Test PyPIRepository.get_hashes() returns only the best candidate hash.
+    """
+
+    package_name = "small-fake-multi-arch"
+    package_version = "0.1"
+    best_link = Link("https://pypi-link")
+    other_link = Link("https://extra-index-link")
+    pypi_hash = "pypi-hash"
+
+    class MockPyPIRepository(PyPIRepository):
+        def _get_project(self, ireq):
+            return {
+                "releases": {
+                    package_version: [
+                        {
+                            "packagetype": "bdist_wheel",
+                            "digests": {"sha256": pypi_hash},
+                            "url": str(best_link),
+                        },
+                    ]
+                }
+            }
+
+        def find_best_match(self, ireq, prereleases=None):
+            result = super().find_best_match(ireq, prereleases)
+            result.link = best_link
+            return result
+
+        def find_all_candidates(self, req_name):
+            return [
+                InstallationCandidate(package_name, package_version, best_link),
+                InstallationCandidate(package_name, package_version, other_link),
+            ]
+
+        def _get_file_hash(self, link):
+            return "sha256:other-hash"
+
+    pypi_repository = MockPyPIRepository(
+        ["--no-cache-dir"], cache_dir=(tmp_path / "pypi-repo-cache")
+    )
+
+    ireq = from_line(f"{package_name}=={package_version}")
+
+    actual_hashes = pypi_repository.get_hashes(ireq, single_hash=True)
+    assert actual_hashes == {"sha256:" + pypi_hash}
 
 
 def test_get_project__returns_data(from_line, monkeypatch, pypi_repository):


### PR DESCRIPTION
<!--- Describe the changes here. --->

##### Contributor checklist

- [X] Included tests for the changes.
- [X] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [ ] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).


---
Rebase of PR #1406 

I'm copying the PR's description so that the information is transmitted here also. 

**Changelog-friendly one-liner**: Option to restrict generated hashes to the single best matching file

Closes https://github.com/jazzband/pip-tools/issues/1330
