### PR TITLE
Fix wrong default check in get_compile_command (click 8.5.0)

### DIFF
--- a/changelog.d/2472.bugfix.md
+++ b/changelog.d/2472.bugfix.md
@@ -1,0 +1,2 @@
+Fixed `pip-compile` sometimes adding `--no-index` to the recorded command
+even when it was not passed, with click 8.5.0 -- by {user}`mnencia`.

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -362,8 +362,10 @@ def get_compile_command(click_ctx: click.Context) -> str:
         if value is None:
             continue
 
-        # Skip options with a default value
-        if option.default == value:
+        # Skip options with a default value.
+        # Use a new Context so that values from config files are
+        # not treated as defaults.
+        if option.get_default(click.Context(click_ctx.command)) == value:
             continue
 
         # Use a file name for file-like objects

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -460,6 +460,16 @@ def test_get_compile_command_with_config(tmp_path_cwd, config_file, expected_com
         assert get_compile_command(ctx) == expected_command
 
 
+def test_get_compile_command_no_index_not_added_by_default(tmp_path_cwd):
+    """
+    --no-index must not show up in the recorded command unless it was
+    actually passed. See GH-2472.
+    """
+    (tmp_path_cwd / "requirements.in").touch()
+    with compile_cli.make_context("pip-compile", ["requirements.in"]) as ctx:
+        assert get_compile_command(ctx) == "pip-compile requirements.in"
+
+
 @pytest.mark.parametrize("config_file", ("pyproject.toml", ".pip-tools.toml"))
 @pytest.mark.parametrize(
     "config_file_content",


### PR DESCRIPTION
Fixes #2472.

With click 8.5.0, `Option.default` is an internal sentinel for a flag with no explicit default, not `False`. `get_compile_command` compares `option.default` to the value to decide if an option is at its default. For `--no-index` (a flag with no negative form), this compare never matches. So `--no-index` gets added to the recorded command every time, even when not passed.

Fix: use `option.get_default()` instead of the raw attribute. I use a new, empty `click.Context` for this call, not the real one. The real context can hold values from a config file, and those would look like defaults too.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`])
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [ ] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).