### PR TITLE
Make pip-tools compatible with click version 8.5

### DIFF
--- a/changelog.d/2472.bugfix.md
+++ b/changelog.d/2472.bugfix.md
@@ -1,0 +1,2 @@
+Fixed `pip-compile` sometimes adding `--no-index` to the recorded command
+even when it was not passed, with click 8.5.0 -- by {user}`mnencia`.

--- a/changelog.d/2474.bugfix.md
+++ b/changelog.d/2474.bugfix.md
@@ -1,0 +1,1 @@
+Make `pip-tools` compatible with `click` version `8.5` -- by {user}`sirosen`.

--- a/changelog.d/2474.bugfix.md
+++ b/changelog.d/2474.bugfix.md
@@ -1,1 +1,1 @@
-Make `pip-tools` compatible with `click` version `8.5` -- by {user}`sirosen`.
+Make `pip-tools` compatible with {pypi}`click` version `8.5` -- by {user}`sirosen`.

--- a/piptools/_compat/_click_compat.py
+++ b/piptools/_compat/_click_compat.py
@@ -1,0 +1,41 @@
+"""
+Compatibility helpers and wrappers for working with :external+click:doc:`click <index>`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import typing as _t
+
+import click
+
+
+def open_output_file(ctx: click.Context, filename: str) -> _t.BinaryIO:
+    """
+    Open a file with the desirable flags set for writing output.
+
+    The file will be lazy and atomic unless it's stdout.
+    """
+    # open_file() returns a typing.IO , but we know it will be binary because of the
+    # mode flag -- so type-ignore the assignment issue
+    file: _t.BinaryIO = click.open_file(  # type: ignore[assignment]
+        filename, "w+b", atomic=True, lazy=True
+    )
+    _defer_lazy_file_close(ctx, file)
+    return file
+
+
+# note that the LazyFile type is not public, so we treat the file object as "Any"
+def _defer_lazy_file_close(ctx: click.Context, fileobj: _t.Any) -> None:
+    """Setup a click "lazy file" to close on exit."""
+    ctx.call_on_close(lambda: _safe_close(fileobj))
+
+
+def _safe_close(fileobj: _t.Any) -> None:
+    """
+    Suppress *all* errors and call ``close_intelligently()``.
+
+    This will not error even if the object does not support ``close_intelligently()``.
+    """
+    with contextlib.suppress(Exception):
+        fileobj.close_intelligently()

--- a/piptools/_compat/_click_compat.py
+++ b/piptools/_compat/_click_compat.py
@@ -25,17 +25,18 @@ def open_output_file(ctx: click.Context, filename: str) -> _t.BinaryIO:
     return file
 
 
-# note that the LazyFile type is not public, so we treat the file object as "Any"
-def _defer_lazy_file_close(ctx: click.Context, fileobj: _t.Any) -> None:
+def _defer_lazy_file_close(ctx: click.Context, fileobj: _t.BinaryIO) -> None:
     """Setup a click "lazy file" to close on exit."""
     ctx.call_on_close(lambda: _safe_close(fileobj))
 
 
-def _safe_close(fileobj: _t.Any) -> None:
+def _safe_close(fileobj: _t.BinaryIO) -> None:
     """
     Suppress *all* errors and call ``close_intelligently()``.
 
     This will not error even if the object does not support ``close_intelligently()``.
     """
+    # Note that the LazyFile type is not public, so we are passed a BinaryIO and we will
+    # try to use the method (which we know `click` provides).
     with contextlib.suppress(Exception):
-        fileobj.close_intelligently()
+        fileobj.close_intelligently()  # type: ignore[attr-defined]

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -9,11 +9,15 @@ from pathlib import Path
 
 import click
 from build import BuildBackendException
-from click.utils import LazyFile, safecall
 from pip._internal.req import InstallRequirement
 from pip._internal.utils.misc import redact_auth_from_url
 
-from .._compat import canonicalize_name, parse_requirements, tempfile_compat
+from .._compat import (
+    _click_compat,
+    canonicalize_name,
+    parse_requirements,
+    tempfile_compat,
+)
 from .._internal import _pip_api
 from ..build import ProjectMetadata, build_project_metadata
 from ..cache import DependencyCache
@@ -166,7 +170,7 @@ def cli(
     annotation_style: str,
     upgrade: bool,
     upgrade_packages: tuple[str, ...],
-    output_file: LazyFile | _t.IO[_t.Any] | None,
+    output_file: _t.BinaryIO | None,
     newline: str,
     allow_unsafe: bool,
     strip_extras: bool | None,
@@ -258,13 +262,7 @@ def cli(
             base_name = src_files[0].rsplit(".", 1)[0]
             file_name = base_name + ".txt"
 
-        output_file = click.open_file(file_name, "w+b", atomic=True, lazy=True)
-
-        # Close the file at the end of the context execution
-        assert output_file is not None
-        # only LazyFile has close_intelligently, newer _t.IO[_t.Any] does not
-        if isinstance(output_file, LazyFile):  # pragma: no cover
-            ctx.call_on_close(safecall(output_file.close_intelligently))
+        output_file = _click_compat.open_output_file(ctx, file_name)
 
     if output_file.name != "-" and output_file.name in src_files:
         raise click.BadArgumentUsage(
@@ -544,7 +542,7 @@ def cli(
     ##
 
     writer = OutputWriter(
-        _t.cast(_t.BinaryIO, output_file),
+        output_file,
         click_ctx=ctx,
         dry_run=dry_run,
         emit_header=header,

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -362,8 +362,10 @@ def get_compile_command(click_ctx: click.Context) -> str:
         if value is None:
             continue
 
-        # Skip options with a default value
-        if option.default == value:
+        # Skip options with a default value.
+        # Use a new Context so that values from config files are
+        # not treated as defaults.
+        if option.get_default(click.Context(click_ctx.command)) == value:
             continue
 
         # Use a file name for file-like objects

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import click
 from click.core import ParameterSource
-from click.utils import LazyFile
 from pip._internal.req import InstallRequirement
 from pip._internal.resolution.resolvelib.base import Requirement as PipRequirement
 from pip._internal.utils.misc import redact_auth_from_url
@@ -368,8 +367,9 @@ def get_compile_command(click_ctx: click.Context) -> str:
         if option.get_default(click.Context(click_ctx.command)) == value:
             continue
 
-        # Use a file name for file-like objects
-        if isinstance(value, LazyFile):
+        # Use a file name for file-like objects; detect this purely via 'hasattr' to
+        # handle click's special lazy file wrapper.
+        if hasattr(value, "name"):
             value = value.name
 
         # Convert value to the list

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -460,6 +460,16 @@ def test_get_compile_command_with_config(tmp_path_cwd, config_file, expected_com
         assert get_compile_command(ctx) == expected_command
 
 
+def test_get_compile_command_no_index_not_added_by_default(tmp_path_cwd):
+    """
+    --no-index must not show up in the recorded command unless it was
+    actually passed. See GH-2472.
+    """
+    (tmp_path_cwd / "requirements.in").touch()
+    with compile_cli.make_context("pip-compile", ["requirements.in"]) as ctx:
+        assert get_compile_command(ctx) == "pip-compile requirements.in"
+
+
 @pytest.mark.parametrize("config_file", ("pyproject.toml", ".pip-tools.toml"))
 @pytest.mark.parametrize(
     "config_file_content",


### PR DESCRIPTION
This fix builds on and closes #2473.

In addition, this changeset handles `LazyFile` objects by means of a new `_click_compat` module.
Not only will this module provide compatibility as `click` changes, but it's also a good location for basic wrappers (as in this case).

Explicitly opening the file now also includes setting up the deferred closing behavior, so the usage site is simplified to its core concern of getting an open stream to write output.

#2473 includes new dedicated tests, but no explicit testing targets `_click_compat`.
I can add some more tests on request, but I think our existing coverage gets this pretty well.

I've left two distinct news fragments in place, as I think that captures the work better than a combined one would.

##### Contributor checklist

- [x] Included tests for the changes.
- [x] A change note is created in `changelog.d/` (see [`changelog.d/README.md`]
      for instructions) or the PR text says "no changelog needed".

[`changelog.d/README.md`]:
https://github.com/jazzband/pip-tools/blob/main/changelog.d/#readme

##### Maintainer checklist

- [x] If no changelog is needed, apply the `bot:chronographer:skip` label.
- [x] Assign the PR to an existing or new milestone for the target version
      (following Semantic Versioning).
